### PR TITLE
Footer: surface Claude usage limits (dividers + clickable detail popover)

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,9 +66,17 @@
         <span class="fver" id="fVer" title="Installed Muster version · click to check for updates"></span>
         <button class="fupdate" id="fUpdate" title="Download the new version and restart Muster" hidden></button>
         <span class="fseg"><span id="fSessions">0</span> sessions</span>
+        <span class="fdiv"></span>
         <span class="fseg">today <b id="fCost">$0.00</b></span>
-        <span class="fseg">5h <b id="fRl">–</b><span class="fsub" id="fRlReset"></span></span>
-        <span class="fseg">7d <b id="fRl7">–</b></span>
+        <span class="fdiv"></span>
+        <span class="fseg fclick" id="fUsageSeg" title="Claude usage limits — click for detail">
+          <span class="flabel">limits</span>
+          <b id="fRl">–</b><span class="fsub">5h</span>
+          <span class="fmid">·</span>
+          <b id="fRl7">–</b><span class="fsub">7d</span>
+          <span class="fcaret">▴</span>
+        </span>
+        <span class="fdiv"></span>
         <span class="fseg fclick" id="fEngineSeg" title="Choose where new sessions open">new in <b id="fEngine">embedded</b> <span class="fcaret">▴</span></span>
         <span class="spacer"></span>
         <span class="fseg fk">⌘K · ⌘1–9 switch · ⌘B sidebar · ⌘I inspector · ⌘± font</span>
@@ -112,5 +120,6 @@
     <div class="colorpop" id="colorPop"></div>
     <div class="menupop" id="enginePop"></div>
     <div class="menupop attnpop" id="attnPop"></div>
+    <div class="menupop usagepop" id="usagePop"></div>
   </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -842,6 +842,15 @@ function fmtDur(ms: number) {
 }
 // Absolute wall-clock time of a reset (epoch seconds) — "15:45" / "3:45 PM".
 function fmtClock(ts: number): string { return new Date(ts * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }); }
