### PR TITLE
Add caffeinate keep-awake button with agent-aware mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,22 @@
         <div class="kbar" id="kbar"><span>⌕</span><span>Jump to a session, launch a project…</span><span class="kbd"><kbd>⌘</kbd><kbd>K</kbd></span></div>
         <div class="top-right">
           <button class="attn-badge" id="attnBadge"><span class="bdot"></span><span id="attnBadgeTxt"></span></button>
+          <div class="caf" id="caf">
+            <button class="caf-main" id="cafMain" aria-label="Keep this Mac awake">
+              <svg class="caf-ic" viewBox="0 0 24 24" aria-hidden="true">
+                <g class="caf-steam" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round">
+                  <path class="s1" d="M9 2.6c-.8 1-.8 2 0 3s.8 2 0 3" />
+                  <path class="s2" d="M13 2.6c-.8 1-.8 2 0 3s.8 2 0 3" />
+                  <path class="s3" d="M17 2.6c-.8 1-.8 2 0 3s.8 2 0 3" />
+                </g>
+                <path class="caf-cup" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"
+                  d="M4.5 10h12v4.5a5 5 0 0 1-5 5h-2a5 5 0 0 1-5-5V10Z" />
+                <path class="caf-handle" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"
+                  d="M16.5 11h1.8a2.6 2.6 0 0 1 0 5.2h-1.3" />
+              </svg>
+            </button>
+            <button class="caf-caret" id="cafCaret" aria-label="Choose caffeinate mode">▾</button>
+          </div>
           <button class="ibtn" id="themeBtn" title="Toggle theme" aria-label="Toggle theme">◐</button>
         </div>
       </header>
@@ -111,6 +127,7 @@
     <div class="toast" id="toast"></div>
     <div class="colorpop" id="colorPop"></div>
     <div class="menupop" id="enginePop"></div>
+    <div class="menupop cafpop" id="cafPop"></div>
     <div class="menupop attnpop" id="attnPop"></div>
   </body>
 </html>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,6 +39,10 @@ struct AppState {
     /// Answered later by the `resolve_permission` command.
     pending: Mutex<HashMap<String, tiny_http::Request>>,
     next_perm: std::sync::atomic::AtomicU64,
+    /// The single running `caffeinate` child, if the user has toggled it on.
+    /// Started with `-w <our pid>` so it self-terminates if Muster ever dies
+    /// without a clean stop — no orphaned process keeps the Mac awake forever.
+    caffeinate: Mutex<Option<std::process::Child>>,
 }
 
 /// Find a request header by (case-insensitive) name.
@@ -585,6 +589,50 @@ fn kill_session(state: State<AppState>, session_id: String) -> Result<(), String
             state.owned_pids.lock().unwrap().remove(&p);
         }
     }
+    Ok(())
+}
+
+/// A caffeinate flag we're willing to pass through: a short-option cluster over
+/// the sleep-assertion letters (`-d -i -m -s -u`, or combined like `-dimsu`),
+/// the `-t` timeout switch, or a bare decimal number (its seconds argument).
+/// Everything the UI sends is a fixed preset, so this is just belt-and-braces
+/// against ever handing an arbitrary string to the shell-less spawn.
+fn valid_caffeinate_flag(f: &str) -> bool {
+    if let Some(rest) = f.strip_prefix('-') {
+        return !rest.is_empty() && rest.chars().all(|c| "dimsut".contains(c));
+    }
+    !f.is_empty() && f.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Toggle a macOS `caffeinate` power-assertion on or off. Only ever one child
+/// runs: any existing one is killed first, so switching presets is just a
+/// stop+restart. `active=false` (or an empty `flags`) simply stops it.
+#[tauri::command]
+fn set_caffeinate(state: State<AppState>, active: bool, flags: Vec<String>) -> Result<(), String> {
+    let mut guard = state.caffeinate.lock().unwrap();
+    // Tear down whatever's running (also reaps a child that self-exited on -t).
+    if let Some(mut child) = guard.take() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    if !active || flags.is_empty() {
+        return Ok(());
+    }
+    if let Some(bad) = flags.iter().find(|f| !valid_caffeinate_flag(f)) {
+        return Err(format!("refusing unknown caffeinate flag: {bad}"));
+    }
+    // `-w <our pid>`: caffeinate exits on its own the moment Muster does, so a
+    // crash or force-quit can't leave the display pinned awake.
+    let mut cmd = std::process::Command::new("/usr/bin/caffeinate");
+    cmd.arg("-w").arg(std::process::id().to_string());
+    for f in &flags {
+        cmd.arg(f);
+    }
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    let child = cmd.spawn().map_err(|e| format!("caffeinate: {e}"))?;
+    *guard = Some(child);
     Ok(())
 }
 
@@ -1576,6 +1624,7 @@ pub fn run() {
                 owned_pids: Mutex::new(HashSet::new()),
                 pending: Mutex::new(HashMap::new()),
                 next_perm: std::sync::atomic::AtomicU64::new(1),
+                caffeinate: Mutex::new(None),
             });
 
             let handle = app.handle().clone();
