### PR TITLE
Working-set diff viewer + per-folder dirty indicators

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,12 @@ npm run tauri dev      # run the app (Tauri + Vite dev server on fixed port 1420
 npm run tauri build    # production bundle
 npm run build          # tsc typecheck + vite build (frontend only; the beforeBuildCommand)
 npx tsc --noEmit       # typecheck only (tsconfig is noEmit)
+npm test               # vitest — frontend unit tests (test/*.test.ts)
 ```
 
-Rust backend (run from `src-tauri/`): `cargo check`, `cargo clippy`, `cargo build`.
+Rust backend (run from `src-tauri/`): `cargo check`, `cargo clippy`, `cargo test`, `cargo build`.
 
-There is **no test suite and no linter beyond `tsc` (strict) and `clippy`**. Verification is running the app and exercising it — the statusLine half of telemetry only fires in interactive mode, so it cannot be checked headlessly with `claude -p`. Requires `claude` on PATH, Node 18+, and Rust stable + Tauri system deps.
+Test coverage is **thin and unit-only** — there is no end-to-end harness. What exists: `vitest` over pure frontend logic (currently the diff parser, `test/diff.test.ts`, importing from `src/diff.ts`) and `#[cfg(test)]` integration tests in `lib.rs` that drive real `git` against a temp repo. Anything touching the DOM, PTYs, or live telemetry is still verified by **running the app and exercising it** — the statusLine half of telemetry only fires in interactive mode, so it cannot be checked headlessly with `claude -p`. Beyond tests, the linters are `tsc` (strict) and `clippy`. Requires `claude` on PATH, Node 18+, and Rust stable + Tauri system deps.
 
 ## The core mechanism: per-launch instrumentation
 

--- a/index.html
+++ b/index.html
@@ -96,6 +96,14 @@
       </div>
     </div>
 
+    <div class="diffdlg" id="diffDlg" role="dialog" aria-modal="true">
+      <div class="diff-head">
+        <div class="diff-title-wrap"><b id="diffTitle"></b><span class="diff-sub" id="diffSub"></span></div>
+        <button class="diff-x" id="diffClose" title="Close (Esc)">✕</button>
+      </div>
+      <div class="diff-body" id="diffBody"></div>
+    </div>
+
     <div class="dbg-panel" id="dbgPanel" hidden>
       <div class="dbg-head">
         <b>Debug console</b>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muster",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muster",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",
