### PR TITLE
Group sidebar sessions by worktree

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -746,6 +746,28 @@ fn git_head(workdir: String) -> Option<HeadInfo> {
     Some(HeadInfo { branch, short })
 }
 
+/// Resolve `cwd` to its repo's MAIN worktree root and current branch. This is what
+/// lets external sessions running in different worktrees of one repo group under that
+/// repo (and merge into its project) instead of each cwd becoming its own top-level
+/// entry in the sidebar. One git call: line 1 = the common `.git` dir (its parent is
+/// the main worktree, identical for the main checkout AND every linked worktree),
+/// line 2 = the branch ("HEAD" when detached). (None, None) when `cwd` isn't a repo.
+fn git_repo_info(cwd: &str) -> (Option<String>, Option<String>) {
+    let out = match git_cmd(cwd, &["rev-parse", "--path-format=absolute", "--git-common-dir", "--abbrev-ref", "HEAD"]).output() {
+        Ok(o) if o.status.success() => o,
+        _ => return (None, None),
+    };
+    let text = String::from_utf8_lossy(&out.stdout);
+    let mut lines = text.lines();
+    let common = lines.next().unwrap_or("").trim();
+    let branch = lines.next().unwrap_or("").trim();
+    let root = std::path::Path::new(common).parent()
+        .map(|p| p.to_string_lossy().into_owned())
+        .filter(|s| !s.is_empty());
+    let branch = if branch.is_empty() || branch == "HEAD" { None } else { Some(branch.to_string()) };
+    (root, branch)
+}
+
 /// A `git` command hardened for running under a GUI app.
 ///
 /// Three things are non-negotiable here, and each one has bitten this codebase's
@@ -1217,6 +1239,11 @@ struct ExternalSession {
     status_updated_at: Option<i64>,
     started_at: Option<i64>,
     version: String,
+    /// Main worktree root of this session's repo — the key the sidebar groups by, so
+    /// every worktree of one repo lands under it. None when cwd isn't a git repo.
+    repo_root: Option<String>,
+    /// Branch checked out in this session's cwd (None when detached / not a repo).
+    branch: Option<String>,
 }
 
 /// One `ps -o <fields>=` line for a single pid (trimmed), or None if the process
@@ -1299,6 +1326,8 @@ fn list_external_sessions(state: State<AppState>, exclude: Vec<String>) -> Vec<E
             status_updated_at: v.get("statusUpdatedAt").and_then(|x| x.as_i64()),
             started_at: v.get("startedAt").and_then(|x| x.as_i64()),
             version: v.get("version").and_then(|x| x.as_str()).unwrap_or("").to_string(),