@@ -1656,6 +1705,7 @@ pub fn run() {
             git_action,
             session_resources,
             create_worktree,
+            set_caffeinate,
             resolve_permission,
             list_worktrees,
             spawn_ghostty,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1173,6 +1173,7 @@ function renderAll() {
     renderInspector(s); renderHeader(s);
   }
   updateTray();
+  reconcileCaf(); // agent-aware mode follows the fleet's phases; no-op otherwise
 }
 
 // ---------- debug console ----------
@@ -1530,6 +1531,7 @@ document.addEventListener("click", (e) => {
   const t = e.target as HTMLElement;
   if (!t.closest("#colorPop, .pdot, .rm-dot")) closeColorPop();
   if (!t.closest("#enginePop, #fEngineSeg")) closeEnginePop();
+  if (!t.closest("#cafPop, #caf")) closeCafPop();
   if (!t.closest("#attnPop, #attnBadge")) closeAttnPop();
   const dot = t.closest<HTMLElement>(".pdot, .rm-dot");
   if (dot) { const owner = dot.closest<HTMLElement>("[data-key]"); if (owner?.dataset.key) { openColorPopover(owner.dataset.key, e.clientX, e.clientY); return; } }
@@ -1629,6 +1631,154 @@ $("enginePop").addEventListener("click", (e) => {
   if (!b) return;
   setEngine(b.dataset.engine as Engine);
   closeEnginePop();
+});
+
+// ---------- caffeinate (keep-awake) ----------
+// The top-bar split button drives a macOS `caffeinate` power assertion. The icon
+// toggles the last-used preset (one click); the caret opens the picker. Three
+// kinds of preset:
+//   • static  — fixed flags, on until you stop it (display / system / full)
+//   • timer   — a chosen duration (15m/1h/2h/4h), auto-off when it elapses
+//   • agents  — dynamic: hold the Mac awake ONLY while sessions are busy, and
+//               release when the fleet goes dormant; re-arms when work resumes
+// "Armed" (the user turned it on) is distinct from "asserting" (a caffeinate
+// child is actually running right now). For the agent mode those differ: armed
+// but idle shows the cup lit without steam; asserting adds the steam + glow.
+// reconcileCaf() is the single choke point — called on every renderAll(), it
+// diffs the desired flags against what's running and only pokes the backend on a
+// real change (same guarded-invoke pattern as updateTray).
+type CafKind = "static" | "timer" | "agents";
+interface CafPreset { id: string; kind: CafKind; label: string; desc: string; glyph: string; flags?: string[] }
+const CAF_PRESETS: CafPreset[] = [
+  { id: "display", kind: "static", label: "Keep display awake", desc: "Screen + system stay on",     glyph: "☀", flags: ["-d"] },
+  { id: "system",  kind: "static", label: "Keep system awake",  desc: "Runs on; screen may sleep",   glyph: "⏻", flags: ["-i"] },
+  { id: "full",    kind: "static", label: "Fully caffeinated",  desc: "Display, disk & system",      glyph: "✺", flags: ["-dimsu"] },
+  { id: "timer",   kind: "timer",  label: "Timed",              desc: "Stay awake, then auto-off",   glyph: "◷" },
+  { id: "agents",  kind: "agents", label: "Until agents idle",  desc: "Awake only while agents work", glyph: "⟳" },
+];
+const CAF_DURATIONS: { sec: number; label: string }[] = [
+  { sec: 900, label: "15m" }, { sec: 3600, label: "1h" }, { sec: 7200, label: "2h" }, { sec: 14400, label: "4h" },
+];
+const cafPreset = (id: string): CafPreset => CAF_PRESETS.find((p) => p.id === id) || CAF_PRESETS[0];
+let cafPresetId = localStorage.getItem("cc-caffeinate") || CAF_PRESETS[0].id;
+if (!CAF_PRESETS.some((p) => p.id === cafPresetId)) cafPresetId = CAF_PRESETS[0].id;
+let cafTimerSec = parseInt(localStorage.getItem("cc-caf-timer") || "", 10) || 3600;
+if (!CAF_DURATIONS.some((d) => d.sec === cafTimerSec)) cafTimerSec = 3600;
+// agents mode: also count "waiting on you" (permission prompt / your turn) as
+// busy, so an unattended run's prompt keeps the screen up. User-toggled switch.
+let cafAgentsAwait = localStorage.getItem("cc-caf-await") !== "0";
+let cafArmed = false;         // the user turned it on
+let cafAssertKey = "";        // flags currently handed to the backend ("" = off)
+let cafTimerHandle: number | null = null;
+
+function cafPersist() {
+  localStorage.setItem("cc-caffeinate", cafPresetId);
+  localStorage.setItem("cc-caf-timer", String(cafTimerSec));
+  localStorage.setItem("cc-caf-await", cafAgentsAwait ? "1" : "0");
+}
+// Is any real (non-shell) session doing work worth staying awake for?
+function cafAgentsBusy(): boolean {
+  for (const s of sessions.values()) {
+    if (s.shell || s.phase === "ended") continue;
+    if (s.phase === "working" || s.phase === "thinking") return true;
+    if (cafAgentsAwait && (!!s.attention || s.phase === "done")) return true;
+  }
+  return false;
+}
+// The flags we WANT running now, or null for "assert nothing".
+function cafDesiredFlags(): string[] | null {
+  if (!cafArmed) return null;
+  const p = cafPreset(cafPresetId);
+  if (p.kind === "agents") return cafAgentsBusy() ? ["-i"] : null;
+  if (p.kind === "timer") return ["-di", "-t", String(cafTimerSec)];
+  return p.flags ?? null;
+}
+function cafArmTimer() {
+  if (cafTimerHandle !== null) { clearTimeout(cafTimerHandle); cafTimerHandle = null; }
+  if (cafArmed && cafPreset(cafPresetId).kind === "timer") {
+    cafTimerHandle = window.setTimeout(() => { cafArmed = false; reconcileCaf(); toast("Caffeinate ended"); }, cafTimerSec * 1000);
+  }
+}
+function reconcileCaf() {
+  const flags = cafDesiredFlags();
+  const key = flags ? flags.join(" ") : "";
+  if (key !== cafAssertKey) {
+    cafAssertKey = key;
+    invoke("set_caffeinate", { active: !!flags, flags: flags ?? [] }).catch((e) => { cafAssertKey = ""; toast("caffeinate: " + e); });
+  }
+  renderCaf();
+}
+function renderCaf() {
+  const p = cafPreset(cafPresetId);
+  $("caf").classList.toggle("on", cafArmed);
+  $("caf").classList.toggle("asserting", cafAssertKey !== "");
+  $("cafMain").title = !cafArmed ? `Keep this Mac awake · ${p.label}`
+    : p.kind === "agents" ? (cafAssertKey ? "Awake — agents are working" : "Armed — sleeps until agents work")
+    : p.kind === "timer" ? `Awake · ${cafDurLabel(cafTimerSec)} timer — click to stop`
+    : `Awake · ${p.label} — click to stop`;
+}
+const cafDurLabel = (sec: number) => (CAF_DURATIONS.find((d) => d.sec === sec) || { label: sec + "s" }).label;
+
+// user actions -------------------------------------------------------------
+function cafToggle() { cafArmed = !cafArmed; cafPersist(); cafArmTimer(); reconcileCaf(); dlog("info", `caffeinate ${cafArmed ? "on · " + cafPresetId : "off"}`); }
+function cafPick(id: string) { cafPresetId = id; cafArmed = true; cafPersist(); cafArmTimer(); reconcileCaf(); dlog("info", `caffeinate on · ${id}`); }
+function cafStop() { cafArmed = false; cafPersist(); cafArmTimer(); reconcileCaf(); }
+function cafSetDuration(sec: number) { cafTimerSec = sec; cafPresetId = "timer"; cafArmed = true; cafPersist(); cafArmTimer(); reconcileCaf(); fillCafPop(); }
+function cafSetAwait(v: boolean) { cafAgentsAwait = v; cafPersist(); reconcileCaf(); fillCafPop(); }
+
+function fillCafPop() {
+  const rows = CAF_PRESETS.map((p) => {
+    const active = cafArmed && p.id === cafPresetId;
+    const last = !cafArmed && p.id === cafPresetId; // what a plain click would use
+    let right = "";
+    if (p.kind === "static") right = `<span class="mp-flags">${esc((p.flags ?? []).join(" "))}</span>`;
+    else if (p.kind === "agents") right = `<span class="mp-flags">-i</span>`;
+    const item = `<button class="mp-item ${active ? "on" : last ? "cur" : ""}" data-caf="${p.id}">`
+      + `<span class="mp-ic">${p.glyph}</span>`
+      + `<span class="mp-main"><span class="mp-l">${esc(p.label)}</span><span class="mp-s">${esc(p.desc)}</span></span>`
+      + right + `</button>`;
+    let sub = "";
+    if (p.kind === "timer") {
+      sub = `<div class="caf-sub caf-durs">` + CAF_DURATIONS.map((d) =>
+        `<button class="caf-dur ${d.sec === cafTimerSec ? "on" : ""}" data-cafdur="${d.sec}">${d.label}</button>`).join("") + `</div>`;
+    } else if (p.kind === "agents") {
+      sub = `<div class="caf-sub caf-switch-row">`
+        + `<span class="caf-sw-lbl">Stay awake while agents await you</span>`
+        + `<button class="caf-switch ${cafAgentsAwait ? "on" : ""}" role="switch" aria-checked="${cafAgentsAwait}" data-cafawait="1"><span class="caf-knob"></span></button></div>`;
+    }
+    return `<div class="caf-opt">${item}${sub}</div>`;
+  }).join("");
+  const off = cafArmed
+    ? `<div class="mp-sep"></div><button class="mp-item mp-off" data-caf="off"><span class="mp-ic">⏹</span><span class="mp-main"><span class="mp-l">Stop caffeinate</span></span></button>`
+    : "";
+  $("cafPop").innerHTML = rows + off;
+}
+function openCafPop() {
+  const r = $("caf").getBoundingClientRect();
+  const pop = $("cafPop");
+  fillCafPop();
+  const w = 260;
+  pop.style.left = Math.max(8, Math.min(r.left, window.innerWidth - w - 8)) + "px";
+  pop.style.top = (r.bottom + 6) + "px";
+  pop.style.bottom = "auto";
+  pop.classList.add("show");
+}
+function closeCafPop() { $("cafPop").classList.remove("show"); }
+$("cafMain").addEventListener("click", (e) => { e.stopPropagation(); closeCafPop(); cafToggle(); });
+$("cafCaret").addEventListener("click", (e) => { e.stopPropagation(); $("cafPop").classList.contains("show") ? closeCafPop() : openCafPop(); });
+$("cafPop").addEventListener("click", (e) => {
+  const t = e.target as HTMLElement;
+  // Sub-controls rebuild the popover (fillCafPop), which detaches the clicked
+  // node — so stop the event before it reaches the document outside-click
+  // handler, which would then see a detached target and close the popover.
+  const dur = t.closest<HTMLElement>("[data-cafdur]");
+  if (dur) { e.stopPropagation(); cafSetDuration(+dur.dataset.cafdur!); return; } // keep open — sub-control
+  if (t.closest("[data-cafawait]")) { e.stopPropagation(); cafSetAwait(!cafAgentsAwait); return; } // keep open — sub-control
+  const b = t.closest<HTMLElement>("[data-caf]");
+  if (!b) return;
+  const id = b.dataset.caf!;
+  if (id === "off") cafStop(); else cafPick(id);
+  closeCafPop();
 });
 
 // Reactor click → jump straight to the longest-waiting session, or open a picker
@@ -1944,4 +2094,7 @@ setInterval(refreshBranches, 4000);
 
 setSort(sortMode, false); // paint the sort button's glyph/title for the persisted mode
 initProjectDnD();
+// caffeinate always starts off (its -w guard died with the last run); renderAll's
+// reconcileCaf() paints the button. Note this is the ONE place agent-mode could
+// auto-assert on launch — but cafArmed is false at boot, so it stays dormant.
 renderAll();

--- a/src/styles.css
+++ b/src/styles.css
@@ -71,6 +71,56 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .attn-badge .bdot { width: 5px; height: 5px; border-radius: 50%; background: var(--rc, var(--st-attention)); }
 .ibtn { width: 26px; height: 26px; border-radius: 8px; cursor: pointer; display: grid; place-items: center; font-size: 13px; color: var(--muted); background: var(--surface); border: 1px solid var(--hair); }
 .ibtn:hover { color: var(--text); border-color: var(--hair-strong); }
+
+/* caffeinate split button — icon toggles the last-used preset, caret opens the
+   preset dropdown. The whole control reflects on/off via the .on class. */
+.caf { display: inline-flex; align-items: stretch; height: 26px; border-radius: 8px; overflow: hidden; color: var(--muted); background: var(--surface); border: 1px solid var(--hair); box-shadow: inset 0 1px 0 var(--lift); }
+.caf:hover { border-color: var(--hair-strong); }
+.caf-main, .caf-caret { border: 0; background: transparent; cursor: pointer; color: inherit; display: grid; place-items: center; padding: 0; }
+.caf-main { width: 28px; }
+.caf-caret { width: 15px; font-size: 8px; color: var(--muted-2); border-left: 1px solid var(--hair); }
+.caf-main:hover, .caf-caret:hover { color: var(--text); background: var(--lift); }
+.caf-ic { width: 16px; height: 16px; display: block; overflow: visible; }
+.caf-steam { opacity: 0; transition: opacity .25s; }
+.caf-cup, .caf-handle { transition: stroke .2s; }
+/* ARMED (.on) — accent tint. ASSERTING (a caffeinate child is actually running)
+   adds the glow + rising steam. Agent mode armed-but-idle is .on without
+   .asserting: a lit cup, quiet, waiting for the fleet to get busy. */
+.caf.on { color: var(--accent-ink); background: var(--accent-wash); border-color: var(--accent-line); }
+.caf.on .caf-caret { color: var(--accent-ink); border-left-color: var(--accent-line); }
+.caf.asserting { box-shadow: inset 0 1px 0 var(--lift), 0 0 12px -4px var(--accent-glow); }
+.caf.asserting .caf-steam { opacity: .85; }
+@media (prefers-reduced-motion: no-preference) {
+  .caf.asserting .caf-steam path { transform-box: fill-box; animation: caf-steam 2.1s ease-in-out infinite; }
+  .caf.asserting .caf-steam .s2 { animation-delay: .5s; }
+  .caf.asserting .caf-steam .s3 { animation-delay: 1s; }
+  @keyframes caf-steam { 0% { opacity: 0; transform: translateY(2.5px); } 45% { opacity: .85; } 100% { opacity: 0; transform: translateY(-2.5px); } }
+}
+
+/* caffeinate preset dropdown (reuses .menupop chrome) */
+.cafpop { min-width: 244px; }
+.cafpop .mp-main { flex: 1; }
+.cafpop .mp-flags { flex: none; margin-left: 8px; font: 10px var(--font-mono); color: var(--muted-2); background: var(--surface-2); border: 1px solid var(--hair); border-radius: 5px; padding: 1px 6px; }
+.cafpop .mp-item.on { background: var(--accent-wash); border-color: var(--accent-line); }
+.cafpop .mp-item.on .mp-ic, .cafpop .mp-item.on .mp-l { color: var(--accent-ink); }
+.cafpop .mp-item.on .mp-flags { color: var(--accent-ink); border-color: var(--accent-line); background: transparent; }
+.cafpop .mp-item.cur .mp-ic { color: var(--accent-ink); }
+.cafpop .mp-sep { height: 1px; margin: 5px 7px; background: var(--hair); }
+.cafpop .mp-off .mp-ic { color: var(--st-attention); }
+.cafpop .mp-off .mp-l { color: var(--st-attention); }
+/* a preset row + its optional sub-controls (timer durations / agent switch) */
+.cafpop .caf-opt { display: flex; flex-direction: column; }
+.cafpop .caf-sub { display: flex; align-items: center; gap: 6px; padding: 0 10px 7px 36px; }
+.cafpop .caf-durs { gap: 5px; }
+.cafpop .caf-dur { flex: none; height: 22px; padding: 0 10px; border-radius: 6px; cursor: pointer; font: 600 10.5px var(--font-mono); color: var(--muted); background: var(--surface); border: 1px solid var(--hair); }
+.cafpop .caf-dur:hover { color: var(--text); border-color: var(--hair-strong); }
+.cafpop .caf-dur.on { color: var(--accent-ink); background: var(--accent-wash); border-color: var(--accent-line); }
+.cafpop .caf-switch-row { justify-content: space-between; }
+.cafpop .caf-sw-lbl { font-size: 10.5px; color: var(--muted); }
+.cafpop .caf-switch { flex: none; width: 30px; height: 17px; border-radius: 999px; cursor: pointer; padding: 0; border: 1px solid var(--hair-strong); background: var(--surface-2); position: relative; transition: background .15s, border-color .15s; }
+.cafpop .caf-switch .caf-knob { position: absolute; top: 1.5px; left: 1.5px; width: 12px; height: 12px; border-radius: 50%; background: var(--muted); transition: transform .15s, background .15s; }
+.cafpop .caf-switch.on { background: var(--accent-wash); border-color: var(--accent-line); }
+.cafpop .caf-switch.on .caf-knob { transform: translateX(13px); background: var(--accent-ink); }
 @media (prefers-reduced-motion: no-preference) { .attn-badge .bdot { animation: pulse 1.5s ease-in-out infinite; } }
 
 /* left rail */


### PR DESCRIPTION
## Summary

Adds a caffeinate keep-awake button to the top bar so macOS won't sleep while your agents run — including a Muster-native mode that keeps the Mac awake **only while agents are actually busy**.

## What it does

The ☕ split button (top-right, left of the theme toggle):
- **One click** on the cup — toggles the last-used preset on/off.
- **Caret ▾** — opens the preset picker.

Presets:
- **Keep display awake** (`-d`), **Keep system awake** (`-i`), **Fully caffeinated** (`-dimsu`) — static, on until you stop them.
- **Timed** — 15m / 1h / 2h / 4h, auto-off when it elapses.
- **Until agents idle** — dynamic: holds the Mac awake only while sessions are working/thinking, releases when the fleet goes dormant, and re-arms when work resumes. An in-dropdown switch (*"Stay awake while agents await you"*) extends that to sessions blocked on a permission prompt or waiting for your turn.

The button reflects state: muted when off, a lit accent cup when armed, and rising steam + glow when it's actually holding the Mac awake — so agent-mode "armed but idle" is visibly distinct from "actively caffeinating".

## Implementation

- **Backend** (`set_caffeinate`): runs a single whitelisted `caffeinate -w <muster pid> …` child. The `-w` ties its lifetime to Muster's, so a crash or force-quit can't orphan a process that keeps your screen awake. Flags are validated before spawn.
- **Frontend**: one `reconcileCaf()` runs on every `renderAll()`, diffs desired vs. running flags, and pokes the backend only on a change — the same guarded-invoke pattern the tray already uses, which is what lets agent-phase transitions drive the dynamic mode for free.

## Testing

- `tsc`, `cargo check`, `cargo clippy` clean; `vite build` OK.
- Verified the OS behavior: `caffeinate` assertions appear/clear in `pmset -g assertions`, and the `-w` guard self-terminates when the watched pid dies.
- Verified the dropdown sub-controls (duration chips + await switch) keep the popover open.

## Screenshots:

<img width="346" height="373" alt="popover" src="https://github.com/user-attachments/assets/f55b0476-10cb-4381-80ac-c9af458e95ac" />
<img width="159" height="91" alt="active" src="https://github.com/user-attachments/assets/b426f6d1-532c-45d8-8c3e-966c9568e8da" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)