### PR TITLE
Crash forensics: rolling file log + panic hook

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -33,6 +33,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +949,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1019,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -2159,12 +2195,14 @@ name = "muster"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "log",
  "portable-pty",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-updater",
@@ -2248,6 +2286,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3884,6 +3931,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-log"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6792296e6f389268016c77db21ebae1fc0568f2fccf88b1ec7e2ea71330afb4c"
+dependencies = [
+ "android_logger",
+ "fern",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4117,7 +4185,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,4 +28,8 @@ base64 = "0.22.1"
 tauri-plugin-dialog = "2.7.1"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+# Crash forensics: rolling file log + panic hook. The app previously wrote no
+# logs at all — a panic that unwound out of main left zero trace on disk.
+log = "0.4"
+tauri-plugin-log = "2"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -75,8 +75,23 @@ fn run_telemetry_server(server: tiny_http::Server, app: AppHandle) {
         let stable_sid = header_value(&request, "X-CC-Session").or_else(|| query_param(&url, "sid"));
         let mut body = String::new();
         let _ = request.as_reader().read_to_string(&mut body);
-        let mut data: serde_json::Value =
-            serde_json::from_str(&body).unwrap_or(serde_json::Value::Null);
+        // A parse failure here silently degrades the whole pane (session shows but
+        // no model/cost/phase) — e.g. the PowerShell-BOM class of bug — so it must
+        // be loud. Log length + error only, never the body (it can carry prompts).
+        let mut data: serde_json::Value = match serde_json::from_str(&body) {
+            Ok(v) => v,
+            Err(e) => {
+                if !body.is_empty() {
+                    log::warn!(
+                        "telemetry: dropping unparseable {} payload ({} bytes, sid {}): {e}",
+                        url,
+                        body.len(),
+                        stable_sid.as_deref().unwrap_or("?")
+                    );
+                }
+                serde_json::Value::Null
+            }
+        };
         if let Some(sid) = &stable_sid {
             if !data.is_object() {
                 data = serde_json::json!({});
@@ -384,6 +399,10 @@ fn spawn_claude(
     cmd.env("CC_LAUNCHER_SESSION", &session_id);
     apply_utf8_locale(&mut cmd);
 
+    log::info!(
+        "spawn claude · {session_id} · {workdir}{}",
+        resume.as_deref().map(|r| format!(" · resume {r}")).unwrap_or_default()
+    );
     let child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
     drop(pair.slave);
 
@@ -441,6 +460,7 @@ fn stream_pty_session(
 
     std::thread::spawn(move || {
         let code = child.wait().map(|s| s.exit_code()).unwrap_or(0);
+        log::info!("pty exit · {session_id} · code {code}");
         if let Some(st) = app.try_state::<AppState>() {
             st.sessions.lock().unwrap().remove(&session_id);
             if let Some(p) = child_pid {
@@ -833,6 +853,7 @@ fn resolve_permission(state: State<AppState>, id: String, behavior: String) {
 fn kill_session(state: State<AppState>, session_id: String) -> Result<(), String> {
     let killed = state.sessions.lock().unwrap().remove(&session_id);
     if let Some(mut s) = killed {
+        log::info!("kill session · {session_id}");
         let _ = s.killer.kill();
         if let Some(p) = s.pid {
             state.owned_pids.lock().unwrap().remove(&p);
@@ -2238,18 +2259,68 @@ fn update_tray(
     Ok(())
 }
 
+/// Log every panic — message, location, thread, backtrace — before the process
+/// dies. A panic that unwinds out of `main` terminates a GUI app *cleanly* as far
+/// as the OS is concerned: no crash dump, no WER/CrashReporter entry, the window
+/// just vanishes. This hook is the only on-disk trace of that failure class. It
+/// writes through the `log` facade (→ the rolling muster.log) AND appends raw to
+/// `panic.log` in the same directory, in case the logger itself is what broke.
+fn install_panic_hook(log_dir: std::path::PathBuf) {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let backtrace = std::backtrace::Backtrace::force_capture();
+        let thread = std::thread::current();
+        let msg = format!(
+            "panic on thread '{}': {info}\n{backtrace}",
+            thread.name().unwrap_or("<unnamed>")
+        );
+        log::error!("{msg}");
+        let _ = std::fs::create_dir_all(&log_dir);
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(log_dir.join("panic.log"))
+        {
+            let secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let _ = writeln!(f, "[unix {secs}] {msg}\n");
+        }
+        prev(info);
+    }));
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(
+            tauri_plugin_log::Builder::new()
+                .targets([
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir {
+                        file_name: Some("muster".into()),
+                    }),
+                ])
+                .level(log::LevelFilter::Info)
+                .max_file_size(1_000_000)
+                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepSome(5))
+                .timezone_strategy(tauri_plugin_log::TimezoneStrategy::UseLocal)
+                .build(),
+        )
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .setup(|app| {
+            // Before anything that can panic: from here on, panics leave a trace.
+            install_panic_hook(app.path().app_log_dir()?);
+            log::info!("muster v{} starting", app.package_info().version);
+
             let server = tiny_http::Server::http("127.0.0.1:0")
                 .expect("bind telemetry server on 127.0.0.1");
             let port = server.server_addr().to_ip().map(|a| a.port()).unwrap_or(0);
-            println!("[cc-launcher] telemetry server on 127.0.0.1:{port}");
+            log::info!("telemetry server on 127.0.0.1:{port}");
 
             app.manage(AppState {
                 port,
@@ -2417,8 +2488,20 @@ pub fn run() {
             update_tray,
             confirm_quit
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while running tauri application")
+        // Record clean shutdowns: a log that ends WITHOUT one of these lines is an
+        // abnormal termination — that alone answers "did it crash or was it quit?".
+        .run(|_app, event| match event {
+            tauri::RunEvent::ExitRequested { code, .. } => {
+                log::info!(
+                    "exit requested{}",
+                    code.map(|c| format!(" (code {c})")).unwrap_or_default()
+                );
+            }
+            tauri::RunEvent::Exit => log::info!("exit · clean shutdown"),
+            _ => {}
+        });
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Why

The installed app terminates unexpectedly but leaves **zero trace**: no Application-log fault event, no WER report, no crash dump, no WebView2 Crashpad entry. A process that faults always leaves one of those — a process that *panics and unwinds out of `main`* leaves none, because to the OS that's a clean exit. Muster also wrote no logs of its own, so this failure class was completely invisible. This PR makes it visible.

## What

- **`tauri-plugin-log`** — INFO+ to stdout and a rolling `muster.log` (1 MB × 5 files, local-time timestamps) in the app log dir:
  - Windows: `%LOCALAPPDATA%\io.respeak.cclauncher\logs\`
  - macOS: `~/Library/Logs/io.respeak.cclauncher/`
- **Panic hook** (installed first thing in `setup`) — logs message, location, thread and backtrace through the logger **and** raw-appends to `panic.log` in the same dir, in case the panic is in or below the logger itself. Chains to the previous hook, so stderr behaviour is unchanged.
- **Clean-shutdown markers** — `RunEvent::ExitRequested`/`Exit` are logged, so a log that just stops mid-stream is by itself evidence of an abnormal termination.
- **Lifecycle breadcrumbs** — `spawn claude`, `kill session`, `pty exit · code N` — enough to reconstruct what was running when it died.
- **Loud telemetry-parse failures** — a payload that fails `serde_json` parsing now logs URL, byte count, sid and the error (never the body — it can carry prompt content). This is the silent-drop class of bug (e.g. the PowerShell BOM one) that previously degraded a pane with no indication why.

## Verification

- `cargo check` clean (one pre-existing `git_repo_info` dead-code warning, untouched by this PR)
- `cargo test`: 7/7 pass
- Frontend untouched

## Notes for reviewers

- The log plugin is registered **first** so later plugin/setup activity is captured.
- Backend-only: no JS-side `@tauri-apps/plugin-log`, so no capability/permission changes needed.
- `RotationStrategy::KeepSome(5)` bounds disk use at ~5 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)