+            repo_root: None,
+            branch: None,
         });
     }
     if parsed.is_empty() {
@@ -1337,6 +1366,15 @@ fn list_external_sessions(state: State<AppState>, exclude: Vec<String>) -> Vec<E
     let self_pid = std::process::id();
     let owned = state.owned_pids.lock().unwrap().clone();
     parsed.retain(|s| !owned.contains(&s.pid) && !is_descendant_of(s.pid, self_pid));
+
+    // Enrich survivors with their repo root + branch so worktrees of one repo group
+    // together (and merge into that repo's project) rather than each cwd becoming its
+    // own top-level entry. After the filters, so no git runs on stale or owned pids.
+    for s in parsed.iter_mut() {
+        let (root, branch) = git_repo_info(&s.cwd);
+        s.repo_root = root;
+        s.branch = branch;
+    }
 
     // most-recently-active first
     parsed.sort_by(|a, b| b.status_updated_at.unwrap_or(0).cmp(&a.status_updated_at.unwrap_or(0)));

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,6 +88,30 @@ const SORT_META: Record<SortMode, { glyph: string; label: string }> = {
 };
 let sortMode: SortMode = (localStorage.getItem("cc-sort") as SortMode) || "manual";
 if (!SORT_MODES.includes(sortMode)) sortMode = "manual";
+// --- sidebar worktree grouping -------------------------------------------------
+// Sessions of a repo already collapse into one project group (colorKey = repo root);
+// this decides how the worktrees WITHIN that group are shown. The distinguishing key
+// per worktree is s.workdir (the actual checkout dir); s.worktree holds its branch.
+//   off       — flat rows, branch only as a fallback label (legacy behaviour)
+//   subheader — a ⑃-branch header per worktree cluster, sessions nested under it
+//   toplevel  — each worktree becomes its own top-level group ("repo · branch")
+//   chip      — flat rows, each worktree row carries a colour-coded ⑃ chip
+// off/subheader/chip differ purely in the render layer; toplevel also splits
+// projectList() so close-navigation and the mini-rail stay coherent. A project with a
+// single checkout always renders flat, whatever the mode. Persisted under
+// cc-worktree-group; no in-app control yet — the settings window (separate branch)
+// will own the picker, until then flip it via setWtGroup() / localStorage.
+type WtGroup = "off" | "subheader" | "toplevel" | "chip";
+const WT_GROUPS: WtGroup[] = ["off", "subheader", "toplevel", "chip"];
+let wtGroup: WtGroup = (localStorage.getItem("cc-worktree-group") as WtGroup) || "subheader";
+if (!WT_GROUPS.includes(wtGroup)) wtGroup = "subheader";
+function setWtGroup(m: WtGroup) {
+  wtGroup = WT_GROUPS.includes(m) ? m : "subheader";
+  localStorage.setItem("cc-worktree-group", wtGroup);
+  renderAll();
+}
+// Dev affordance until the settings window ships: musterWtGroup("chip") in the console.
+(window as unknown as { musterWtGroup: typeof setWtGroup }).musterWtGroup = setWtGroup;
 // While a project group is being dragged, renderSidebar() must not rebuild the
 // #projects DOM — doing so would destroy the node the browser is dragging,
 // killing the drop. Telemetry ticks call renderAll() constantly, so this guard
@@ -165,6 +189,9 @@ function rlReset(reset: number | null): number | null {
 interface ExtSession {
   pid: number; session_id: string; cwd: string; name: string;
   status: string; status_updated_at?: number | null; started_at?: number | null; version: string;
+  // repo_root = the main worktree of this session's repo (backend-resolved), so all
+  // worktrees of one repo group under it; branch = the branch checked out in cwd.
+  repo_root?: string | null; branch?: string | null;
 }
 let externals: ExtSession[] = [];
 let activeExtId: string | null = null;      // session_id of the external session being mirrored
@@ -420,6 +447,10 @@ async function refreshExternals() {
   try {
     const list = await invoke<ExtSession[]>("list_external_sessions", { exclude: [...sessions.keys()] });
     externals = list;
+    // Scour each external repo for its logo, keyed by the same repo_root the sidebar
+    // groups by — otherwise ext-only projects would forever show the accent dot.
+    // probeIcon dedupes by key, so this hits the backend at most once per repo.
+    for (const e of externals) probeIcon(e.repo_root || e.cwd);
     if (activeExtId && !externals.some((e) => e.session_id === activeExtId)) {
       // the mirrored session ended — fall back to a Muster session or the empty state
       closeExternalView();
@@ -645,7 +676,49 @@ function applyStatusline(s: Sess, data: any) {
 }
 
 // ---------- rendering ----------
-interface ProjGroup { name: string; path: string; accent: string; sessions: Sess[]; externals: ExtSession[] }
+interface ProjGroup { name: string; path: string; accent: string; sessions: Sess[]; externals: ExtSession[]; wtBranch?: string }
+// A worktree cluster = the sessions of one project that share a checkout dir. Order
+// follows first appearance in the (already-sorted) session list, so the active/
+// attention sort still decides which worktree floats up. The repo-root checkout
+// (worktree === null) is the "main" cluster; its label is the live branch.
+interface WtCluster { key: string; branch: string; isMain: boolean; sessions: Sess[]; externals: ExtSession[] }
+function clusterByWorktree(p: ProjGroup): WtCluster[] {
+  const by = new Map<string, WtCluster>();
+  const order: WtCluster[] = [];
+  const bucket = (key: string, branch: string): WtCluster => {
+    let c = by.get(key);
+    if (!c) { c = { key, branch, isMain: key === p.path, sessions: [], externals: [] }; by.set(key, c); order.push(c); }
+    else if (!c.branch && branch) c.branch = branch;
+    return c;
+  };
+  for (const s of p.sessions) bucket(s.workdir || p.path, s.branch || s.worktree || "").sessions.push(s);
+  for (const e of p.externals) bucket(e.cwd || p.path, e.branch || "").externals.push(e);
+  // Label clusters that never carried a branch: the repo-root checkout is "main",
+  // any other bare dir falls back to its folder name.
+  for (const c of order) if (!c.branch) c.branch = c.isMain ? "main" : basename(c.key);
+  return order;
+}
+// A stable colour per branch, from the same hash as project accents so the sidebar's
+// colour language stays consistent (a branch and a project just seed different hues).
+const branchHue = (c: WtCluster) => accentFor(c.branch || c.key);
+// toplevel mode: explode any project whose sessions span >1 worktree into one group
+// per worktree. The root checkout keeps the project's identity (path/favourite/
+// externals); each worktree gets its own group keyed by its checkout dir, carrying
+// the branch in wtBranch. Single-checkout projects pass through untouched.
+function splitByWorktree(list: ProjGroup[]): ProjGroup[] {
+  const out: ProjGroup[] = [];
+  for (const p of list) {
+    const cl = clusterByWorktree(p);
+    const wts = cl.filter((c) => !c.isMain);
+    if (!wts.length) { out.push(p); continue; }
+    const root = cl.find((c) => c.isMain);
+    // Keep the root group only when it carries something — root-checkout rows or a
+    // favourite (a launch target). Drops the phantom empty root of a worktree-only repo.
+    if (root || FAVORITES.some((f) => f.path === p.path)) out.push({ ...p, sessions: root?.sessions ?? [], externals: root?.externals ?? [] });
+    for (const c of wts) out.push({ name: p.name, path: c.key, accent: p.accent, sessions: c.sessions, externals: c.externals, wtBranch: c.branch });
+  }
+  return out;
+}
 function projectList(): ProjGroup[] {
   const list: ProjGroup[] = FAVORITES.map((f) => ({ name: f.name, path: f.path, accent: accentFor(f.path), sessions: [], externals: [] }));
   const byName = new Map(list.map((p) => [p.name, p]));
@@ -656,23 +729,31 @@ function projectList(): ProjGroup[] {
     p.sessions.push(s);
   }
   for (const e of externals) {
-    let p = byPath.get(e.cwd);
-    if (!p) { p = { name: basename(e.cwd), path: e.cwd, accent: accentFor(e.cwd), sessions: [], externals: [] }; list.push(p); byPath.set(e.cwd, p); byName.set(p.name, p); }
+    // Group by the repo's main worktree, not the raw cwd, so every worktree of one
+    // repo lands under it (and merges into that repo's favourite when paths match).
+    const key = e.repo_root || e.cwd;
+    let p = byPath.get(key);
+    if (!p) { p = { name: basename(key), path: key, accent: accentFor(key), sessions: [], externals: [] }; list.push(p); byPath.set(key, p); byName.set(p.name, p); }
     p.externals.push(e);
   }
+  // Sort sessions within each project first, then (in toplevel mode) split by
+  // worktree so each split group inherits the sorted order, then order the groups.
+  const sessCmp = sortMode === "active" ? (a: Sess, b: Sess) => b.lastActivity - a.lastActivity
+    : sortMode === "attention" ? (a: Sess, b: Sess) => urgencyRank(a) - urgencyRank(b) || a.phaseSince - b.phaseSince
+    : null;
+  if (sessCmp) for (const p of list) p.sessions.sort(sessCmp);
+  const groups = wtGroup === "toplevel" ? splitByWorktree(list) : list;
   if (sortMode === "active") {
-    for (const p of list) p.sessions.sort((a, b) => b.lastActivity - a.lastActivity);
-    list.sort((a, b) => projActivity(b) - projActivity(a));
+    groups.sort((a, b) => projActivity(b) - projActivity(a));
   } else if (sortMode === "attention") {
-    for (const p of list) p.sessions.sort((a, b) => urgencyRank(a) - urgencyRank(b) || a.phaseSince - b.phaseSince);
-    list.sort((a, b) => projUrgency(a) - projUrgency(b) || projWaitSince(a) - projWaitSince(b));
+    groups.sort((a, b) => projUrgency(a) - projUrgency(b) || projWaitSince(a) - projWaitSince(b));
   } else {
     // manual: the user's drag-drop order; unlisted projects keep their natural
     // order after listed ones (stable sort preserves ties).
     const rank = (path: string) => { const i = projOrder.indexOf(path); return i === -1 ? Number.MAX_SAFE_INTEGER : i; };
-    list.sort((a, b) => rank(a.path) - rank(b.path));
+    groups.sort((a, b) => rank(a.path) - rank(b.path));
   }
-  return list;
+  return groups;
 }
 // How much a session wants the user's attention (lower = more urgent). Shared by
 // the sidebar's "attention" sort and the header reactor.
@@ -705,7 +786,9 @@ function nextAfterClose(s: Sess): Sess | null {
   return flat[fi + 1] || flat[fi - 1] || null;
 }
 
-function sessionRow(s: Sess): string {
+// `chip` (chip mode only) tags the row with its worktree's colour-coded branch,
+// which expands from a bare ⑃ to the branch name on row hover.
+function sessionRow(s: Sess, chip?: WtCluster): string {
   const k = statusKey(s);
   // Prefer the abbreviated title; fall back to the branch/worktree only until
   // Claude sets a title, so idle rows stay identifiable. (Branch is kept in the
@@ -714,17 +797,50 @@ function sessionRow(s: Sess): string {
   // shells have no telemetry phase — show a terminal prompt glyph (a dot once exited)
   const glyph = s.shell ? (s.phase === "ended" ? GLYPH.ended : "❯") : GLYPH[k];
   const gcls = s.shell ? (s.phase === "ended" ? GCLASS.ended : "g-idle") : GCLASS[k];
-  return `<div class="srow ${s.id === activeId ? "active" : ""}" data-sel="${s.id}">
+  const chipHtml = chip
+    ? `<span class="chip" style="--wtc:${branchHue(chip)}"><span class="fork">⑃</span><span class="lbl">${esc(chip.branch)}</span></span>`
+    : "";
+  return `<div class="srow${chip ? " o3" : ""} ${s.id === activeId ? "active" : ""}" data-sel="${s.id}">
     <span class="sglyph ${gcls}">${glyph}</span>
-    <span class="sbranch" title="${esc(label)}">${esc(label)}</span>
+    <span class="sbranch" title="${esc(label)}">${esc(label)}</span>${chipHtml}
     <span class="sctx">${s.ctxPct != null ? Math.round(s.ctxPct) + "%" : ""}</span>
     <span class="sclose" data-close="${s.id}" title="Close session">✕</span></div>`;
 }
-function extRow(e: ExtSession): string {
+// The full body of a project group (owned sessions + external rows), shaped by the
+// worktree-grouping mode. subheader → ⑃ cluster headers with nested rows; chip →
+// flat rows each tagged with a colour-coded branch chip; off/toplevel → plain flat
+// rows. A single-checkout project (one cluster) always renders flat — nothing to
+// disambiguate. Externals cluster right alongside owned sessions (same checkout dir).
+function groupBody(p: ProjGroup): string {
+  const flat = () => p.sessions.map((s) => sessionRow(s)).join("") + p.externals.map((e) => extRow(e)).join("");
+  if (wtGroup === "subheader") {
+    const cl = clusterByWorktree(p);
+    if (cl.length >= 2) return cl.map((c) => {
+      const col = branchHue(c), n = c.sessions.length + c.externals.length;
+      const body = c.sessions.map((s) => sessionRow(s)).join("") + c.externals.map((e) => extRow(e)).join("");
+      return `<div class="wthead"><span class="wtglyph" style="color:${col}">⑃</span>`
+        + `<span class="wtname" style="color:${col}" title="${esc(c.branch)}">${esc(c.branch)}</span>`
+        + `<span class="wtcount">${n}</span></div>`
+        + `<div class="wtsessions" style="--wtc:${col}">${body}</div>`;
+    }).join("");
+  } else if (wtGroup === "chip") {
+    const cl = clusterByWorktree(p);
+    if (cl.length >= 2) {
+      const byKey = new Map(cl.map((c) => [c.key, c]));
+      return p.sessions.map((s) => sessionRow(s, byKey.get(s.workdir || p.path))).join("")
+        + p.externals.map((e) => extRow(e, byKey.get(e.cwd || p.path))).join("");
+    }
+  }
+  return flat();
+}
+function extRow(e: ExtSession, chip?: WtCluster): string {
   const working = extWorking(e);
-  return `<div class="srow extrow ${e.session_id === activeExtId ? "active" : ""}" data-ext="${e.session_id}" data-key="${esc(e.cwd)}">
+  const chipHtml = chip
+    ? `<span class="chip" style="--wtc:${branchHue(chip)}"><span class="fork">⑃</span><span class="lbl">${esc(chip.branch)}</span></span>`
+    : "";
+  return `<div class="srow extrow${chip ? " o3e" : ""} ${e.session_id === activeExtId ? "active" : ""}" data-ext="${e.session_id}" data-key="${esc(e.cwd)}">
     <span class="sglyph ${working ? "g-work" : "g-idle"}">${working ? "●" : "○"}</span>
-    <span class="sbranch">${esc(e.name || basename(e.cwd))}</span>
+    <span class="sbranch">${esc(e.name || basename(e.cwd))}</span>${chipHtml}
     <span class="ext-tag" title="Running outside Muster · Claude v${esc(e.version)} · pid ${e.pid}">ext</span>
     <span class="sjump" data-jump="${e.pid}" title="Jump to its terminal ↗">↗</span></div>`;
 }
@@ -732,12 +848,13 @@ function renderSidebar() {
   // Don't stomp the DOM the browser is mid-drag on — see draggingProjects.
   if (draggingProjects) return;
   $("projects").innerHTML = projectList().map((p) => {
-    const rows = p.sessions.map(sessionRow).join("") + p.externals.map(extRow).join("");
+    const rows = groupBody(p);
     const total = p.sessions.length + p.externals.length;
     const isFav = FAVORITES.some((f) => f.path === p.path);
+    const wtSuffix = p.wtBranch ? `<span class="pwt">· ${esc(p.wtBranch)}</span>` : "";
     let head: string;
     if (p.sessions.length) {
-      head = `<div class="phead" data-sel="${p.sessions[0].id}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span><span class="pcount">${total}</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}">＋</span></div>`;
+      head = `<div class="phead" data-sel="${p.sessions[0].id}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}${wtSuffix}</span><span class="pcount">${total}</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}">＋</span></div>`;
     } else if (isFav) {
       const tail = p.externals.length ? `<span class="pcount ext">${p.externals.length} ext</span>` : `<span class="plaunch">launch →</span>`;
       head = `<div class="phead empty-p" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${tail}<span class="premove" data-remove="${esc(p.path)}" title="Remove project">✕</span></div>`;

--- a/src/styles.css
+++ b/src/styles.css
@@ -145,6 +145,26 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .g-work{color:var(--st-working);} .g-attn{color:var(--st-attention);} .g-done{color:var(--st-done);} .g-idle{color:var(--st-idle);} .g-error{color:var(--st-error);} .g-ended{color:var(--muted-2);}
 @media (prefers-reduced-motion: no-preference) { .g-work,.g-attn{ animation: pulse 1.5s ease-in-out infinite; } @keyframes pulse{0%,100%{opacity:1;}50%{opacity:.4;}} }
 
+/* ---- worktree grouping ---- */
+/* subheader mode: a ⑃-branch cluster header, its sessions nested under a tinted rule */
+/* padding-left 0 + a 13px glyph box centres the ⑃ (box centre 6.5px) on the
+   .wtsessions border-left below it (margin-left 6px + 0.5px half-border) */
+.wthead { display: flex; align-items: center; gap: 7px; padding: 4px 8px 2px 0; margin-top: 1px; }
+.wtglyph { flex: none; width: 13px; text-align: center; font-size: 11px; line-height: 1; }
+.wtname { min-width: 0; font-size: 11px; font-weight: 600; letter-spacing: -.01em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.wtcount { flex: none; margin-left: auto; font: 600 9px var(--font-mono); color: var(--muted-2); }
+.wtsessions { padding-left: 8px; margin-left: 6px; border-left: 1px solid color-mix(in srgb, var(--wtc, var(--hair)) 45%, transparent); display: flex; flex-direction: column; gap: 1px; }
+/* toplevel mode: the branch suffix on a per-worktree group header */
+.pwt { margin-left: 5px; color: var(--muted-2); font-weight: 550; }
+/* chip mode: a colour-coded ⑃ that expands to the branch name on row hover */
+.srow.o3 { grid-template-columns: 14px minmax(0,1fr) auto auto; }
+.srow.extrow.o3e { grid-template-columns: 14px minmax(0,1fr) auto auto auto; }
+.chip { display: inline-flex; align-items: center; overflow: hidden; font: 600 10px var(--font-mono); color: var(--wtc, var(--muted-2)); }
+.chip .fork { flex: none; }
+.chip .lbl { max-width: 0; opacity: 0; white-space: nowrap; transform: translateX(-3px); transition: max-width .22s ease, opacity .18s ease, transform .22s ease, margin-left .22s ease; }
+.srow.o3:hover .chip .lbl, .srow.o3e:hover .chip .lbl { max-width: 130px; opacity: 1; transform: none; margin-left: 4px; }
+@media (prefers-reduced-motion: reduce) { .chip .lbl { transition: none; } }
+
 /* minified icon-rail */
 .railmini { display: none; flex-direction: column; align-items: center; gap: 8px; padding: 10px 0; overflow-y: auto; }
 .app.rail-mini .rail-scroll { display: none; }


### PR DESCRIPTION
## What

Sessions of a repo already collapse into one project group, but worktrees were shown as a flat list — and for **external** sessions each worktree became its *own* top-level project (e.g. `muster`, `muster-cb`, `weekly-useage-…` all showed up separately instead of under `muster`).

This adds a worktree-grouping engine with four modes behind a single config value `cc-worktree-group` (default `subheader`):

| Mode | Behaviour |
|------|-----------|
| `subheader` **(default)** | a `⑃`-branch header per worktree cluster, sessions nested under a tinted rule |
| `toplevel` | each worktree becomes its own top-level group (`repo · branch`) |
| `chip` | flat rows, each worktree row tagged with a colour-coded `⑃` chip that expands to the branch on hover |
| `off` | legacy flat rows |

The distinguishing key per worktree is the checkout dir. A single-checkout project always renders flat — no nesting noise.

## External sessions

The key fix for real usage: external sessions (started outside Muster) previously grouped by raw `cwd`, so every worktree looked like a different repo. They now carry a backend-resolved `repo_root` + `branch` — one `git rev-parse --path-format=absolute --git-common-dir --abbrev-ref HEAD` per session (via the hardened `git_cmd`, run only *after* the liveness/ownership filters). The `--git-common-dir` is identical for a repo's main checkout and every linked worktree, so its parent is the shared repo root.

Frontend then:
- groups externals by `repo_root` (worktrees merge under the repo, and into that repo's favourite when paths match),
- clusters **owned and external** sessions together per checkout dir,
- probes the logo for ext-only projects too (they used to be stuck on the accent dot).

## Not included

No in-app control yet — flip the mode via `localStorage["cc-worktree-group"]` / `setWtGroup()` (a `musterWtGroup(mode)` console hook is exposed). A tabbed settings window that owns the picker is intended as a separate branch.

## Testing

- `tsc --noEmit`, `cargo check`, `cargo clippy` (only 2 pre-existing warnings), `vite build` — all green.
- Manually verified in the running dev app across a real external-session fleet spanning multiple `muster` worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)