+// Time remaining until a reset (epoch seconds) — "2h 10m" / "3d 4h". The weekly
+// window can be days out, where fmtClock's time-of-day alone would be misleading.
+function fmtUntil(ts: number): string {
+  const s = Math.max(0, Math.floor(ts - Date.now() / 1000));
+  const d = Math.floor(s / 86400), h = Math.floor((s % 86400) / 3600), m = Math.floor((s % 3600) / 60);
+  if (d > 0) return `${d}d ${h}h`;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
 const mc = (v: number) => (v >= 80 ? "hot" : v >= 55 ? "warn" : "");
 function renderShellInspector(s: Sess) {
   const ended = s.phase === "ended";
@@ -1084,10 +1093,41 @@ function renderFoot() {
   $("fRl").textContent = r != null ? Math.round(r) + "%" : "–";
   const r7 = rlPct(rl.d7, rl.d7Reset);
   $("fRl7").textContent = r7 != null ? Math.round(r7) + "%" : "–";
-  const reset = rlReset(rl.h5Reset);
-  $("fRlReset").textContent = reset != null ? ` · resets ${fmtClock(reset)}` : "";
   $("fEngine").textContent = engineDef(termEngine).label;
+  if ($("usagePop").classList.contains("show")) renderUsagePop();
 }
+// One usage window (session/5h or weekly/7d): label, % meter, and reset time.
+function usageRow(label: string, sub: string, pct: number | null, reset: number | null): string {
+  const cls = pct == null ? "" : mc(pct);
+  const w = pct == null ? 0 : Math.min(100, Math.round(pct));
+  const pctTxt = pct == null ? "–" : Math.round(pct) + "%";
+  const resetTxt = reset != null
+    ? `resets ${fmtClock(reset)} · in ${fmtUntil(reset)}`
+    : (pct == null ? "no reading yet" : "no active window");
+  return `<div class="up-row">
+    <div class="up-top"><span class="up-l">${label}</span><span class="up-sub">${sub}</span><span class="up-pct ${cls}">${pctTxt}</span></div>
+    <div class="up-bar ${cls}"><i style="width:${w}%"></i></div>
+    <div class="up-reset">${resetTxt}</div>
+  </div>`;
+}
+function renderUsagePop() {
+  const noData = rl.h5 == null && rl.d7 == null;
+  $("usagePop").innerHTML = `<div class="up-h">Claude usage limits</div>
+    ${usageRow("Session", "5-hour window", rlPct(rl.h5, rl.h5Reset), rlReset(rl.h5Reset))}
+    ${usageRow("Weekly", "7-day window", rlPct(rl.d7, rl.d7Reset), rlReset(rl.d7Reset))}
+    <div class="up-foot"><span>today <b>$${(usage[todayKey()] || 0).toFixed(2)}</b></span><span>${sessions.size} live · account-wide</span></div>
+    ${noData ? `<div class="up-note">Appears once a running session reports a statusLine.</div>` : ""}`;
+}
+function openUsagePop() {
+  const r = $("fUsageSeg").getBoundingClientRect();
+  const pop = $("usagePop");
+  renderUsagePop();
+  pop.style.left = Math.max(8, Math.min(r.left, window.innerWidth - 260)) + "px";
+  pop.style.bottom = (window.innerHeight - r.top + 6) + "px";
+  pop.style.top = "auto";
+  pop.classList.add("show");
+}
+function closeUsagePop() { $("usagePop").classList.remove("show"); }
 // The fleet's "needs you" set — sessions with a blocking permission, an error, or
 // finished and awaiting your reply — most urgent first (waiting wins), longest in
 // that state first. Independent of the sidebar sort so the reactor is stable.
@@ -1530,6 +1570,7 @@ document.addEventListener("click", (e) => {
   const t = e.target as HTMLElement;
   if (!t.closest("#colorPop, .pdot, .rm-dot")) closeColorPop();
   if (!t.closest("#enginePop, #fEngineSeg")) closeEnginePop();
+  if (!t.closest("#usagePop, #fUsageSeg")) closeUsagePop();
   if (!t.closest("#attnPop, #attnBadge")) closeAttnPop();
   const dot = t.closest<HTMLElement>(".pdot, .rm-dot");
   if (dot) { const owner = dot.closest<HTMLElement>("[data-key]"); if (owner?.dataset.key) { openColorPopover(owner.dataset.key, e.clientX, e.clientY); return; } }
@@ -1773,6 +1814,7 @@ $("btnWorktree").addEventListener("click", () => { const c = activeProjectCtx();
 $("btnTerm").addEventListener("click", openPlainTerminal);
 $("fRepo").addEventListener("click", (e) => { e.preventDefault(); openUrl("https://github.com/respeak-io/muster").catch(() => {}); });
 $("fEngineSeg").addEventListener("click", (e) => { e.stopPropagation(); $("enginePop").classList.contains("show") ? closeEnginePop() : openEnginePopover(); });
+$("fUsageSeg").addEventListener("click", (e) => { e.stopPropagation(); $("usagePop").classList.contains("show") ? closeUsagePop() : openUsagePop(); });
 $("btnClose").addEventListener("click", () => { if (activeId) closeSession(activeId); });
 $("wtGo").addEventListener("click", wtCreate);
 $("wtCancel").addEventListener("click", closeWt);

--- a/src/styles.css
+++ b/src/styles.css
@@ -328,12 +328,16 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .foot .fseg { display: flex; align-items: center; gap: 6px; }
 .foot .fseg b { color: var(--text); font-weight: 700; }
 .foot .fdot { width: 5px; height: 5px; border-radius: 50%; background: var(--muted-2); }
+.foot .fdiv { width: 1px; height: 12px; background: var(--hair-strong); flex: none; }
+.foot .flabel { color: var(--muted); }
+.foot .fmid { color: var(--muted-2); margin: 0 -2px; }
+.foot .fseg .fsub { margin-left: -3px; }
 .foot .spacer { margin-left: auto; }
 .foot .fk { color: var(--muted-2); }
 .foot .fsub { color: var(--muted-2); }
 .foot .fver { color: var(--muted-2); letter-spacing: .02em; cursor: pointer; padding: 0 4px; margin: 0 -4px; border-radius: 5px; }
 .foot .fver:hover { color: var(--accent-ink); background: var(--surface); }
-.foot .fupdate { display: flex; align-items: center; font: inherit; letter-spacing: .02em; cursor: pointer; padding: 2px 8px; border-radius: 999px; color: #16121f; background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 88%, white 12%), var(--accent)); border: 1px solid transparent; box-shadow: 0 4px 12px -8px var(--accent-glow); }
+.foot .fupdate { display: flex; align-items: center; font: 700 9px var(--font-mono); letter-spacing: .01em; cursor: pointer; padding: 1px 7px; border-radius: 999px; color: #16121f; background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 88%, white 12%), var(--accent)); border: 1px solid transparent; box-shadow: 0 2px 7px -7px var(--accent-glow); }
 .foot .fupdate:hover { filter: brightness(1.06); }
 @media (prefers-reduced-motion: no-preference) { .foot .fupdate { animation: pulse 1.6s ease-in-out infinite; } }
 .foot .fclick { cursor: pointer; padding: 0 4px; margin: 0 -4px; border-radius: 5px; }
@@ -422,6 +426,26 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .attnpop .ap-proj { font: 700 11.5px var(--font-ui); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .attnpop .ap-ttl { font-size: 10px; color: var(--muted-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .attnpop .ap-reason { flex: none; max-width: 40%; font-size: 9px; font-weight: 600; color: var(--st-attention); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* account usage-limits popover (5-hour session + 7-day weekly windows) */
+.usagepop { min-width: 244px; gap: 4px; padding: 10px; }
+.usagepop .up-h { font: 700 10px var(--font-mono); letter-spacing: .06em; text-transform: uppercase; color: var(--muted-2); padding: 0 2px 3px; }
+.usagepop .up-row { display: flex; flex-direction: column; gap: 4px; padding: 6px 2px; }
+.usagepop .up-row + .up-row { border-top: 1px solid var(--hair); }
+.usagepop .up-top { display: flex; align-items: baseline; gap: 6px; }
+.usagepop .up-l { font: 650 12px var(--font-ui); color: var(--text); }
+.usagepop .up-sub { font-size: 10px; color: var(--muted-2); }
+.usagepop .up-pct { margin-left: auto; font: 700 12px var(--font-mono); color: var(--text); }
+.usagepop .up-pct.warn { color: var(--st-working); }
+.usagepop .up-pct.hot { color: var(--st-error); }
+.usagepop .up-bar { height: 5px; border-radius: 3px; background: var(--surface-2); overflow: hidden; }
+.usagepop .up-bar i { display: block; height: 100%; border-radius: 3px; background: var(--accent); transition: width .3s ease; }
+.usagepop .up-bar.warn i { background: var(--st-working); }
+.usagepop .up-bar.hot i { background: var(--st-error); }
+.usagepop .up-reset { font: 500 10px var(--font-mono); color: var(--muted-2); }
+.usagepop .up-foot { display: flex; justify-content: space-between; font: 600 10px var(--font-mono); color: var(--muted); padding: 5px 2px 1px; border-top: 1px solid var(--hair); }
+.usagepop .up-foot b { color: var(--text); }
+.usagepop .up-note { font-size: 10px; color: var(--muted-2); padding: 2px; line-height: 1.4; }
 
 /* ---------- external (non-Muster) sessions ---------- */
 /* sidebar row for a session running in another terminal */


### PR DESCRIPTION
## What

The 5h / 7d rate-limit readouts were already wired up (fed by the statusLine `rate_limits` payload) but easy to miss in the footer — separated only by `gap` and looking like arbitrary numbers next to *sessions* and *today*.

## Changes

- **Dividers** — vertical hairlines between footer segments (`sessions │ today │ limits │ new in`) so the units read as distinct.
- **Clickable `limits` segment** — folds the two loose `5h`/`7d` readouts into one segment (label + caret, mirroring the engine picker) that opens a **usage popover**:
  - labelled meter bars for the 5-hour *Session* window and 7-day *Weekly* window
  - each with %, warn/hot colour coding (reuses `mc()`), and reset time shown **absolute + relative** (`resets 15:45 · in 2h 10m`)
  - new `fmtUntil()` helper — `fmtClock` alone is misleading when the weekly reset is days out
  - popover re-renders live off the existing 30s footer heartbeat
- **Smaller update chip** — 10px→9px, tighter padding, softer glow, so it no longer dominates the footer.

Data path is unchanged; `rate_limits` still come from the statusLine payload and remain account-wide. (We looked into reading usage out-of-band / with 0 live sessions — there's no personal-account endpoint, CLI command, or on-disk cache for it, so that's out of scope here.)

## Verification

`tsc --noEmit` clean. UI-only change; not visually exercised headlessly since `rate_limits` only populate from a live interactive session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)