### PR TITLE
Add Cmd+Q confirmation guard to prevent accidental quit

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,7 +14,7 @@ use std::sync::Mutex;
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine as _;
 use portable_pty::{native_pty_system, ChildKiller, CommandBuilder, MasterPty, PtySize};
-use tauri::menu::MenuBuilder;
+use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
 use tauri::tray::TrayIconBuilder;
 use tauri::{AppHandle, Emitter, Manager, State};
 
@@ -1509,6 +1509,18 @@ fn read_transcript(cwd: String, session_id: String, limit: usize) -> Result<Vec<
     Ok(msgs)
 }
 
+// ---------- app quit ----------
+
+/// Actually terminate the app. The Cmd+Q accelerator is bound to our own menu
+/// item (see the app menu in `run`), which asks the frontend to confirm instead
+/// of quitting; the frontend calls this once the user (or an empty session list)
+/// has approved the quit. Kept as a command so the *only* immediate-exit paths
+/// are this and the tray's "Quit Muster".
+#[tauri::command]
+fn confirm_quit(app: AppHandle) {
+    app.exit(0);
+}
+
 // ---------- macOS menu-bar (tray) ----------
 
 #[derive(serde::Deserialize)]
@@ -1632,6 +1644,11 @@ pub fn run() {
                             }
                             let _ = app.emit("tray-check-updates", ());
                         }
+                        // Cmd+Q is handled by the app menu's own quit item, but that
+                        // MenuEvent also reaches this handler — every menu handler shares
+                        // one global listener list — so swallow it here instead of letting
+                        // it fall through to the session catch-all below.
+                        "quit-confirm" => {}
                         sid => {
                             if let Some(w) = app.get_webview_window("main") {
                                 let _ = w.show();
@@ -1642,6 +1659,60 @@ pub fn run() {
                     }
                 })
                 .build(app)?;
+
+            // ---- App menu with a Cmd+Q catcher ----
+            // Cmd+Q is a "special Apple event" that Tauri does not reliably surface
+            // as an app/window event on macOS (tauri-apps/tauri#9198), so
+            // RunEvent::ExitRequested/prevent_exit can't be trusted to intercept it.
+            // Instead we *own* the Quit item: binding our own menu item to Cmd+Q means
+            // the keystroke fires `on_menu_event` (deterministic) rather than the OS
+            // `terminate:`. The handler asks the frontend to confirm; only `confirm_quit`
+            // actually exits. Replacing the default menu means we must re-add the Edit
+            // submenu ourselves, or Cmd+C/X/V/Z/A stop working in the app's inputs.
+            let quit_item = MenuItemBuilder::with_id("quit-confirm", "Quit Muster")
+                .accelerator("CmdOrCtrl+Q")
+                .build(app)?;
+            let app_menu = SubmenuBuilder::new(app, "Muster")
+                .about(None)
+                .separator()
+                .services()
+                .separator()
+                .hide()
+                .hide_others()
+                .show_all()
+                .separator()
+                .item(&quit_item)
+                .build()?;
+            let edit_menu = SubmenuBuilder::new(app, "Edit")
+                .undo()
+                .redo()
+                .separator()
+                .cut()
+                .copy()
+                .paste()
+                .select_all()
+                .build()?;
+            let window_menu = SubmenuBuilder::new(app, "Window")
+                .minimize()
+                .fullscreen()
+                .separator()
+                .close_window()
+                .build()?;
+            let menu = MenuBuilder::new(app)
+                .items(&[&app_menu, &edit_menu, &window_menu])
+                .build()?;
+            app.set_menu(menu)?;
+            app.on_menu_event(|app, event| {
+                if event.id().0.as_str() == "quit-confirm" {
+                    // Surface the window so the confirm dialog has context, then let the
+                    // frontend decide (it quits straight away when nothing is running).
+                    if let Some(w) = app.get_webview_window("main") {
+                        let _ = w.show();
+                        let _ = w.set_focus();
+                    }
+                    let _ = app.emit("quit-requested", ());
+                }
+            });
 
             Ok(())
         })
