### PR TITLE
External sessions: OS-agnostic listing via sysinfo (enables Windows)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,11 +68,11 @@ One ~2650-line `main.ts`, no framework. State lives in a `sessions: Map<session_
 
 ## External (non-Muster) sessions
 
-Muster surfaces Claude sessions started *outside* it, discovered from `~/.claude/sessions/<pid>.json` (one per running interactive session; format details in the `claude-code-local-session-registry` memory). `list_external_sessions` liveness-checks survivors via `ps`.
+Muster surfaces Claude sessions started *outside* it, discovered from `~/.claude/sessions/<pid>.json` (one per running interactive session — same path and format on Windows under `%USERPROFILE%`, VS Code-hosted sessions included, verified on CC 2.1.216; format details in the `claude-code-local-session-registry` memory). The **listing is OS-agnostic**: `list_external_sessions` liveness-checks survivors against `ProcTable`, one in-process `sysinfo` snapshot of the process table (no `ps`/`tasklist` spawns — the frontend polls every 3s), so discovery works on macOS, Windows and (untested) Linux alike.
 
-- **Filter owned sessions by pid, never by session id.** Muster's own sessions register there too (confirmed CC 2.1.211), and `/resume`/`/clear` rewrite `<pid>.json` with a *new* id — so an id-based exclude lets a live, Muster-owned session reappear as "external" showing the resumed transcript. `AppState.owned_pids` holds every claude pid Muster spawned; `is_descendant_of` also catches child-terminal launches.
+- **Filter owned sessions by pid, never by session id.** Muster's own sessions register there too (confirmed CC 2.1.211), and `/resume`/`/clear` rewrite `<pid>.json` with a *new* id — so an id-based exclude lets a live, Muster-owned session reappear as "external" showing the resumed transcript. `AppState.owned_pids` holds every claude pid Muster spawned; the ancestry walk (`ProcTable::is_descendant_of`) also catches child-terminal launches.
 - **That ancestry walk is deliberately broad, and it bites during development.** Anything started from a terminal *inside* Muster — notably `pnpm tauri dev` — becomes its descendant, so a second Muster instance's sessions are silently filtered out of the first's external list. **Run dev builds from a real terminal, not a Muster pane.** (Dev and installed also share one localStorage and one `muster-debug.json`, so prefer quitting the installed app entirely.)
-- `read_transcript` mirrors a session read-only (decoding the cwd→`<enc>` path scheme). `focus_external_session` jumps to its terminal: exact tab focus by tty via AppleScript for Terminal.app/iTerm2, else `open` on the owning top-level `.app`. That `.app` fallback is **required** for Electron hosts like VS Code — their integrated terminal runs under a *helper* process System Events can't target by unix id (fails `-1719`); the tradeoff is we can only front VS Code, not the specific panel.
+- `read_transcript` mirrors a session read-only (decoding the cwd→`<enc>` path scheme). `focus_external_session` — still **macOS-only** — jumps to its terminal: exact tab focus by tty via AppleScript for Terminal.app/iTerm2, else `open` on the owning top-level `.app`. That `.app` fallback is **required** for Electron hosts like VS Code — their integrated terminal runs under a *helper* process System Events can't target by unix id (fails `-1719`); the tradeoff is we can only front VS Code, not the specific panel.
 - **Known gap:** sessions launched into an external Terminal.app/iTerm (via `open -a`) aren't in Muster's process tree, so they still rely on the session-id `exclude` and can leak after a `/resume`.
 
 ## Restorable sessions (surviving a restart)
@@ -89,6 +89,6 @@ Muster's launch uuid **is** Claude's `--session-id`, so every session it launche
 
 ## Notes on scope & doc drift
 
-macOS-only assumptions are pervasive and intentional for now: `osascript`, `open -a`, `/bin/zsh` wrappers, hard-coded app paths, `/usr/bin/curl`. Windows would need a PowerShell/`curl.exe` variant of the generated hooks.
+macOS-first assumptions remain in the window/terminal layer: `osascript`, `open -a`, external-terminal engines, per-session CPU/RAM via `ps`, terminal-window focus. Windows has a working embedded-only port (PowerShell/`curl.exe` hook variants behind `#[cfg(windows)]`, cross-platform external-session listing); Linux is unported but the non-`ps` paths are written to be OS-agnostic.
 
 `SPIKE.md` and `README.md` describe an earlier state (single-session, "observe-only" permissions). The code has moved past both — it is multi-session and the permission hook is answerable. **Trust the code over the docs** when they disagree.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2162,6 +2162,7 @@ dependencies = [
  "portable-pty",
  "serde",
  "serde_json",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -2211,6 +2212,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2375,6 +2385,16 @@ dependencies = [
  "block2",
  "libc",
  "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -3631,6 +3651,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3677,7 +3711,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -3760,7 +3794,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3901,7 +3935,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -3970,7 +4004,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3995,7 +4029,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4780,7 +4814,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -4804,7 +4838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -4860,11 +4894,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -4874,6 +4920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4910,7 +4965,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -4955,6 +5021,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5093,6 +5169,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5335,7 +5420,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,4 +28,8 @@ base64 = "0.22.1"
 tauri-plugin-dialog = "2.7.1"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+# Process-table introspection (external-session liveness + ancestry) without
+# spawning `ps`/`tasklist` — one in-process snapshot, same code on every OS.
+# 0.38 (not latest) because newer sysinfo raises MSRV past our rustc.
+sysinfo = { version = "0.38", default-features = false, features = ["system"] }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1707,6 +1707,13 @@ fn find_project_icon(dir: String) -> Option<ProjectIcon> {
 // own live session as "external". What remains is the sessions started outside
 // Muster (a plain terminal, an IDE, etc.) — we jump to their terminal window and
 // show a read-only mirror of their transcript.
+//
+// The registry format and directory are identical on Windows (verified on CC
+// 2.1.216: `%USERPROFILE%\.claude\sessions\<pid>.json`, VS Code-hosted sessions
+// included), so LISTING is fully cross-platform: liveness/ownership checks go
+// through `ProcTable`, an in-process `sysinfo` snapshot that works the same on
+// macOS, Windows and Linux. Only `focus_external_session` (jumping to the
+// owning terminal window) remains platform-specific — macOS-only today.
 
 #[derive(serde::Serialize)]
 struct ExternalSession {
@@ -1726,8 +1733,10 @@ struct ExternalSession {
 }
 
 /// One `ps -o <fields>=` line for a single pid (trimmed), or None if the process
-/// is gone / no output. Windows has no `ps`; process introspection (per-session
-/// resources, external-session ownership) is macOS-only for now, so this is None.
+/// is gone / no output. Windows has no `ps`; the remaining `ps` consumers
+/// (per-session CPU/RAM, terminal-window focus) are macOS-only for now, so this
+/// is None there. External-session listing does NOT go through here — it uses
+/// the cross-platform `ProcTable` below.
 #[cfg(windows)]
 fn ps_one(_pid: u32, _fields: &str) -> Option<String> {
     None
@@ -1743,43 +1752,104 @@ fn ps_one(pid: u32, fields: &str) -> Option<String> {
     if s.is_empty() { None } else { Some(s) }
 }
 
-/// True if `pid` is `ancestor`, or a descendant of it (walks the ppid chain).
-/// Used to recognise `claude` processes Muster launched — directly (embedded
-/// PTY) or via a child terminal (e.g. Ghostty) — regardless of their session id.
-#[cfg(not(windows))]
-fn is_descendant_of(pid: u32, ancestor: u32) -> bool {
-    let mut cur = pid;
-    for _ in 0..24 {
-        if cur == ancestor {
-            return true;
-        }
-        match ps_one(cur, "ppid=").and_then(|s| s.trim().parse::<u32>().ok()) {
-            Some(ppid) if ppid > 1 => cur = ppid,
-            _ => return false,
-        }
-    }
-    false
+/// A point-in-time snapshot of the system process table (pid → parent + name),
+/// taken in-process via `sysinfo` so the exact same code serves macOS, Windows
+/// and Linux — no `ps`/`tasklist` child processes. The frontend polls external
+/// sessions every ~3s; refreshing only the bare process list (no CPU/memory/
+/// exe/cmd lookups) keeps a snapshot to a few milliseconds.
+struct ProcTable {
+    /// pid → (ppid, lowercased process name)
+    procs: std::collections::HashMap<u32, (Option<u32>, String)>,
 }
 
-/// Surfacing sessions started outside Muster relies on `ps` liveness/ownership
-/// checks that don't exist on Windows yet, so this is empty there.
-#[cfg(windows)]
-#[tauri::command]
-fn list_external_sessions(_state: State<AppState>, _exclude: Vec<String>) -> Vec<ExternalSession> {
-    Vec::new()
+impl ProcTable {
+    fn snapshot() -> Self {
+        use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System};
+        let mut sys = System::new();
+        sys.refresh_processes_specifics(
+            ProcessesToUpdate::All,
+            true,
+            ProcessRefreshKind::nothing(),
+        );
+        let procs = sys
+            .processes()
+            .iter()
+            .map(|(pid, p)| {
+                (
+                    pid.as_u32(),
+                    (p.parent().map(|pp| pp.as_u32()), p.name().to_string_lossy().to_lowercase()),
+                )
+            })
+            .collect();
+        Self { procs }
+    }
+
+    /// True if `pid` is currently a live process whose name contains "claude" —
+    /// the identity check that guards against stale registry files and pid
+    /// reuse. Matched loosely because the name varies: `claude` on macOS/Linux,
+    /// `claude.exe` on Windows, and self-update renames like
+    /// `claude.exe.old.<ts>` for a binary updated while running.
+    fn is_live_claude(&self, pid: u32) -> bool {
+        self.procs.get(&pid).is_some_and(|(_, name)| name.contains("claude"))
+    }
+
+    /// True if `pid` is `ancestor`, or a descendant of it (walks the ppid chain).
+    /// Used to recognise `claude` processes Muster launched — directly (embedded
+    /// PTY) or via a child terminal (e.g. Ghostty) — regardless of their session
+    /// id. The iteration cap also bounds ppid cycles, which Windows can produce
+    /// after pid reuse (a dead parent's pid handed to a new process).
+    fn is_descendant_of(&self, pid: u32, ancestor: u32) -> bool {
+        let mut cur = pid;
+        for _ in 0..24 {
+            if cur == ancestor {
+                return true;
+            }
+            match self.procs.get(&cur).and_then(|(ppid, _)| *ppid) {
+                Some(ppid) if ppid > 1 && ppid != cur => cur = ppid,
+                _ => return false,
+            }
+        }
+        false
+    }
+}
+
+/// Parse one `~/.claude/sessions/<pid>.json` registry file into an
+/// `ExternalSession` (repo_root/branch enriched later). None for malformed
+/// files and non-interactive entries (`claude -p`, SDK runs).
+fn parse_registry_entry(txt: &str) -> Option<ExternalSession> {
+    let v: serde_json::Value = serde_json::from_str(txt).ok()?;
+    if v.get("kind").and_then(|k| k.as_str()) != Some("interactive") {
+        return None;
+    }
+    let pid = v.get("pid").and_then(|x| x.as_u64())? as u32;
+    let session_id = v.get("sessionId").and_then(|x| x.as_str()).unwrap_or("").to_string();
+    if session_id.is_empty() {
+        return None;
+    }
+    Some(ExternalSession {
+        pid,
+        session_id,
+        cwd: v.get("cwd").and_then(|x| x.as_str()).unwrap_or("").to_string(),
+        name: v.get("name").and_then(|x| x.as_str()).unwrap_or("").to_string(),
+        status: v.get("status").and_then(|x| x.as_str()).unwrap_or("idle").to_string(),
+        status_updated_at: v.get("statusUpdatedAt").and_then(|x| x.as_i64()),
+        started_at: v.get("startedAt").and_then(|x| x.as_i64()),
+        version: v.get("version").and_then(|x| x.as_str()).unwrap_or("").to_string(),
+        repo_root: None,
+        branch: None,
+    })
 }
 
 /// List interactive Claude Code sessions running OUTSIDE Muster. `exclude` is the
 /// set of session ids Muster already owns (belt-and-suspenders — ours don't
 /// register anyway). Dead/stale registry files are filtered by verifying the pid
 /// is still a live `claude` process.
-#[cfg(not(windows))]
 #[tauri::command]
 fn list_external_sessions(state: State<AppState>, exclude: Vec<String>) -> Vec<ExternalSession> {
-    let home = match std::env::var("HOME") {
-        Ok(h) => h,
-        Err(_) => return vec![],
-    };
+    let home = home_dir();
+    if home.is_empty() {
+        return vec![];
+    }
     let dir = std::path::Path::new(&home).join(".claude").join("sessions");
     let entries = match std::fs::read_dir(&dir) {
         Ok(e) => e,
@@ -1788,70 +1858,22 @@ fn list_external_sessions(state: State<AppState>, exclude: Vec<String>) -> Vec<E
     let exclude: std::collections::HashSet<String> =
         exclude.into_iter().map(|s| s.to_lowercase()).collect();
 
-    let mut parsed: Vec<ExternalSession> = Vec::new();
-    for ent in entries.flatten() {
-        let p = ent.path();
-        if p.extension().and_then(|e| e.to_str()) != Some("json") {
-            continue;
-        }
-        let txt = match std::fs::read_to_string(&p) {
-            Ok(t) => t,
-            Err(_) => continue,
-        };
-        let v: serde_json::Value = match serde_json::from_str(&txt) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        if v.get("kind").and_then(|k| k.as_str()) != Some("interactive") {
-            continue;
-        }
-        let pid = match v.get("pid").and_then(|x| x.as_u64()) {
-            Some(n) => n as u32,
-            None => continue,
-        };
-        let session_id = v.get("sessionId").and_then(|x| x.as_str()).unwrap_or("").to_string();
-        if session_id.is_empty() || exclude.contains(&session_id.to_lowercase()) {
-            continue;
-        }
-        parsed.push(ExternalSession {
-            pid,
-            session_id,
-            cwd: v.get("cwd").and_then(|x| x.as_str()).unwrap_or("").to_string(),
-            name: v.get("name").and_then(|x| x.as_str()).unwrap_or("").to_string(),
-            status: v.get("status").and_then(|x| x.as_str()).unwrap_or("idle").to_string(),
-            status_updated_at: v.get("statusUpdatedAt").and_then(|x| x.as_i64()),
-            started_at: v.get("startedAt").and_then(|x| x.as_i64()),
-            version: v.get("version").and_then(|x| x.as_str()).unwrap_or("").to_string(),
-            repo_root: None,
-            branch: None,
-        });
-    }
+    let mut parsed: Vec<ExternalSession> = entries
+        .flatten()
+        .map(|ent| ent.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("json"))
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .filter_map(|txt| parse_registry_entry(&txt))
+        .filter(|s| !exclude.contains(&s.session_id.to_lowercase()))
+        .collect();
     if parsed.is_empty() {
         return parsed;
     }
 
-    // Liveness + identity: one `ps` for all pids; keep those still running `claude`
-    // (guards against stale files and pid reuse).
-    let pids_csv = parsed.iter().map(|s| s.pid.to_string()).collect::<Vec<_>>().join(",");
-    let live: std::collections::HashSet<u32> = std::process::Command::new("ps")
-        .args(["-p", &pids_csv, "-o", "pid=,comm="])
-        .output()
-        .ok()
-        .map(|o| {
-            String::from_utf8_lossy(&o.stdout)
-                .lines()
-                .filter_map(|l| {
-                    let l = l.trim();
-                    let mut it = l.splitn(2, char::is_whitespace);
-                    let pid = it.next()?.trim().parse::<u32>().ok()?;
-                    let comm = it.next().unwrap_or("");
-                    if comm.to_lowercase().contains("claude") { Some(pid) } else { None }
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-
-    parsed.retain(|s| live.contains(&s.pid));
+    // Liveness + identity: one process-table snapshot for all pids; keep those
+    // still running `claude` (guards against stale files and pid reuse).
+    let table = ProcTable::snapshot();
+    parsed.retain(|s| table.is_live_claude(s.pid));
 
     // Drop Muster's OWN sessions, matched by pid — NOT by session id. Their id on
     // disk changes when the user runs /resume or /clear (the pid file is rewritten
@@ -1861,7 +1883,7 @@ fn list_external_sessions(state: State<AppState>, exclude: Vec<String>) -> Vec<E
     // catches sessions launched into a child terminal (e.g. Ghostty).
     let self_pid = std::process::id();
     let owned = state.owned_pids.lock().unwrap().clone();
-    parsed.retain(|s| !owned.contains(&s.pid) && !is_descendant_of(s.pid, self_pid));
+    parsed.retain(|s| !owned.contains(&s.pid) && !table.is_descendant_of(s.pid, self_pid));
 
     // Enrich survivors with their repo root + branch so worktrees of one repo group
     // together (and merge into that repo's project) rather than each cwd becoming its
@@ -2140,22 +2162,18 @@ fn read_transcript(cwd: String, session_id: String, limit: usize) -> Result<Vec<
         match content {
             Some(serde_json::Value::String(s)) => text.push_str(s),
             Some(serde_json::Value::Array(arr)) => {
+                // Only "text" blocks: tool calls (Bash, Read, Edit, …), tool_result
+                // echoes and thinking blocks are noise in a read-only conversation
+                // mirror — keep the human/assistant prose. An assistant turn that is
+                // only tool calls collapses to empty and is dropped below.
                 for blk in arr {
-                    match blk.get("type").and_then(|x| x.as_str()) {
-                        Some("text") => {
-                            if let Some(s) = blk.get("text").and_then(|x| x.as_str()) {
-                                if !text.is_empty() {
-                                    text.push('\n');
-                                }
-                                text.push_str(s);
+                    if blk.get("type").and_then(|x| x.as_str()) == Some("text") {
+                        if let Some(s) = blk.get("text").and_then(|x| x.as_str()) {
+                            if !text.is_empty() {
+                                text.push('\n');
                             }
+                            text.push_str(s);
                         }
-                        // Tool calls (Bash, Read, Edit, …), tool_result echoes and
-                        // thinking blocks are noise in a read-only conversation
-                        // mirror — keep only the human/assistant prose. An assistant
-                        // turn that is only tool calls collapses to empty and is
-                        // dropped below.
-                        _ => {}
                     }
                 }
             }
@@ -2632,5 +2650,63 @@ mod tests {
         assert!(body.len() as u64 > 512 * 1024, "fixture must exceed the tail cap");
         assert_eq!(transcript_meta(&path).unwrap().0, "Fresh tail title");
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn table(entries: &[(u32, Option<u32>, &str)]) -> ProcTable {
+        ProcTable {
+            procs: entries.iter().map(|&(pid, ppid, name)| (pid, (ppid, name.to_string()))).collect(),
+        }
+    }
+
+    #[test]
+    fn proc_table_identity_and_ancestry() {
+        // muster(100) → ghostty(200) → claude(300); unrelated claude(400) under init.
+        let t = table(&[
+            (100, Some(1), "muster"),
+            (200, Some(100), "ghostty"),
+            (300, Some(200), "claude"),
+            (400, Some(1), "claude.exe"),
+        ]);
+        assert!(t.is_descendant_of(300, 100), "grandchild via child terminal");
+        assert!(t.is_descendant_of(100, 100), "a pid is its own ancestor");
+        assert!(!t.is_descendant_of(400, 100), "unrelated session must stay external");
+        assert!(t.is_live_claude(300));
+        assert!(t.is_live_claude(400), "windows .exe name still matches");
+        assert!(!t.is_live_claude(200), "live but not claude");
+        assert!(!t.is_live_claude(999), "dead pid");
+    }
+
+    #[test]
+    fn proc_table_ancestry_survives_ppid_cycles() {
+        // Windows pid reuse can produce ppid cycles; the walk must terminate.
+        let t = table(&[(10, Some(20), "a"), (20, Some(10), "b")]);
+        assert!(!t.is_descendant_of(10, 99));
+    }
+
+    #[test]
+    fn proc_table_snapshot_sees_this_process() {
+        // Real sysinfo snapshot on whatever OS runs the tests: our own pid must
+        // be present and count as its own descendant.
+        let t = ProcTable::snapshot();
+        let me = std::process::id();
+        assert!(t.procs.contains_key(&me), "own pid missing from process snapshot");
+        assert!(t.is_descendant_of(me, me));
+    }
+
+    #[test]
+    fn parse_registry_entry_accepts_interactive_rejects_rest() {
+        // Shape verified against a real CC 2.1.216 registry file on Windows;
+        // the keys are identical on macOS.
+        let win = r#"{"pid":41708,"sessionId":"20283E01-6874-4FBB-B696-C29A89F13CC6","cwd":"E:\\Programming\\Work\\Respeak\\muster","startedAt":1784613714619,"procStart":"639202177128968910","version":"2.1.216","peerProtocol":1,"kind":"interactive","entrypoint":"cli","name":"muster-15","nameSource":"derived","status":"busy","updatedAt":1784614124255,"statusUpdatedAt":1784614124255}"#;
+        let s = parse_registry_entry(win).expect("interactive entry should parse");
+        assert_eq!(s.pid, 41708);
+        assert_eq!(s.cwd, r"E:\Programming\Work\Respeak\muster");
+        assert_eq!(s.status, "busy");
+        assert_eq!(s.status_updated_at, Some(1784614124255));
+
+        // Non-interactive (`claude -p`, SDK) and malformed entries are skipped.
+        assert!(parse_registry_entry(r#"{"pid":1,"sessionId":"x","kind":"print"}"#).is_none());
+        assert!(parse_registry_entry(r#"{"sessionId":"x","kind":"interactive"}"#).is_none());
+        assert!(parse_registry_entry("not json").is_none());
     }
 }


### PR DESCRIPTION
## Why

On Windows, Muster never showed Claude sessions running outside it (PowerShell, VS Code) — `list_external_sessions` was a `#[cfg(windows)]` stub returning `[]`, because both the liveness check and the Muster-ownership ancestry walk ran through macOS-only `ps`. The `~/.claude/sessions/<pid>.json` registry itself is identical on Windows (verified on CC 2.1.216 under `%USERPROFILE%`, VS Code-hosted sessions included), so only the process introspection was missing.

## What

- **`ProcTable`**: one in-process `sysinfo` snapshot of the process table (pid → ppid + lowercased name), shared verbatim by macOS, Windows, and (future) Linux. No `ps`/`tasklist` child processes — relevant since the frontend polls every 3 s.
  - `is_live_claude` guards stale registry files / pid reuse; the name is matched loosely to cover `claude`, `claude.exe`, and self-update renames like `claude.exe.old.<ts>` (observed live).
  - `is_descendant_of` replaces the `ps`-based walk; the iteration cap also bounds ppid cycles, which Windows can produce after pid reuse.
- **`list_external_sessions`**: single cfg-free implementation (`home_dir()` instead of `$HOME`); per-file JSON parsing factored into `parse_registry_entry()` for testability.
- `ps_one` stays for the remaining macOS-only consumers (per-session CPU/RAM, terminal focus). `focus_external_session` is unchanged — jump-to-terminal still errs on Windows.
- `sysinfo 0.38` pinned (0.39 raises MSRV past our rustc), default features off, `system` only.
- Tests: `ProcTable` identity/ancestry/cycle cases, a real-snapshot smoke test, registry parsing against a captured CC 2.1.216 entry.
- Drive-by: folded a single-pattern `match` in `read_transcript` into `if let` (pre-existing clippy warning — clippy is clean again); CLAUDE.md external-sessions + platform-scope sections updated.

## Verification

- `cargo check`, `cargo clippy --all-targets` (clean), `cargo test` (11/11) on Windows, after rebasing onto `dev`.
- End-to-end on Windows: launched the app and read the debug mirror — it listed all 10 live external sessions (PowerShell + VS Code hosts across 4 repos) with correct status, and kept excluding Muster-owned ones. Stale registry files for dead pids were filtered.

## Follow-ups (not in this PR)

- `focus_external_session` on Windows (best-effort `SetForegroundWindow` via the pid's window).
- `session_resources` (CPU/RAM) could move to `sysinfo` too and light up on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)