@@ -20,7 +20,8 @@
       "devDependencies": {
         "@tauri-apps/cli": "^2",
         "typescript": "~5.6.2",
-        "vite": "^6.0.3"
+        "vite": "^6.0.3",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -465,6 +466,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
@@ -815,6 +823,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.1.tgz",
@@ -1078,12 +1093,143 @@
         "@tauri-apps/api": "^2.10.1"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
@@ -1105,6 +1251,40 @@
       "workspaces": [
         "addons/*"
       ]
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1148,6 +1328,26 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1181,6 +1381,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.16",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
@@ -1199,6 +1409,27 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1294,6 +1525,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1302,6 +1540,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1319,6 +1588,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -1408,6 +1687,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
     "tauri": "tauri"
   },
   "dependencies": {
@@ -22,6 +23,7 @@
   "devDependencies": {
     "@tauri-apps/cli": "^2",
     "typescript": "~5.6.2",
-    "vite": "^6.0.3"
+    "vite": "^6.0.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -897,6 +897,68 @@ fn git_diffstat(workdir: String) -> Option<DiffStat> {
 }
 
 #[derive(serde::Serialize)]
+struct GitDiff {
+    /// Combined unified-diff patch for the working set: tracked changes vs HEAD,
+    /// followed by each untracked file rendered as a new-file diff. The frontend
+    /// parses this into files/hunks for the peek viewer.
+    patch: String,
+    /// True when we stopped early because the patch hit the size/file cap — the
+    /// viewer shows a "truncated" note so a partial diff can't read as complete.
+    truncated: bool,
+}
+
+/// The full *uncommitted* diff behind the working-set card, for the peek viewer.
+/// Tracked changes come from `diff HEAD`; untracked files are appended as new-file
+/// diffs via `diff --no-index` against `/dev/null` — which, unlike `add -N`, never
+/// touches the index (important while a live session may be staging/committing).
+/// `core.quotepath=false` keeps non-ASCII paths literal; a size + file-count cap
+/// stops a huge working tree from shipping a multi-MB payload into the webview.
+#[tauri::command]
+fn git_diff(workdir: String) -> Option<GitDiff> {
+    const CAP: usize = 800_000; // ~0.8 MB of patch text — ample for a peek
+    const MAX_UNTRACKED: usize = 300;
+
+    let tracked = git_cmd(&workdir, &["-c", "core.quotepath=false", "--no-optional-locks", "diff", "HEAD"])
+        .output()
+        .ok()?;
+    if !tracked.status.success() {
+        return None; // not a repo, or an unborn HEAD (no commits)
+    }
+    let mut patch = String::from_utf8_lossy(&tracked.stdout).into_owned();
+    let mut truncated = false;
+    if patch.len() > CAP {
+        patch.truncate(CAP);
+        truncated = true;
+    }
+
+    // Untracked files, each as its own new-file diff. `--no-index` exits 1 whenever
+    // the files differ (always, vs /dev/null), so we read stdout regardless of status.
+    if !truncated {
+        if let Ok(o) = git_cmd(&workdir, &["--no-optional-locks", "ls-files", "--others", "--exclude-standard", "-z"]).output() {
+            let listing = String::from_utf8_lossy(&o.stdout);
+            let others: Vec<&str> = listing.split('\0').filter(|s| !s.is_empty()).collect();
+            if others.len() > MAX_UNTRACKED {
+                truncated = true;
+            }
+            for f in others.into_iter().take(MAX_UNTRACKED) {
+                if patch.len() >= CAP {
+                    truncated = true;
+                    break;
+                }
+                if let Ok(d) = git_cmd(&workdir, &["-c", "core.quotepath=false", "diff", "--no-index", "--", "/dev/null", f]).output() {
+                    patch.push_str(&String::from_utf8_lossy(&d.stdout));
+                }
+            }
+            if patch.len() > CAP {
+                patch.truncate(CAP);
+                truncated = true;
+            }
+        }
+    }
+    Some(GitDiff { patch, truncated })
+}
+
+#[derive(serde::Serialize)]
 struct GitActionResult {
     ok: bool,
     /// One line for the toast.
@@ -1653,6 +1715,7 @@ pub fn run() {
             git_branch,
             git_head,
             git_diffstat,
+            git_diff,
             git_action,
             session_resources,
             create_worktree,
@@ -1672,4 +1735,68 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    /// A fresh, empty scratch directory under the OS temp dir. No randomness (pid +
+    /// an atomic counter keep it unique even under cargo's parallel test threads).
+    fn scratch_dir() -> PathBuf {
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let dir = std::env::temp_dir().join(format!("muster_git_diff_test_{}_{}", std::process::id(), n));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Run a git command in `dir`, asserting success. Identity/signing are passed via
+    /// `-c` so the test doesn't depend on (or touch) the developer's global gitconfig.
+    fn git(dir: &Path, args: &[&str]) {
+        let out = Command::new("git").current_dir(dir).args(args).output().expect("failed to spawn git");
+        assert!(out.status.success(), "git {args:?} failed: {}", String::from_utf8_lossy(&out.stderr));
+    }
+
+    #[test]
+    fn git_diff_reports_tracked_and_untracked_changes() {
+        let dir = scratch_dir();
+        git(&dir, &["init", "-q"]);
+        std::fs::write(dir.join("tracked.txt"), "line1\nline2\nline3\n").unwrap();
+        git(&dir, &["add", "-A"]);
+        git(&dir, &["-c", "user.email=t@example.com", "-c", "user.name=T", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "init"]);
+
+        // Working-tree changes: edit the tracked file, add an untracked one.
+        std::fs::write(dir.join("tracked.txt"), "line1\nCHANGED\nline3\nline4\n").unwrap();
+        std::fs::write(dir.join("new.txt"), "brand new\n").unwrap();
+
+        let d = git_diff(dir.to_str().unwrap().to_string()).expect("git_diff returned None for a real repo");
+        assert!(!d.truncated);
+        // Tracked modification, diffed against HEAD.
+        assert!(d.patch.contains("diff --git a/tracked.txt b/tracked.txt"), "missing tracked diff:\n{}", d.patch);
+        assert!(d.patch.contains("+CHANGED") && d.patch.contains("-line2"));
+        // Untracked file rendered as a new-file diff.
+        assert!(d.patch.contains("diff --git a/new.txt b/new.txt"), "missing untracked diff:\n{}", d.patch);
+        assert!(d.patch.contains("new file mode") && d.patch.contains("+brand new"));
+
+        // Crucially, surfacing the untracked file must NOT have staged it — `--no-index`
+        // leaves the index untouched, which is why we use it over `git add -N`.
+        let st = Command::new("git").current_dir(&dir).args(["status", "--porcelain"]).output().unwrap();
+        let st = String::from_utf8_lossy(&st.stdout);
+        assert!(st.contains("?? new.txt"), "new.txt should still be untracked, got:\n{st}");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn git_diff_returns_none_outside_a_repo() {
+        let dir = scratch_dir();
+        assert!(git_diff(dir.to_str().unwrap().to_string()).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,0 +1,54 @@
+// Parsing for the working-set diff viewer. The backend (git_diff) hands us one
+// combined unified-diff patch; we turn it into per-file records here rather than
+// in Rust, keeping that side thin. Kept in its own module (no DOM/Tauri imports)
+// so it can be unit-tested in isolation — see test/diff.test.ts.
+
+export interface DiffLine { kind: "ctx" | "add" | "del"; text: string; oldNo: number | null; newNo: number | null; }
+export interface DiffHunk { header: string; lines: DiffLine[]; }
+export interface DiffFile { path: string; oldPath: string | null; status: "modified" | "added" | "deleted" | "renamed"; binary: boolean; added: number; removed: number; hunks: DiffHunk[]; }
+
+// Parse a combined unified diff into per-file records. Robust to spaces in paths
+// (we read the +++/--- headers, which git terminates with a tab, and fall back to
+// the `diff --git`/rename lines), /dev/null sides for adds & deletes, and the
+// "Binary files … differ" marker.
+export function parsePatch(patch: string): DiffFile[] {
+  const files: DiffFile[] = [];
+  let cur: DiffFile | null = null;
+  let hunk: DiffHunk | null = null;
+  let oldNo = 0, newNo = 0;
+  const strip = (p: string) => p.replace(/\t.*$/, "").replace(/^[ab]\//, "");
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("diff --git ")) {
+      cur = { path: "", oldPath: null, status: "modified", binary: false, added: 0, removed: 0, hunks: [] };
+      hunk = null;
+      files.push(cur);
+      // Provisional name from the header; refined by the ---/+++ or rename lines.
+      const m = line.slice(11).match(/^a\/(.*) b\/(.*)$/);
+      if (m) cur.path = m[2];
+      continue;
+    }
+    if (!cur) continue;
+    if (line.startsWith("new file mode")) { cur.status = "added"; continue; }
+    if (line.startsWith("deleted file mode")) { cur.status = "deleted"; continue; }
+    if (line.startsWith("rename from ")) { cur.oldPath = line.slice(12); cur.status = "renamed"; continue; }
+    if (line.startsWith("rename to ")) { cur.path = line.slice(10); cur.status = "renamed"; continue; }
+    if (line.startsWith("Binary files")) { cur.binary = true; continue; }
+    if (line.startsWith("--- ")) { const p = line.slice(4); if (p !== "/dev/null") cur.oldPath = strip(p); continue; }
+    if (line.startsWith("+++ ")) { const p = line.slice(4); if (p !== "/dev/null") cur.path = strip(p); continue; }
+    if (line.startsWith("@@")) {
+      const m = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@(.*)$/);
+      oldNo = m ? +m[1] : 0;
+      newNo = m ? +m[2] : 0;
+      hunk = { header: m ? m[3].trim() : "", lines: [] };
+      cur.hunks.push(hunk);
+      continue;
+    }
+    if (!hunk) continue; // index/mode/similarity headers between `diff --git` and the first @@
+    const c = line[0];
+    if (c === "+") { hunk.lines.push({ kind: "add", text: line.slice(1), oldNo: null, newNo: newNo++ }); cur.added++; }
+    else if (c === "-") { hunk.lines.push({ kind: "del", text: line.slice(1), oldNo: oldNo++, newNo: null }); cur.removed++; }
+    else if (c === " ") { hunk.lines.push({ kind: "ctx", text: line.slice(1), oldNo: oldNo++, newNo: newNo++ }); }
+    // "\ No newline at end of file" and trailing blank lines fall through, ignored.
+  }
+  return files;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
 import "@xterm/xterm/css/xterm.css";
+import { parsePatch, type DiffFile, type DiffHunk } from "./diff";
 
 function loadWebgl(term: Terminal) {
   try {
@@ -170,6 +171,14 @@ let externals: ExtSession[] = [];
 let activeExtId: string | null = null;      // session_id of the external session being mirrored
 let extTranscriptTimer: number | undefined;
 const extWorking = (e: ExtSession) => !!e.status && !["idle", "sleeping", "done", ""].includes(e.status);
+
+// Uncommitted git state keyed by folder (a session's workdir or an external's cwd),
+// polled by refreshDirtyStates. It's the single source of truth for the sidebar's
+// "has changes" dot and the external inspector's diff card: s.git only stays fresh
+// for the *active* session, so nothing else can rely on it across every project.
+const dirtyByFolder = new Map<string, DiffStat | null>();
+const isDirty = (g?: DiffStat | null): boolean => !!g && (g.files > 0 || g.untracked > 0);
+const folderDirty = (f: string): boolean => isDirty(dirtyByFolder.get(f));
 
 // persisted daily usage rollup (survives app + system restarts)
 const usage: Record<string, number> = JSON.parse(localStorage.getItem("cc-usage") || "{}");
@@ -433,6 +442,26 @@ async function refreshExternals() {
     renderSidebar(); renderMini();
   } catch { /* backend not ready yet */ }
 }
+// Poll uncommitted git state for every folder in play (session workdirs + external
+// cwds), so the sidebar dot and the external diff card are accurate for all projects
+// at once — not just whichever session is active. git_diffstat is the same cheap
+// call the inspector already makes; here it fans out across the distinct folders.
+async function refreshDirtyStates() {
+  const folders = new Set<string>();
+  for (const s of sessions.values()) if (!s.shell && s.workdir) folders.add(s.workdir);
+  for (const e of externals) if (e.cwd) folders.add(e.cwd);
+  for (const f of [...dirtyByFolder.keys()]) if (!folders.has(f)) dirtyByFolder.delete(f); // prune gone folders
+  const sig = (g?: DiffStat | null) => (g ? `${g.files}/${g.untracked}/${g.added}/${g.removed}` : "-");
+  let changed = false;
+  await Promise.all([...folders].map(async (f) => {
+    const g = await invoke<DiffStat | null>("git_diffstat", { workdir: f }).catch(() => null);
+    if (sig(dirtyByFolder.get(f)) !== sig(g)) changed = true;
+    dirtyByFolder.set(f, g ?? null);
+  }));
+  if (!changed) return;
+  renderSidebar();
+  if (activeExtId) { const e = externals.find((x) => x.session_id === activeExtId); if (e) renderExtInspector(e); }
+}
 function openExternal(sid: string) {
   const e = externals.find((x) => x.session_id === sid);
   if (!e) return;
@@ -444,6 +473,7 @@ function openExternal(sid: string) {
   document.documentElement.style.setProperty("--accent", accentFor(e.cwd));
   renderExtHeader(e); renderExtInspector(e); renderSidebar(); renderMini(); renderFoot();
   $("extBody").innerHTML = `<div class="ext-empty">Loading transcript…</div>`;
+  void refreshDirtyStates(); // fill the working-set card promptly, not on the next poll tick
   loadTranscript(e, true);
   clearInterval(extTranscriptTimer);
   extTranscriptTimer = window.setInterval(() => {
@@ -487,11 +517,27 @@ function renderExtHeader(e: ExtSession) {
   $("hTitle").textContent = e.name || "";
   $("hPath").textContent = tilde(e.cwd);
 }
+// A read-only working-set peek for an external session's folder — the same card as a
+// Muster session's, minus the fetch/pull/push row (we don't drive this checkout).
+// Shown only when the folder actually has uncommitted changes.
+function extPeekHtml(e: ExtSession, g: DiffStat): string {
+  const tot = g.added + g.removed || 1;
+  const aw = Math.round((g.added / tot) * 100);
+  const newBadge = g.untracked ? ` · ${g.untracked} new` : "";
+  return `<div class="wset ext-wset">
+    <div class="lab" style="margin-bottom:2px">Working set · in this folder</div>
+    <div class="wpeek" data-diff="${esc(e.cwd)}" data-difftitle="${esc(basename(e.cwd))}" title="Open the uncommitted diff">
+      <div class="wtop"><span class="add">+${g.added}</span><span class="del">−${g.removed}</span><span class="files">${g.files} file${g.files === 1 ? "" : "s"}${newBadge}</span><span class="wpeek-cue">⤢</span></div>
+      <div class="stackbar"><span class="sa" style="width:${aw}%"></span><span class="sd" style="width:${100 - aw}%"></span></div>
+    </div></div>`;
+}
 function renderExtInspector(e: ExtSession) {
   const working = extWorking(e);
   const pill = $("iPill"); pill.className = "pill " + (working ? "working" : "idle");
   $("iPillTxt").textContent = e.status || "external";
   const started = e.started_at ? new Date(e.started_at).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" }) : "–";
+  const g = dirtyByFolder.get(e.cwd);
+  const peek = isDirty(g) ? extPeekHtml(e, g!) : "";
   $("inspector").innerHTML = `
     <div class="ext-card">
       <div class="ext-hl">↗ Running outside Muster</div>
@@ -503,7 +549,7 @@ function renderExtInspector(e: ExtSession) {
       <div class="ext-meta"><span class="label">PID</span><span class="mono">${e.pid}</span></div>
       <button class="ext-jump-btn" data-jump="${e.pid}">↗ Jump to its terminal</button>
       <div class="ext-note">Muster can't drive this session — it was launched in another terminal. The panel on the left is a live read-only mirror of its transcript.</div>
-    </div>`;
+    </div>${peek}`;
 }
 
 // ---------- telemetry ----------
@@ -735,15 +781,19 @@ function renderSidebar() {
     const rows = p.sessions.map(sessionRow).join("") + p.externals.map(extRow).join("");
     const total = p.sessions.length + p.externals.length;
     const isFav = FAVORITES.some((f) => f.path === p.path);
+    // Any member folder (a session's workdir or an external's cwd) with uncommitted
+    // changes lights the project's dot — so a dirty worktree marks its parent too.
+    const dirty = p.sessions.some((s) => folderDirty(s.workdir)) || p.externals.some((e) => folderDirty(e.cwd));
+    const dot = dirty ? `<span class="pdirty" title="Uncommitted changes in this project"></span>` : "";
     let head: string;
     if (p.sessions.length) {
-      head = `<div class="phead" data-sel="${p.sessions[0].id}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span><span class="pcount">${total}</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}">＋</span></div>`;
+      head = `<div class="phead" data-sel="${p.sessions[0].id}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}<span class="pcount">${total}</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}">＋</span></div>`;
     } else if (isFav) {
       const tail = p.externals.length ? `<span class="pcount ext">${p.externals.length} ext</span>` : `<span class="plaunch">launch →</span>`;
-      head = `<div class="phead empty-p" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${tail}<span class="premove" data-remove="${esc(p.path)}" title="Remove project">✕</span></div>`;
+      head = `<div class="phead empty-p" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="premove" data-remove="${esc(p.path)}" title="Remove project">✕</span></div>`;
     } else {
       // discovered via an external session only — not a saved project
-      head = `<div class="phead ext-only" data-key="${esc(p.path)}" title="${esc(tilde(p.path))}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span><span class="pcount ext">${p.externals.length} ext</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" title="Launch a Muster session here">＋</span></div>`;
+      head = `<div class="phead ext-only" data-key="${esc(p.path)}" title="${esc(tilde(p.path))}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}<span class="pcount ext">${p.externals.length} ext</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" title="Launch a Muster session here">＋</span></div>`;
     }
     return `<div class="pgroup" draggable="true" data-path="${esc(p.path)}">${head}${rows ? `<div class="psessions">${rows}</div>` : ""}</div>`;
   }).join("");
@@ -992,8 +1042,9 @@ function wsetHtml(s: Sess): string {
   // The diff half is only worth drawing when something is actually uncommitted —
   // a clean tree that's 5 behind still needs the branch/sync row below.
   const diff = dirty
-    ? `<div class="wtop"><span class="add">+${g.added}</span><span class="del">−${g.removed}</span><span class="files">${g.files} file${g.files === 1 ? "" : "s"}</span></div>
-    <div class="stackbar"><span class="sa" style="width:${aw}%"></span><span class="sd" style="width:${100 - aw}%"></span></div>`
+    ? `<div class="wpeek" data-diff="${esc(s.workdir)}" data-difftitle="${esc(s.project + (s.branch ? " · " + s.branch : ""))}" title="Open the uncommitted diff">
+      <div class="wtop"><span class="add">+${g.added}</span><span class="del">−${g.removed}</span><span class="files">${g.files} file${g.files === 1 ? "" : "s"}</span><span class="wpeek-cue">⤢</span></div>
+      <div class="stackbar"><span class="sa" style="width:${aw}%"></span><span class="sd" style="width:${100 - aw}%"></span></div></div>`
     : "";
   const sync = g.upstream
     ? `<span class="sync${g.ahead || g.behind ? "" : " even"}" title="${esc(g.upstream)} — as of the last fetch">${
@@ -1029,6 +1080,72 @@ function gitBtnsHtml(s: Sess, g: DiffStat): string {
     ${btn("push", "push", up && !g.ahead ? "Nothing to push" : "", pushHint)}
   </div>`;
 }
+
+// ---------- working-set diff viewer ----------
+// Clicking the +N −M card opens a read-only peek at the uncommitted diff. The
+// backend (git_diff) hands us one combined unified-diff patch; parsePatch turns it
+// into files/hunks (in ./diff, unit-tested there). Rendering stays here, in the DOM.
+const DSTAT: Record<DiffFile["status"], [string, string]> = {
+  modified: ["M", "s-mod"], added: ["A", "s-add"], deleted: ["D", "s-del"], renamed: ["R", "s-ren"],
+};
+let diffOpen = false;
+// Keyed by folder (workdir/cwd), not session id, so the same viewer serves Muster's
+// own sessions and read-only external ones alike — both are just a git working tree.
+async function openDiff(workdir: string, title: string) {
+  if (!workdir) return;
+  diffOpen = true;
+  $("scrim").classList.add("show");
+  $("diffDlg").classList.add("show");
+  $("diffTitle").textContent = title || basename(workdir);
+  $("diffSub").textContent = "reading working tree…";
+  $("diffBody").innerHTML = `<div class="diff-empty">Reading the working tree…</div>`;
+  try {
+    const res = await invoke<{ patch: string; truncated: boolean } | null>("git_diff", { workdir });
+    if (!diffOpen) return; // closed while the diff was loading
+    renderDiffBody(res ? parsePatch(res.patch) : [], !!res?.truncated);
+  } catch (e) {
+    if (!diffOpen) return;
+    $("diffSub").textContent = "";
+    $("diffBody").innerHTML = `<div class="diff-empty">Couldn't read the diff.<br><span class="mono">${esc(String(e))}</span></div>`;
+  }
+}
+function closeDiff() {
+  diffOpen = false;
+  $("diffDlg").classList.remove("show");
+  if (!$("palette").classList.contains("show") && !$("wtDlg").classList.contains("show")) $("scrim").classList.remove("show");
+}
+function renderDiffBody(files: DiffFile[], truncated: boolean) {
+  const tot = files.reduce((a, f) => ({ add: a.add + f.added, rem: a.rem + f.removed }), { add: 0, rem: 0 });
+  $("diffSub").innerHTML = files.length
+    ? `<span class="add">+${tot.add}</span> <span class="del">−${tot.rem}</span> · ${files.length} file${files.length === 1 ? "" : "s"}`
+    : "";
+  if (!files.length) { $("diffBody").innerHTML = `<div class="diff-empty">No uncommitted changes to show.</div>`; return; }
+  const sections = files.map((f, i) => {
+    const [glyph, cls] = DSTAT[f.status];
+    const name = f.status === "renamed" && f.oldPath
+      ? `<span class="d-old">${esc(f.oldPath)}</span><span class="d-arr">→</span>${esc(f.path)}`
+      : esc(f.path);
+    const counts = f.binary ? `<span class="d-bin">binary</span>`
+      : `<span class="add">+${f.added}</span> <span class="del">−${f.removed}</span>`;
+    const body = f.binary
+      ? `<div class="d-binbody">Binary file — no textual diff.</div>`
+      : f.hunks.map(hunkHtml).join("") || `<div class="d-binbody">No line changes (mode or metadata only).</div>`;
+    return `<div class="dfile" data-fi="${i}">
+      <div class="dfhead" data-dtoggle="${i}"><span class="dchev">▾</span><span class="dstat ${cls}">${glyph}</span><span class="dpath">${name}</span><span class="dcount">${counts}</span></div>
+      <div class="dfbody">${body}</div></div>`;
+  }).join("");
+  const note = truncated ? `<div class="diff-trunc">Diff truncated — too large to show in full. Open a terminal for the complete diff.</div>` : "";
+  $("diffBody").innerHTML = sections + note;
+}
+function hunkHtml(h: DiffHunk): string {
+  const rows = h.lines.map((l) => {
+    const sign = l.kind === "add" ? "+" : l.kind === "del" ? "−" : "";
+    return `<div class="dline ${l.kind}"><span class="ln">${l.oldNo ?? ""}</span><span class="ln">${l.newNo ?? ""}</span><span class="dsign">${sign}</span><span class="lc">${esc(l.text)}</span></div>`;
+  }).join("");
+  const ctx = h.header ? `<span class="dhh-ctx">${esc(h.header)}</span>` : "";
+  return `<div class="dhunk"><div class="dhh">⋯${ctx}</div>${rows}</div>`;
+}
+
 function timelineHtml(s: Sess): string {
   const acts = s.activity.slice(0, 8);
   if (!acts.length) return `<div><div class="lab" style="margin-bottom:6px">Activity</div><div class="insp-empty" style="padding:12px 0">No activity yet.</div></div>`;
@@ -1209,7 +1326,8 @@ function dbgSnapshot() {
       ctxPct: s.ctxPct, cost: s.cost, durMs: s.durMs, subagents: s.subagents,
       lastEvent: s.lastEvent, external: s.external, branch: s.branch, workdir: s.workdir,
     })),
-    externals: externals.map((e) => ({ pid: e.pid, session_id: e.session_id, cwd: e.cwd, status: e.status })),
+    externals: externals.map((e) => ({ pid: e.pid, session_id: e.session_id, cwd: e.cwd, status: e.status, dirty: folderDirty(e.cwd) })),
+    dirtyFolders: [...dirtyByFolder.entries()].map(([f, g]) => ({ folder: f, added: g?.added ?? 0, removed: g?.removed ?? 0, files: g?.files ?? 0, untracked: g?.untracked ?? 0, dirty: isDirty(g) })),
     log: dbgLog.slice(-250),
   };
 }
@@ -1533,10 +1651,11 @@ document.addEventListener("click", (e) => {
   if (!t.closest("#attnPop, #attnBadge")) closeAttnPop();
   const dot = t.closest<HTMLElement>(".pdot, .rm-dot");
   if (dot) { const owner = dot.closest<HTMLElement>("[data-key]"); if (owner?.dataset.key) { openColorPopover(owner.dataset.key, e.clientX, e.clientY); return; } }
-  const el = t.closest<HTMLElement>("[data-perm],[data-git],[data-wt],[data-close],[data-remove],[data-add],[data-jump],[data-ext],[data-sel],[data-launch],[data-pal],[data-rail],[data-toast]");
+  const el = t.closest<HTMLElement>("[data-perm],[data-git],[data-diff],[data-wt],[data-close],[data-remove],[data-add],[data-jump],[data-ext],[data-sel],[data-launch],[data-pal],[data-rail],[data-toast]");
   if (!el) return;
   if (el.dataset.perm) resolvePermission(el.dataset.permid || "", el.dataset.perm);
   else if (el.dataset.git) runGit(el.dataset.gitsid || "", el.dataset.git);
+  else if (el.dataset.diff) openDiff(el.dataset.diff, el.dataset.difftitle || "");
   else if (el.dataset.wt) openWorktreeSession(el.dataset.wt, el.dataset.wtbranch || "");
   else if (el.dataset.close) closeSession(el.dataset.close);
   else if (el.dataset.remove) removeFavorite(el.dataset.remove);
@@ -1778,7 +1897,13 @@ $("wtGo").addEventListener("click", wtCreate);
 $("wtCancel").addEventListener("click", closeWt);
 $("wtMain").addEventListener("click", () => { if (!wtCtx) return; const { project, repoDir } = wtCtx; closeWt(); launch(project, repoDir, { colorKey: repoDir }); });
 $("wtBranch").addEventListener("keydown", (e) => { if (e.key === "Enter") { e.preventDefault(); wtCreate(); } else if (e.key === "Escape") closeWt(); });
-$("scrim").addEventListener("click", () => { closePalette(); closeWt(); });
+$("scrim").addEventListener("click", () => { closePalette(); closeWt(); closeDiff(); });
+$("diffClose").addEventListener("click", closeDiff);
+// Collapse / expand a file section by clicking its header.
+$("diffBody").addEventListener("click", (e) => {
+  const h = (e.target as HTMLElement).closest<HTMLElement>("[data-dtoggle]");
+  if (h) h.parentElement!.classList.toggle("collapsed");
+});
 $("palInput").addEventListener("input", refreshPal);
 $("palInput").addEventListener("keydown", (e) => {
   const meta = e.metaKey || e.ctrlKey;
@@ -1805,6 +1930,7 @@ window.addEventListener("keydown", (e) => {
   else if (meta && (e.key === "=" || e.key === "+")) { e.preventDefault(); bumpFont(0.5); }
   else if (meta && e.key === "-") { e.preventDefault(); bumpFont(-0.5); }
   else if (meta && e.key === "0") { e.preventDefault(); termFontSize = 12.5; applyFontSize(); toast("Terminal font 12.5px"); }
+  else if (e.key === "Escape" && diffOpen) { e.preventDefault(); closeDiff(); }
 });
 new ResizeObserver(() => refit()).observe($("terminals"));
 
@@ -1936,6 +2062,11 @@ setInterval(() => {
 // discover Claude Code sessions running outside Muster and keep them fresh.
 refreshExternals();
 setInterval(refreshExternals, 3000);
+
+// keep the sidebar's "uncommitted changes" dot (and the external diff card) honest
+// for every project at once — s.git alone only covers the active session.
+refreshDirtyStates();
+setInterval(refreshDirtyStates, 5000);
 
 // keep each session's branch label honest — re-read the real HEAD so switching
 // branches inside a session (or a worktree) is reflected instead of the stale

--- a/src/styles.css
+++ b/src/styles.css
@@ -119,6 +119,8 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 /* pname flexes + truncates so a long name never wraps the header onto a 2nd row */
 .pname { flex: 0 1 auto; min-width: 0; font-weight: 650; letter-spacing: -.01em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .pcount { flex: none; margin-left: auto; font: 600 10px var(--font-mono); color: var(--muted-2); background: var(--surface-2); padding: 1px 6px; border-radius: 6px; }
+/* project has uncommitted changes in one of its folders — sits right after the name */
+.pdirty { flex: none; width: 6px; height: 6px; border-radius: 50%; background: var(--st-working); box-shadow: 0 0 5px color-mix(in srgb, var(--st-working) 70%, transparent); }
 .padd { flex: none; font-size: 13px; color: var(--muted-2); padding: 0 2px; }
 .padd:hover { color: var(--text); }
 .phead.empty-p .pname { color: var(--muted-2); font-weight: 550; }
@@ -279,6 +281,10 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .wset .files { color: var(--muted); margin-left: auto; }
 .stackbar { height: 6px; border-radius: 3px; overflow: hidden; display: flex; background: var(--hair-strong); }
 .stackbar .sa { background: var(--st-done); } .stackbar .sd { background: var(--st-attention); }
+/* the +N −M card is a button into the diff viewer */
+.wpeek { display: flex; flex-direction: column; gap: 8px; cursor: pointer; }
+.wpeek-cue { margin-left: 8px; color: var(--muted-2); font-size: 12px; transition: color .12s; }
+.wpeek:hover .wpeek-cue { color: var(--accent-ink); } .wpeek:hover .files { color: var(--text); }
 .wset .branch { display: flex; align-items: center; gap: 8px; font-size: 11px; color: var(--muted); }
 .wset .branch .b { font-family: var(--font-mono); color: var(--accent-ink); }
 .wset .unc { margin-left: auto; font: 9.5px var(--font-mono); color: var(--st-working); background: color-mix(in srgb, var(--st-working) 14%, transparent); padding: 2px 6px; border-radius: 5px; }
@@ -293,6 +299,53 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .gitrow .gitb:hover:not(:disabled) { filter: brightness(1.12); border-color: var(--accent-ink); }
 .gitrow .gitb:disabled { opacity: .38; cursor: default; }
 .gitrow.busy { opacity: .6; }
+
+/* --- working-set diff viewer (modal) --- */
+.diffdlg { position: fixed; top: 8vh; left: 50%; transform: translateX(-50%) translateY(-8px) scale(.985); width: min(1000px, 94vw); max-height: 82vh; z-index: 41; display: flex; flex-direction: column; border-radius: var(--radius-lg); overflow: hidden; opacity: 0; pointer-events: none; transition: opacity .16s, transform .16s; background: color-mix(in srgb, var(--panel) 92%, transparent); backdrop-filter: blur(24px) saturate(1.4); border: 1px solid var(--hair-strong); box-shadow: 0 40px 100px -30px rgba(0,0,0,.8), inset 0 1px 0 rgba(255,255,255,.06); }
+.diffdlg.show { opacity: 1; pointer-events: auto; transform: translateX(-50%) translateY(0) scale(1); }
+.diff-head { display: flex; align-items: center; gap: 10px; padding: 10px 13px; border-bottom: 1px solid var(--hair); flex: none; }
+.diff-title-wrap { display: flex; align-items: baseline; gap: 10px; min-width: 0; }
+.diff-title-wrap b { font-size: 13px; font-weight: 650; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.diff-sub { font: 11px var(--font-mono); color: var(--muted); white-space: nowrap; flex: none; }
+.diff-sub .add { color: var(--st-done); } .diff-sub .del { color: var(--st-attention); }
+.diff-x { margin-left: auto; width: 24px; height: 24px; border-radius: 7px; border: 1px solid var(--hair); background: var(--surface); color: var(--muted); cursor: pointer; font-size: 12px; flex: none; }
+.diff-x:hover { color: var(--text); border-color: var(--hair-strong); }
+.diff-body { flex: 1; min-height: 0; overflow-y: auto; padding: 10px; }
+.diff-empty, .diff-trunc { color: var(--muted); font-size: 12px; padding: 16px; text-align: center; }
+.diff-trunc { color: var(--st-working); }
+
+.dfile { border: 1px solid var(--hair); border-radius: var(--radius-sm); margin-bottom: 9px; overflow: hidden; background: var(--bg-2); }
+.dfile:last-child { margin-bottom: 0; }
+.dfhead { display: flex; align-items: center; gap: 9px; padding: 7px 10px; cursor: pointer; background: var(--surface); user-select: none; }
+.dfhead:hover { background: var(--surface-2); }
+.dfile:not(.collapsed) .dfhead { border-bottom: 1px solid var(--hair); }
+.dfile.collapsed .dfbody { display: none; }
+.dfile.collapsed .dchev { transform: rotate(-90deg); }
+.dchev { color: var(--muted-2); font-size: 9px; transition: transform .12s; width: 10px; flex: none; }
+.dstat { width: 16px; height: 16px; border-radius: 4px; display: grid; place-items: center; font: 700 10px var(--font-mono); flex: none; }
+.dstat.s-mod { color: var(--st-working); background: color-mix(in srgb, var(--st-working) 16%, transparent); }
+.dstat.s-add { color: var(--st-done); background: color-mix(in srgb, var(--st-done) 16%, transparent); }
+.dstat.s-del { color: var(--st-attention); background: color-mix(in srgb, var(--st-attention) 16%, transparent); }
+.dstat.s-ren { color: var(--tool-read); background: color-mix(in srgb, var(--tool-read) 16%, transparent); }
+.dpath { font: 12px var(--font-mono); color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.d-old { color: var(--muted); } .d-arr { color: var(--muted-2); margin: 0 5px; }
+.dcount { margin-left: auto; font: 11px var(--font-mono); flex: none; white-space: nowrap; }
+.dcount .add { color: var(--st-done); } .dcount .del { color: var(--st-attention); }
+.d-bin { color: var(--muted-2); font-size: 10px; }
+.d-binbody { color: var(--muted); font: 11px var(--font-mono); padding: 8px 12px; }
+
+.dhunk { border-top: 1px solid var(--hair); }
+.dhunk:first-child { border-top: none; }
+.dhh { padding: 3px 10px; font: 10.5px var(--font-mono); color: var(--muted-2); background: color-mix(in srgb, var(--accent) 5%, transparent); }
+.dhh-ctx { color: var(--muted); margin-left: 8px; }
+.dline { display: flex; font: 11.5px/1.55 var(--font-mono); }
+.dline .ln { flex: none; width: 40px; padding-right: 8px; text-align: right; color: var(--muted-2); opacity: .55; user-select: none; }
+.dsign { flex: none; width: 15px; text-align: center; color: var(--muted-2); user-select: none; }
+.lc { flex: 1; min-width: 0; padding-right: 10px; tab-size: 2; white-space: pre-wrap; overflow-wrap: anywhere; }
+.dline.add { background: color-mix(in srgb, var(--st-done) 11%, transparent); }
+.dline.add .dsign { color: var(--st-done); }
+.dline.del { background: color-mix(in srgb, var(--st-attention) 11%, transparent); }
+.dline.del .dsign { color: var(--st-attention); }
 
 /* --- timeline (colour by tool, latency bar) --- */
 .tl2 { display: flex; flex-direction: column; }

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import { parsePatch } from "../src/diff";
+
+// Patches are built from real `git` output shapes. Lines are joined rather than
+// written as template literals because diff bodies contain backticks and ${…}.
+const patch = (...lines: string[]) => lines.join("\n");
+
+describe("parsePatch", () => {
+  it("returns [] for an empty or contentless patch", () => {
+    expect(parsePatch("")).toEqual([]);
+    expect(parsePatch("\n\n")).toEqual([]);
+    expect(parsePatch("not a diff at all")).toEqual([]);
+  });
+
+  it("parses a modified file: counts, hunk, and per-line numbers", () => {
+    const [f] = parsePatch(patch(
+      "diff --git a/tracked.txt b/tracked.txt",
+      "index 83db48f..e0c9b5e 100644",
+      "--- a/tracked.txt",
+      "+++ b/tracked.txt",
+      "@@ -1,3 +1,4 @@",
+      " line1",
+      "-line2",
+      "+CHANGED",
+      " line3",
+      "+line4",
+    ));
+    expect(f.status).toBe("modified");
+    expect(f.path).toBe("tracked.txt");
+    expect(f.oldPath).toBe("tracked.txt");
+    expect(f.binary).toBe(false);
+    expect([f.added, f.removed]).toEqual([2, 1]);
+    expect(f.hunks).toHaveLength(1);
+    expect(f.hunks[0].lines).toEqual([
+      { kind: "ctx", text: "line1", oldNo: 1, newNo: 1 },
+      { kind: "del", text: "line2", oldNo: 2, newNo: null },
+      { kind: "add", text: "CHANGED", oldNo: null, newNo: 2 },
+      { kind: "ctx", text: "line3", oldNo: 3, newNo: 3 },
+      { kind: "add", text: "line4", oldNo: null, newNo: 4 },
+    ]);
+  });
+
+  it("parses an added file (path from +++, oldPath stays null) and keeps blank added lines", () => {
+    const [f] = parsePatch(patch(
+      "diff --git a/GUIDE.md b/GUIDE.md",
+      "new file mode 100644",
+      "index 0000000..f4a5322",
+      "--- /dev/null",
+      "+++ b/GUIDE.md",
+      "@@ -0,0 +1,3 @@",
+      "+# demo",
+      "+",
+      "+A small helper library.",
+    ));
+    expect(f.status).toBe("added");
+    expect(f.path).toBe("GUIDE.md");
+    expect(f.oldPath).toBeNull();
+    expect([f.added, f.removed]).toEqual([3, 0]);
+    expect(f.hunks[0].lines[1]).toEqual({ kind: "add", text: "", oldNo: null, newNo: 2 });
+  });
+
+  it("parses a deleted file (+++ is /dev/null, so path comes from the header)", () => {
+    const [f] = parsePatch(patch(
+      "diff --git a/README.md b/README.md",
+      "deleted file mode 100644",
+      "index 6d4d468..0000000",
+      "--- a/README.md",
+      "+++ /dev/null",
+      "@@ -1,2 +0,0 @@",
+      "-# demo",
+      "-old readme",
+    ));
+    expect(f.status).toBe("deleted");
+    expect(f.path).toBe("README.md");
+    expect(f.oldPath).toBe("README.md");
+    expect([f.added, f.removed]).toEqual([0, 2]);
+  });
+
+  it("handles paths with spaces and git's trailing-tab termination (untracked via --no-index)", () => {
+    const [f] = parsePatch(patch(
+      "diff --git a/weird näme.txt b/weird näme.txt",
+      "new file mode 100644",
+      "index 0000000..26ff09d",
+      "--- /dev/null",
+      "+++ b/weird näme.txt\t", // git appends a tab when the path has spaces
+      "@@ -0,0 +1 @@",
+      '+a "quoted" line',
+    ));
+    expect(f.status).toBe("added");
+    expect(f.path).toBe("weird näme.txt");
+    expect(f.added).toBe(1);
+    // single-line hunk header (no ,count) still yields correct line numbers
+    expect(f.hunks[0].lines[0]).toEqual({ kind: "add", text: 'a "quoted" line', oldNo: null, newNo: 1 });
+  });
+
+  it("marks binary files and gives them no hunks", () => {
+    const [f] = parsePatch(patch(
+      "diff --git a/bin.dat b/bin.dat",
+      "new file mode 100644",
+      "index 0000000..6164d9f",
+      "Binary files /dev/null and b/bin.dat differ",
+    ));
+    expect(f.status).toBe("added");
+    expect(f.binary).toBe(true);
+    expect(f.path).toBe("bin.dat");
+    expect(f.hunks).toHaveLength(0);
+    expect([f.added, f.removed]).toEqual([0, 0]);
+  });
+
+  it("parses a pure rename (100% similarity, no ---/+++ or hunks)", () => {
+    const [f] = parsePatch(patch(
+      "diff --git a/old.txt b/new.txt",
+      "similarity index 100%",
+      "rename from old.txt",
+      "rename to new.txt",
+    ));
+    expect(f.status).toBe("renamed");
+    expect(f.path).toBe("new.txt");
+    expect(f.oldPath).toBe("old.txt");
+    expect(f.hunks).toHaveLength(0);
+  });
+
+  it("parses a rename with content changes (rename headers + a hunk)", () => {
+    const [f] = parsePatch(patch(
+      "diff --git a/old.txt b/new.txt",
+      "similarity index 60%",
+      "rename from old.txt",
+      "rename to new.txt",
+      "index 1111111..2222222 100644",
+      "--- a/old.txt",
+      "+++ b/new.txt",
+      "@@ -1,4 +1,5 @@",
+      " aaaa",
+      "-bbbb",
+      "+CHANGED",
+      " cccc",
+      " dddd",
+      "+eeee",
+    ));
+    expect(f.status).toBe("renamed");
+    expect(f.path).toBe("new.txt");
+    expect(f.oldPath).toBe("old.txt");
+    expect([f.added, f.removed]).toEqual([2, 1]);
+  });
+
+  it("strips only the leading a//b/ prefix, so real paths under a dir named 'a' survive", () => {
+    const [f] = parsePatch(patch(
+      "diff --git a/a/weird.js b/a/weird.js",
+      "index 1111111..2222222 100644",
+      "--- a/a/weird.js",
+      "+++ b/a/weird.js",
+      "@@ -1 +1 @@",
+      "-x",
+      "+y",
+    ));
+    expect(f.path).toBe("a/weird.js");
+    expect(f.oldPath).toBe("a/weird.js");
+  });
+
+  it("resets line numbers per hunk from each @@ header", () => {
+    const [f] = parsePatch(patch(
+      "diff --git a/multi.txt b/multi.txt",
+      "index 1111111..2222222 100644",
+      "--- a/multi.txt",
+      "+++ b/multi.txt",
+      "@@ -1,2 +1,2 @@",
+      " a",
+      "-b",
+      "+B",
+      "@@ -10,2 +10,3 @@ fn context()",
+      " j",
+      "+K",
+      " l",
+    ));
+    expect(f.hunks).toHaveLength(2);
+    expect(f.hunks[1].header).toBe("fn context()"); // trailing @@ context is captured
+    expect(f.hunks[1].lines[0]).toEqual({ kind: "ctx", text: "j", oldNo: 10, newNo: 10 });
+    expect(f.hunks[1].lines[1]).toEqual({ kind: "add", text: "K", oldNo: null, newNo: 11 });
+    expect(f.hunks[1].lines[2]).toEqual({ kind: "ctx", text: "l", oldNo: 11, newNo: 12 });
+  });
+
+  it("ignores the '\\ No newline at end of file' marker without counting it", () => {
+    const [f] = parsePatch(patch(
+      "diff --git a/nonl.txt b/nonl.txt",
+      "index 1111111..2222222 100644",
+      "--- a/nonl.txt",
+      "+++ b/nonl.txt",
+      "@@ -1 +1 @@",
+      "-old",
+      "\\ No newline at end of file",
+      "+new",
+      "\\ No newline at end of file",
+    ));
+    expect([f.added, f.removed]).toEqual([1, 1]);
+    expect(f.hunks[0].lines).toHaveLength(2); // the two "\ No newline" lines dropped
+  });
+
+  it("splits a combined multi-file patch into ordered per-file records", () => {
+    const files = parsePatch(patch(
+      "diff --git a/GUIDE.md b/GUIDE.md",
+      "new file mode 100644",
+      "--- /dev/null",
+      "+++ b/GUIDE.md",
+      "@@ -0,0 +1 @@",
+      "+hi",
+      "diff --git a/README.md b/README.md",
+      "deleted file mode 100644",
+      "--- a/README.md",
+      "+++ /dev/null",
+      "@@ -1 +0,0 @@",
+      "-bye",
+      "diff --git a/src/x.js b/src/x.js",
+      "index 1111111..2222222 100644",
+      "--- a/src/x.js",
+      "+++ b/src/x.js",
+      "@@ -1 +1 @@",
+      "-a",
+      "+b",
+    ));
+    expect(files.map((f) => [f.path, f.status])).toEqual([
+      ["GUIDE.md", "added"],
+      ["README.md", "deleted"],
+      ["src/x.js", "modified"],
+    ]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+// Tests live in test/ (outside the app's tsconfig `include`, so `npm run build`
+// stays decoupled from test tooling). The diff parser is pure, so the default
+// node environment is all it needs.
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## What

Adds a read-only **working-set diff viewer** and surfaces uncommitted git state across the UI.

- The `+N −M · files` inspector card is now a button → opens a diff overlay with per-file collapsible sections, old/new line numbers, and +/− coloring. Backed by a new `git_diff` command that returns one combined unified-diff patch: tracked changes vs `HEAD`, plus untracked files via `diff --no-index` (so the index is never touched, unlike `git add -N`).
- Works for **external sessions** too — keyed off the session's folder, shown as a read-only working-set card in their inspector (no fetch/pull/push, since Muster doesn't drive that checkout).
- Projects with uncommitted changes now show a **dot in the sidebar**, driven by a folder-keyed poller (`dirtyByFolder`) that covers every project at once rather than only the active session.

## Preview

Faithful visual preview, built from the app's own `styles.css` and render functions (numbers are from a live instance):
https://claude.ai/code/artifact/80afe46b-405b-49f2-b372-28dd55fbea16

## Tests (the repo's first)

- `test/diff.test.ts` — 12 **vitest** cases over `parsePatch` (modified / added / deleted / renamed / binary / untracked-with-unicode-names, per-line numbering, multi-hunk resets, multi-file ordering). Adds `npm test`.
- `src-tauri/src/lib.rs` — 2 `cargo test` integration tests driving real `git` against a temp repo; asserts untracked files surface **without** being staged.

Green across `tsc`, `npm test`, `cargo test`, and `cargo clippy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