@@ -1668,7 +1739,8 @@ pub fn run() {
             read_transcript,
             find_project_icon,
             write_debug_file,
-            update_tray
+            update_tray,
+            confirm_quit
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/main.ts
+++ b/src/main.ts
@@ -1879,6 +1879,28 @@ setTimeout(() => checkForUpdates(false), 3000);
 // either way ("you're on the latest version"), so the menu item always answers.
 listen("tray-check-updates", () => { void checkForUpdates(true); });
 
+// Cmd+Q guard. Cmd+Q is bound to our own menu item in the backend (macOS doesn't
+// reliably surface the OS quit as a Tauri event — see tauri#9198), so the keystroke
+// arrives here as `quit-requested` rather than tearing the app down. We only nag
+// when something would actually be lost — an idle Muster quits immediately, keeping
+// the Cmd+Q muscle memory intact.
+listen("quit-requested", async () => {
+  const live = [...sessions.values()].filter((s) => s.phase !== "ended");
+  const agents = live.filter((s) => !s.shell).length;
+  const terms = live.filter((s) => s.shell).length;
+  if (agents + terms === 0) { await invoke("confirm_quit"); return; }
+  const parts: string[] = [];
+  if (agents) parts.push(`${agents} running ${agents === 1 ? "session" : "sessions"}`);
+  if (terms) parts.push(`${terms} ${terms === 1 ? "terminal" : "terminals"}`);
+  const ok = await ask(`${parts.join(" and ")} still running — quitting ends ${agents + terms === 1 ? "it" : "them"}.`, {
+    title: "Quit Muster?",
+    kind: "warning",
+    okLabel: "Quit",
+    cancelLabel: "Cancel",
+  });
+  if (ok) await invoke("confirm_quit");
+});
+
 // ---------- debug console wiring ----------
 $("dbgBtn").addEventListener("click", () => toggleDbg());
 $("dbgClose").addEventListener("click", () => toggleDbg(false));


### PR DESCRIPTION
## Problem

Fat-fingering **Cmd+Q** instantly tears down the whole app — killing every live Claude session and every embedded dev-server shell with no confirmation. Easy to do, expensive to undo.

## Approach

The obvious fix — `RunEvent::ExitRequested` + `api.prevent_exit()` — is **not reliable on macOS**: Cmd+Q is a special Apple event Tauri doesn't dependably surface as an app/window event ([tauri-apps/tauri#9198](https://github.com/tauri-apps/tauri/issues/9198), still open). So instead we **own the Quit menu item** — our own item is bound to `Cmd+Q`, so the keystroke fires a deterministic `on_menu_event` handler instead of the OS `terminate:`. The handler asks the frontend to confirm; only the new `confirm_quit` command actually exits.

## Behavior

- **Nothing running** → Cmd+Q quits immediately (keeps the muscle memory).
- **Live sessions / dev servers** → native dialog naming what's at stake (e.g. *"3 running sessions and 2 terminals still running — quitting ends them."*) with **Quit** / **Cancel**.

## Changes

- `src-tauri/src/lib.rs` — custom App / Edit / Window menus with a `Cmd+Q`-bound quit item; handler emits `quit-requested`. New `confirm_quit` command performs the real `app.exit(0)`. The **Edit** menu is rebuilt explicitly so `Cmd+C/V/X/Z/A` keep working (replacing the default menu would otherwise drop them).
- `src/main.ts` — `quit-requested` listener counts live sessions vs. shells and shows the confirm.
- Guarded a cross-talk bug found while wiring this: all menu handlers share one global listener list in Tauri, so the app-menu quit event also reaches the tray handler — added a `"quit-confirm" => {}` no-op arm so it can't fall through the tray's "unknown id = session" catch-all.

## Notes

- The tray **"Quit Muster"** still exits immediately (deliberate 2-step action, not a fat-finger).
- macOS-only, consistent with the rest of the app.

## Verification

`npx tsc` ✅ · `cargo check` ✅ · `cargo clippy` ✅ (no new warnings). Menu-event routing traced through the Tauri 2.11.5 source. End-to-end Cmd+Q not driven on the live machine to avoid disturbing running work — manual test: `npm run tauri dev`, start a session, press Cmd+Q → dialog appears; Cancel keeps it alive, Quit exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)