### PR TITLE
Worktrees: make the dialog a manager — remove, reopen, and load visibly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,15 @@ Muster's launch uuid **is** Claude's `--session-id`, so every session it launche
 - **The roster is a convenience layer, not a system of record** — `/resume` inside Claude always lists every session for a folder, so nothing dropped or removed is ever lost. Keep UI copy honest about that, and don't build recovery machinery for a problem `/resume` already solves.
 - **The stage has one owner:** `activeId` and the `mirror` pointer (`{kind:"ext"|"past"}`) are mutually exclusive — the read-only kinds share one discriminated pointer rather than a flag each. Timer-driven inspector repaints must bail on `mirror`, not just the external case.
 
+## Worktrees
+
+The worktree dialog (`openWt`) is the whole surface: it starts sessions *and* manages the worktrees themselves. `create_worktree` puts them in a sibling `.cc-worktrees/<repo>/<branch>` tree; `list_worktrees` returns each with the state that decides what's safe (`dirty`, `unmerged`, `locked`, `exists`); `remove_worktree` is the inverse of create.
+
+- **Reachable without a running session.** The ⑃ toolbar button and "＋ Session" both need an active session, so a repo with nothing open used to have no route to its worktrees at all — hence the per-project ⑃ in the sidebar header (`data-wtopen`).
+- **The two kinds of loss are guarded separately**, same rule as `git_action`: never destroy work the UI can't explain. Uncommitted changes exist *only* in the checkout, so removal is refused (`needs_force`) until the caller has been told the count. Commits live on the branch, which `worktree remove` never touches — so the branch is deleted only on request and only via `git branch -d`, which re-checks mergedness itself. **Never `-D`.**
+- **The "is a session running in there" guard lives in the frontend**, because only it knows which panes point where. The backend can't see Muster's session map.
+- Clicking an existing worktree always starts a **new** session in it (a second agent on one branch is a normal thing to want); the "n open" chip is what jumps to a running one.
+
 ## Notes on scope & doc drift
 
 macOS-only assumptions are pervasive and intentional for now: `osascript`, `open -a`, `/bin/zsh` wrappers, hard-coded app paths, `/usr/bin/curl`. Windows would need a PowerShell/`curl.exe` variant of the generated hooks.

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
           </div>
           <div class="st-actions">
             <button class="act" id="btnTerm" title="Open a plain (non-Claude) terminal at the project root">❯ Terminal</button>
-            <button class="act" id="btnWorktree" title="Create git worktree + session">⑃ Worktree</button>
+            <button class="act" id="btnWorktree" title="Worktrees — start a session on another branch, or clean one up">⑃ Worktree</button>
             <button class="act primary" id="btnNew">＋ Session</button>
             <button class="act icon" id="btnClose" title="Close session" hidden>✕</button>
             <button class="act icon" id="inspBtn" title="Toggle inspector (⌘I)">◨</button>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -967,41 +967,199 @@ struct Worktree {
     path: String,
     branch: String,
     is_main: bool,
+    /// Uncommitted entries in this checkout (`git status --porcelain` lines,
+    /// untracked included). This is exactly what removing the worktree would
+    /// destroy, so the UI leads with it before asking to remove.
+    dirty: u32,
+    /// Commits on this branch that the repo's HEAD doesn't have. Removing a worktree
+    /// never touches the branch, so these are safe either way — but they decide
+    /// whether the branch can also be tidied away with it (`branch -d`).
+    unmerged: u32,
+    /// `git worktree lock`ed. Removal needs an explicit unlock, so the UI says that
+    /// instead of surfacing a raw git failure.
+    locked: bool,
+    /// The checkout dir is still on disk. A worktree whose folder was deleted by hand
+    /// lingers in git's metadata until a `worktree prune` — those are removable, but
+    /// not startable.
+    exists: bool,
 }
 
-/// List the git worktrees for a repo (parsed from `git worktree list --porcelain`).
-/// The first entry is the main working tree.
+/// Uncommitted entries in a checkout, untracked included (removing a worktree deletes
+/// those too, so they count as work at risk). `--no-optional-locks` so we never fight
+/// a live `git` in that tree.
+fn dirty_count(dir: &str) -> u32 {
+    git_cmd(dir, &["--no-optional-locks", "status", "--porcelain"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).lines().filter(|l| !l.is_empty()).count() as u32)
+        .unwrap_or(0)
+}
+
+/// List the git worktrees for a repo (parsed from `git worktree list --porcelain`),
+/// each with the state the worktree manager needs to decide what's safe: uncommitted
+/// work, unmerged commits, lock, and whether the dir still exists. The first entry is
+/// the main working tree. The per-worktree probes are a couple of cheap local git
+/// calls each — a repo has a handful of worktrees, not hundreds.
 #[tauri::command]
 fn list_worktrees(repo_dir: String) -> Vec<Worktree> {
-    let out = sys_command("git")
-        .arg("-C").arg(&repo_dir).args(["worktree", "list", "--porcelain"])
-        .output();
+    let out = git_cmd(&repo_dir, &["worktree", "list", "--porcelain"]).output();
     let out = match out {
         Ok(o) if o.status.success() => o,
         _ => return vec![],
     };
     let text = String::from_utf8_lossy(&out.stdout);
     let mut res: Vec<Worktree> = Vec::new();
-    let mut cur_path: Option<String> = None;
-    let mut cur_branch = String::new();
-    let flush = |res: &mut Vec<Worktree>, path: Option<String>, branch: String| {
-        if let Some(path) = path {
-            let is_main = res.is_empty();
-            res.push(Worktree { path, branch, is_main });
-        }
+    // (path, branch, locked) for the record currently being parsed.
+    let mut cur: Option<(String, String, bool)> = None;
+    let flush = |res: &mut Vec<Worktree>, cur: Option<(String, String, bool)>| {
+        let (path, branch, locked) = match cur {
+            Some(c) => c,
+            None => return,
+        };
+        let is_main = res.is_empty();
+        let exists = std::path::Path::new(&path).is_dir();
+        let dirty = if exists { dirty_count(&path) } else { 0 };
+        // vs the repo we were asked about — the same reference point git_branch_list
+        // uses for ahead/behind, so both lists tell one consistent story.
+        let unmerged = if is_main || branch.is_empty() || branch == "(detached)" {
+            0
+        } else {
+            count_commits(&repo_dir, &format!("HEAD..refs/heads/{branch}"))
+        };
+        res.push(Worktree { path, branch, is_main, dirty, unmerged, locked, exists });
     };
     for line in text.lines() {
         if let Some(p) = line.strip_prefix("worktree ") {
-            flush(&mut res, cur_path.take(), std::mem::take(&mut cur_branch));
-            cur_path = Some(p.to_string());
+            flush(&mut res, cur.take());
+            cur = Some((p.to_string(), String::new(), false));
         } else if let Some(b) = line.strip_prefix("branch ") {
-            cur_branch = b.strip_prefix("refs/heads/").unwrap_or(b).to_string();
+            if let Some(c) = cur.as_mut() {
+                c.1 = b.strip_prefix("refs/heads/").unwrap_or(b).to_string();
+            }
         } else if line.starts_with("detached") {
-            cur_branch = "(detached)".to_string();
+            if let Some(c) = cur.as_mut() {
+                c.1 = "(detached)".to_string();
+            }
+        } else if line == "locked" || line.starts_with("locked ") {
+            if let Some(c) = cur.as_mut() {
+                c.2 = true;
+            }
         }
     }
-    flush(&mut res, cur_path.take(), cur_branch);
+    flush(&mut res, cur.take());
     res
+}
+
+/// `git rev-list --count <range>`, 0 on any failure. That default reads as "nothing
+/// unmerged", which would be the dangerous way round if it were load-bearing — it
+/// isn't: 0 only ever *permits* the safe `git branch -d`, which refuses an unmerged
+/// branch on its own. The count is a UI hint; git remains the authority.
+fn count_commits(dir: &str, range: &str) -> u32 {
+    git_cmd(dir, &["rev-list", "--count", range])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8_lossy(&o.stdout).trim().parse().ok())
+        .unwrap_or(0)
+}
+
+#[derive(serde::Serialize)]
+struct WtRemoval {
+    removed: bool,
+    /// Refused: the checkout holds uncommitted work. The UI re-asks naming `dirty`,
+    /// then calls back with `force`. Nothing was touched.
+    needs_force: bool,
+    dirty: u32,
+    /// The branch outlived the worktree — either we weren't asked to delete it, or
+    /// `git branch -d` refused because it holds unmerged commits. We never force-delete
+    /// a branch: the checkout is disposable, commits are not.
+    branch_kept: bool,
+    /// One line for the toast.
+    summary: String,
+}
+
+/// Remove a worktree (and optionally tidy away its branch). The inverse of
+/// `create_worktree`, and the reason the worktree list is a manager rather than a
+/// picker — without it, cleanup means dropping to a shell.
+///
+/// Same design rule as `git_action`: never destroy work the UI can't explain. Two
+/// guards, one per kind of loss. Uncommitted changes live *only* in the checkout, so
+/// they're refused unless the caller explicitly forces (having been told the count).
+/// Commits live on the branch, which `worktree remove` doesn't touch at all — so the
+/// branch is deleted only on request and only via the safe `branch -d`, which refuses
+/// unmerged work on its own. Sessions running inside the worktree are the frontend's
+/// guard: it knows which panes point where.
+#[tauri::command]
+fn remove_worktree(repo_dir: String, path: String, force: bool, delete_branch: bool) -> Result<WtRemoval, String> {
+    // Compare resolved paths: git prints its own canonical form, which on macOS
+    // (/var → /private/var) and Windows (8.3 names, drive case) need not match the
+    // string the frontend is holding.
+    let same = |a: &str, b: &str| {
+        let canon = |p: &str| std::fs::canonicalize(p).unwrap_or_else(|_| std::path::PathBuf::from(p));
+        canon(a) == canon(b)
+    };
+    let all = list_worktrees(repo_dir.clone());
+    if all.is_empty() {
+        return Err("not a git repository".into());
+    }
+    let target = all
+        .iter()
+        .find(|w| same(&w.path, &path))
+        .ok_or_else(|| "not a worktree of this repository".to_string())?;
+    if target.is_main {
+        return Err("that's the repository itself, not a worktree".into());
+    }
+    if target.locked {
+        return Err("this worktree is locked — run `git worktree unlock` first".into());
+    }
+    let branch = target.branch.clone();
+    let dirty = target.dirty;
+    if dirty > 0 && !force {
+        return Ok(WtRemoval {
+            removed: false,
+            needs_force: true,
+            dirty,
+            branch_kept: true,
+            summary: format!("{dirty} uncommitted change{} in that worktree", if dirty == 1 { "" } else { "s" }),
+        });
+    }
+
+    let mut args: Vec<&str> = vec!["worktree", "remove"];
+    if force {
+        args.push("--force");
+    }
+    args.push(&path);
+    let out = git_cmd(&repo_dir, &args).output().map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        // A worktree whose folder was deleted by hand can't be "removed" — it's
+        // pruned. Fall back to that rather than making the user learn the difference.
+        if !target.exists {
+            let _ = git_cmd(&repo_dir, &["worktree", "prune"]).output();
+        } else {
+            let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            return Err(if err.is_empty() { "git worktree remove failed".into() } else { err });
+        }
+    }
+    let _ = git_cmd(&repo_dir, &["worktree", "prune"]).output();
+
+    // `-d` (never `-D`): git re-checks mergedness itself, so a branch that gained
+    // commits since we listed it survives regardless of what we decided up here.
+    let mut branch_kept = true;
+    if delete_branch && !branch.is_empty() && branch != "(detached)" {
+        if let Ok(o) = git_cmd(&repo_dir, &["branch", "-d", &branch]).output() {
+            branch_kept = !o.status.success();
+        }
+    }
+    let label = if branch.is_empty() { "worktree".to_string() } else { branch.clone() };
+    let summary = if !branch_kept {
+        format!("Removed {label} + branch")
+    } else if dirty > 0 {
+        format!("Removed {label} · {dirty} uncommitted change{} discarded", if dirty == 1 { "" } else { "s" })
+    } else {
+        format!("Removed worktree {label}")
+    };
+    Ok(WtRemoval { removed: true, needs_force: false, dirty, branch_kept, summary })
 }
 
 /// One local branch, with enough context for the worktree picker to tell whether
@@ -2402,6 +2560,7 @@ pub fn run() {
             set_caffeinate,
             resolve_permission,
             list_worktrees,
+            remove_worktree,
             git_branch_list,
             spawn_ghostty,
             spawn_shell,
@@ -2438,6 +2597,14 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    /// Where `create_worktree` puts this repo's worktrees. Tests must delete only this,
+    /// never the shared `.cc-worktrees` parent — sibling tests run in parallel out of
+    /// the same temp dir, and pulling that tree out from under them makes their
+    /// checkouts vanish mid-assertion.
+    fn wt_root(repo: &Path) -> PathBuf {
+        repo.parent().unwrap().join(".cc-worktrees").join(repo.file_name().unwrap())
     }
 
     /// Run a git command in `dir`, asserting success. Identity/signing are passed via
@@ -2541,7 +2708,63 @@ mod tests {
         assert_eq!(String::from_utf8_lossy(&orig.stdout).trim(), "dev");
 
         // Worktrees land in a *sibling* .cc-worktrees tree, never inside the repo.
-        let _ = std::fs::remove_dir_all(dir.parent().unwrap().join(".cc-worktrees"));
+        // Clean only this repo's subtree: .cc-worktrees itself is shared by every
+        // test running in parallel out of the same temp dir.
+        let _ = std::fs::remove_dir_all(wt_root(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The remove flow's whole safety story lives in these two guards: uncommitted
+    /// work is refused until the caller has been told how much it is about to lose,
+    /// and the branch (where committed work lives) outlives the checkout unless it is
+    /// fully merged. Both are checked here against a real repo.
+    #[test]
+    fn remove_worktree_guards_uncommitted_work_and_unmerged_branches() {
+        let dir = scratch_dir();
+        git(&dir, &["init", "-q", "-b", "dev"]);
+        let commit = |dir: &Path, msg: &str| git(dir, &["-c", "user.email=t@example.com", "-c", "user.name=T", "-c", "commit.gpgsign=false", "commit", "-q", "--allow-empty", "-m", msg]);
+        commit(&dir, "base");
+        let repo = dir.to_str().unwrap().to_string();
+
+        // A dirty worktree: refused without force, and nothing is touched by the refusal.
+        let dirty_wt = create_worktree(repo.clone(), "dirty-one".into()).expect("create failed");
+        std::fs::write(std::path::Path::new(&dirty_wt).join("scratch.txt"), "work in progress").unwrap();
+        let r = remove_worktree(repo.clone(), dirty_wt.clone(), false, false).expect("should refuse, not error");
+        assert!(
+            !r.removed && r.needs_force && r.dirty == 1,
+            "dirty worktree must be refused: removed={} needs_force={} dirty={}",
+            r.removed, r.needs_force, r.dirty
+        );
+        assert!(std::path::Path::new(&dirty_wt).is_dir(), "a refusal must not remove anything");
+        // Forced, it goes — and the branch is kept because we didn't ask for it.
+        let r = remove_worktree(repo.clone(), dirty_wt.clone(), true, false).expect("forced removal failed");
+        assert!(r.removed && r.branch_kept, "forced removal should remove the worktree and keep the branch");
+        assert!(!std::path::Path::new(&dirty_wt).is_dir(), "the checkout should be gone");
+        assert!(list_worktrees(repo.clone()).iter().all(|w| w.branch != "dirty-one"), "git should no longer list it");
+
+        // A clean worktree whose branch has its own commit: the branch survives even
+        // when deletion is requested, because `branch -d` refuses unmerged work.
+        let keep_wt = create_worktree(repo.clone(), "has-commits".into()).expect("create failed");
+        commit(std::path::Path::new(&keep_wt), "work only on this branch");
+        let listed = list_worktrees(repo.clone());
+        let w = listed.iter().find(|w| w.branch == "has-commits").expect("worktree missing");
+        assert_eq!((w.dirty, w.unmerged, w.is_main), (0, 1, false), "clean checkout, 1 commit ahead of dev");
+        let r = remove_worktree(repo.clone(), keep_wt.clone(), false, true).expect("removal failed");
+        assert!(r.removed && r.branch_kept, "unmerged branch must survive its worktree");
+        let refs = Command::new("git").current_dir(&dir).args(["branch", "--list", "has-commits"]).output().unwrap();
+        assert!(!String::from_utf8_lossy(&refs.stdout).trim().is_empty(), "branch has-commits should still exist");
+
+        // A clean, fully-merged branch is the one case where the branch goes too.
+        let tidy_wt = create_worktree(repo.clone(), "nothing-new".into()).expect("create failed");
+        let r = remove_worktree(repo.clone(), tidy_wt.clone(), false, true).expect("removal failed");
+        assert!(r.removed && !r.branch_kept, "a merged branch should be tidied away with its worktree");
+        let refs = Command::new("git").current_dir(&dir).args(["branch", "--list", "nothing-new"]).output().unwrap();
+        assert!(String::from_utf8_lossy(&refs.stdout).trim().is_empty(), "branch nothing-new should be gone");
+
+        // The repo itself is never removable through this door.
+        assert!(remove_worktree(repo.clone(), repo.clone(), true, false).is_err(), "the main worktree must be refused");
+
+        let _ = std::fs::remove_dir_all(wt_root(&dir));
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -438,10 +438,20 @@ async function launch(project: string, workdir: string, opts: { colorKey?: strin
 }
 
 // Offer a worktree when launching into a repo that already has a session.
-async function requestLaunch(project: string, path: string) {
+//
+// Which of the two happens can't be known without asking git, and on a cold repo that
+// answer is not instant — so the control that was pressed spins for the duration
+// rather than a click appearing to do nothing. The branch git just told us is handed
+// to the dialog, which would otherwise ask again and render its "start here on <b>"
+// button a beat late.
+async function requestLaunch(project: string, path: string, trigger?: HTMLElement | null) {
   if ([...sessions.values()].some((s) => s.colorKey === path)) {
-    const br = await invoke<string | null>("git_branch", { workdir: path });
-    if (br) { openWt(project, path, true); return; }
+    trigger?.classList.add("busy");
+    let br: string | null = null;
+    try { br = await invoke<string | null>("git_branch", { workdir: path }); }
+    catch { /* not a repo, or git is unhappy — fall through to a plain launch */ }
+    finally { trigger?.classList.remove("busy"); }
+    if (br) { openWt(project, path, true, br); return; }
   }
   launch(project, path, { colorKey: path });
 }
@@ -1152,18 +1162,23 @@ function renderSidebar() {
     const dirty = p.sessions.some((s) => folderDirty(s.workdir)) || p.externals.some((e) => folderDirty(e.cwd));
     const dot = dirty ? `<span class="pdirty" title="Uncommitted changes in this project"></span>` : "";
     const wtSuffix = p.wtBranch ? `<span class="pwt">· ${esc(p.wtBranch)}</span>` : "";
+    // Worktrees, straight from the project — the only way in used to be a running
+    // session (the ⑃ toolbar button and "+ Session" both need one), so a repo with
+    // nothing open had no route to its own worktrees at all. In a split group this
+    // targets the worktree's own checkout, which is its repo as far as git cares.
+    const wtBtn = `<span class="pwtb" data-wtopen="${esc(p.path)}" data-proj="${esc(p.name)}" title="Worktrees of ${esc(p.name)} — start a session on another branch, or clean one up">⑃</span>`;
     let head: string;
     if (p.sessions.length) {
-      head = `<div class="phead" data-sel="${p.sessions[0].id}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}${wtSuffix}</span>${dot}<span class="pcount">${total}</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}">＋</span></div>`;
+      head = `<div class="phead" data-sel="${p.sessions[0].id}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}${wtSuffix}</span>${dot}<span class="pcount">${total}</span>${wtBtn}<span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}">＋</span></div>`;
     } else if (isFav) {
       const tail = p.externals.length ? `<span class="pcount ext">${p.externals.length} ext</span>` : `<span class="plaunch">launch →</span>`;
-      head = `<div class="phead empty-p" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="premove" data-remove="${esc(p.path)}" title="Remove project">✕</span></div>`;
+      head = `<div class="phead empty-p" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}${wtBtn}<span class="premove" data-remove="${esc(p.path)}" title="Remove project">✕</span></div>`;
     } else {
       // discovered via an external session or a restorable one only — not a saved project
       const tail = p.externals.length
         ? `<span class="pcount ext">${p.externals.length} ext</span>`
         : `<span class="pcount ext">${p.dormants.length} past</span>`;
-      head = `<div class="phead ext-only" data-key="${esc(p.path)}" title="${esc(tilde(p.path))}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" title="Launch a Muster session here">＋</span></div>`;
+      head = `<div class="phead ext-only" data-key="${esc(p.path)}" title="${esc(tilde(p.path))}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}${wtBtn}<span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" title="Launch a Muster session here">＋</span></div>`;
     }
     return `<div class="pgroup" draggable="true" data-path="${esc(p.path)}">${head}${rows ? `<div class="psessions">${rows}</div>` : ""}</div>`;
   }).join("");
@@ -1850,7 +1865,7 @@ function sessionActions(s: Sess): PalItem[] {
       a.push(mk(ah ? `Push ${ah} commit${ah === 1 ? "" : "s"}` : "Push", "↑", () => runGit(s.id, "push")));
     }
     a.push(mk("Open a terminal here", "❯", () => { setActive(s.id); openPlainTerminal(); }));
-    a.push(mk("New worktree from here", "⑃", () => openWt(s.project, s.colorKey, false)));
+    a.push(mk("Worktrees of this project…", "⑃", () => openWt(s.project, s.colorKey, false)));
   }
   a.push(mk("Close session", "✕", () => closeSession(s.id)));
   return a;
@@ -1962,16 +1977,25 @@ let toastT: number | undefined;
 function toast(m: string) { const el = $("toast"); el.textContent = m; el.classList.add("show"); clearTimeout(toastT); toastT = window.setTimeout(() => el.classList.remove("show"), 1900); }
 
 // ---------- worktree dialog ----------
+// Both the "where should this session run" picker and the only place worktrees are
+// managed: every existing one is listed with the state that decides what's safe to do
+// with it (sessions running inside, uncommitted work, unmerged commits), can take a
+// new session, and can be removed. Without the removal half you can create worktrees
+// here but only clean them up in a shell — which is how they pile up.
 let wtCtx: { project: string; repoDir: string } | null = null;
 type BranchInfo = { name: string; current: boolean; checked_out: boolean; ahead: number; behind: number; rel: string; unix: number };
+type Worktree = { path: string; branch: string; is_main: boolean; dirty: number; unmerged: number; locked: boolean; exists: boolean };
+type WtRemoval = { removed: boolean; needs_force: boolean; dirty: number; branch_kept: boolean; summary: string };
+let wtCache: Worktree[] = [];
 
-async function openWt(project: string, repoDir: string, allowMain: boolean) {
+async function openWt(project: string, repoDir: string, allowMain: boolean, branch?: string) {
   wtCtx = { project, repoDir };
+  wtCache = [];
   const n = [...sessions.values()].filter((s) => s.project === project).length + 1;
-  ($("wtH") as HTMLElement).textContent = allowMain ? "New session" : "New worktree";
+  ($("wtH") as HTMLElement).textContent = allowMain ? "New session" : "Worktrees";
   $("wtSub").textContent = allowMain
     ? `${project} already has a running session — start another below.`
-    : `Start a session in a worktree of ${project}.`;
+    : `Start a session in a worktree of ${project} — or clean one up.`;
   // The "start here — no worktree" escape hatch: what makes a worktree one option
   // rather than the only path. Shown first, above the worktree options. Only in
   // allowMain mode — the ⑃ Worktree button asked for a worktree explicitly. The label
@@ -1981,39 +2005,93 @@ async function openWt(project: string, repoDir: string, allowMain: boolean) {
   ($("wtOr") as HTMLElement).hidden = !allowMain;
   mainBtn.hidden = !allowMain;
   if (allowMain) {
-    mainBtn.innerHTML = "Start here — no worktree";
-    mainBtn.title = "Start a session in the repo itself — no new worktree";
-    invoke<string | null>("git_branch", { workdir: repoDir }).then((b) => {
-      if (!wtCtx || wtCtx.repoDir !== repoDir) return; // dialog moved on / closed
-      if (b) {
-        mainBtn.innerHTML = `Start here on <span class="wt-mainbr">${esc(b)}</span> — no worktree`;
-        mainBtn.title = `Start a session on the current branch (${b}) — no new worktree`;
-      }
-    }).catch(() => {});
+    // The branch is what makes this button concrete ("start here on dev"), so it
+    // shouldn't arrive after the button does. `requestLaunch` already asked git — it
+    // only opens this dialog when the folder *is* a repo — so it hands the answer
+    // down and the label is right on first paint. Any other caller gets a placeholder
+    // holding the branch's place until git answers.
+    if (branch) setWtMainLabel(mainBtn, branch);
+    else {
+      mainBtn.innerHTML = `Start here on <span class="wt-mainbr sk-inline"></span> — no worktree`;
+      mainBtn.title = "Start a session in the repo itself — no new worktree";
+      invoke<string | null>("git_branch", { workdir: repoDir }).then((b) => {
+        if (wtCtx?.repoDir !== repoDir) return; // dialog moved on / closed
+        if (b) setWtMainLabel(mainBtn, b);
+        else mainBtn.innerHTML = "Start here — no worktree"; // detached, or not a repo
+      }).catch(() => { mainBtn.innerHTML = "Start here — no worktree"; });
+    }
   }
   const bi = $("wtBranch") as HTMLInputElement; bi.value = `agent-${n}`;
-  ($("wtList") as HTMLElement).hidden = true; $("wtList").innerHTML = "";
-  ($("wtBranchList") as HTMLElement).hidden = true; $("wtBranchList").innerHTML = "";
   $("wtBranches").innerHTML = "";
   $("scrim").classList.add("show"); $("wtDlg").classList.add("show");
   setTimeout(() => { bi.focus(); bi.select(); }, 30);
-  const wts = await invoke<{ path: string; branch: string; is_main: boolean }[]>("list_worktrees", { repoDir }).catch(() => [] as { path: string; branch: string; is_main: boolean }[]);
-  if (wtCtx && wtCtx.repoDir === repoDir) renderWtList(wts);
+  loadWtLists(repoDir);
+}
+// The branch stays a plain inline span so it shares the button's baseline (see the
+// .wt-here note in styles.css).
+function setWtMainLabel(btn: HTMLElement, branch: string) {
+  btn.innerHTML = `Start here on <span class="wt-mainbr">${esc(branch)}</span> — no worktree`;
+  btn.title = `Start a session on the current branch (${branch}) — no new worktree`;
+}
+// Skeleton rows standing in for a list git hasn't answered for yet. Both lists cost
+// several git calls (the worktree list probes each checkout for dirt and unmerged
+// commits; the branch list runs a rev-list per branch), so on a big or cold repo the
+// dialog would otherwise sit visibly empty — which reads as "this repo has none"
+// rather than "still counting". Placeholder rows say which, and reserve the space so
+// the real ones don't shove the input and buttons down as they land.
+function wtSkeleton(label: string, rows: number): string {
+  return `<div class="wt-lbl">${esc(label)}</div>`
+    + `<div class="wt-item skel" aria-hidden="true"><span class="sk sk-br"></span><span class="sk sk-meta"></span></div>`.repeat(rows);
+}
+function showWtSkeletons() {
+  for (const [id, label, rows] of [["wtList", "Existing worktrees", 2], ["wtBranchList", "Or pick a branch", 3]] as const) {
+    const el = $(id) as HTMLElement;
+    el.innerHTML = wtSkeleton(label, rows);
+    el.hidden = false;
+    el.setAttribute("aria-busy", "true");
+  }
+}
+// Both lists, re-read from git. Called on open and after every change (a removal frees
+// a branch back into the picker, or takes it away entirely), each guarded by the
+// dialog still pointing at the repo it was asked about.
+async function loadWtLists(repoDir: string) {
+  showWtSkeletons();
+  const wts = await invoke<Worktree[]>("list_worktrees", { repoDir }).catch(() => [] as Worktree[]);
+  if (wtCtx?.repoDir !== repoDir) return;
+  // Every repo has at least its own main working tree, so an empty list means this
+  // folder isn't one — say so now rather than after a create attempt fails.
+  if (!wts.length) { const p = wtCtx.project; closeWt(); toast(`${p} isn't a git repository`); return; }
+  wtCache = wts; renderWtList(wts);
   // Show the repo's branches so an existing one can be *picked* rather than recalled.
   // The input has always accepted existing names (create_worktree probes the ref and
   // attaches); the list makes that browsable, with a staleness + ahead/behind cue so
   // it's obvious which branches are worth starting on.
   const branches = await invoke<BranchInfo[]>("git_branch_list", { repoDir }).catch(() => [] as BranchInfo[]);
-  if (wtCtx && wtCtx.repoDir === repoDir) renderBranchList(branches);
+  if (wtCtx?.repoDir === repoDir) renderBranchList(branches);
 }
-function renderWtList(wts: { path: string; branch: string; is_main: boolean }[]) {
+// Sessions Muster owns in a given checkout — the guard on removing it, and the "n open"
+// chip's jump target. Externals are counted separately: we can't close those for you.
+function sessionsIn(path: string): Sess[] { return [...sessions.values()].filter((s) => s.workdir === path); }
+function renderWtList(wts: Worktree[]) {
   const nonMain = wts.filter((w) => !w.is_main);
   const el = $("wtList");
+  el.removeAttribute("aria-busy"); // whatever happens next replaces the skeleton
   if (!nonMain.length) { el.innerHTML = ""; (el as HTMLElement).hidden = true; return; }
   (el as HTMLElement).hidden = false;
   el.innerHTML = `<div class="wt-lbl">Existing worktrees</div>` + nonMain.map((w) => {
-    const isOpen = [...sessions.values()].some((s) => s.workdir === w.path);
-    return `<button class="wt-item" data-wt="${esc(w.path)}" data-wtbranch="${esc(w.branch)}"><span class="wt-br">⑃ ${esc(w.branch)}</span><span class="wt-open">${isOpen ? "open" : "→"}</span></button>`;
+    const open = sessionsIn(w.path);
+    const ext = externals.filter((e) => e.cwd === w.path).length;
+    const tags = (open.length ? `<span class="wt-open on" data-wtjump="${esc(open[0].id)}" title="Jump to the session running here">${open.length} open</span>` : "")
+      + (ext ? `<span class="wt-tag" title="Running outside Muster">${ext} ext</span>` : "")
+      + (w.dirty ? `<span class="wt-dirty" title="${w.dirty} uncommitted change${w.dirty === 1 ? "" : "s"} — removing the worktree would discard them">●${w.dirty}</span>` : "")
+      + (w.unmerged ? `<span class="wt-ab wt-ahead" title="${w.unmerged} commit${w.unmerged === 1 ? "" : "s"} not in the current branch — the branch keeps them either way">↑${w.unmerged}</span>` : "")
+      + (w.locked ? `<span class="wt-tag">locked</span>` : "")
+      + (!w.exists ? `<span class="wt-tag gone" title="The folder is gone — only git's bookkeeping is left">missing</span>` : "");
+    const tip = w.exists ? `${tilde(w.path)}\nStart a session here` : `${tilde(w.path)}\nThe folder no longer exists`;
+    return `<div class="wt-item wt-wt${w.exists ? "" : " gone"}" data-wt="${esc(w.path)}" data-wtbranch="${esc(w.branch)}" title="${esc(tip)}">`
+      + `<span class="wt-br">⑃ ${esc(w.branch || basename(w.path))}</span>`
+      + `<span class="wt-bmeta">${tags}<span class="wt-rm" data-wtrm="${esc(w.path)}" title="Remove this worktree…">✕</span></span>`
+      + `</div>`;
   }).join("");
 }
 // Branches you could start a *new* worktree on. The current branch (the "start here"
@@ -2024,6 +2102,7 @@ function renderBranchList(bs: BranchInfo[]) {
   const pick = bs.filter((b) => !b.current && !b.checked_out);
   $("wtBranches").innerHTML = pick.map((b) => `<option value="${esc(b.name)}"></option>`).join("");
   const el = $("wtBranchList") as HTMLElement;
+  el.removeAttribute("aria-busy"); // whatever happens next replaces the skeleton
   if (!pick.length) { el.innerHTML = ""; el.hidden = true; return; }
   el.hidden = false;
   const STALE = 45 * 86400, now = Date.now() / 1000;
@@ -2037,12 +2116,15 @@ function renderBranchList(bs: BranchInfo[]) {
       + `</button>`;
   }).join("");
 }
+// Start a session in an existing worktree. Always a *new* one, even when the worktree
+// already has sessions: this dialog exists to start work, and a second agent on the
+// same branch is a normal thing to want. Jumping to a running one is the "n open"
+// chip's job (and the sidebar's).
 function openWorktreeSession(path: string, branch: string) {
   if (!wtCtx) return;
   const { project, repoDir } = wtCtx;
+  if (!wtCache.find((w) => w.path === path)?.exists) { toast("That folder is gone — remove the worktree"); return; }
   closeWt();
-  const existing = [...sessions.values()].find((s) => s.workdir === path);
-  if (existing) { setActive(existing.id); return; }
   launch(project, path, { colorKey: repoDir, worktree: branch, branch });
 }
 function closeWt() { $("wtDlg").classList.remove("show"); if (!$("palette").classList.contains("show")) $("scrim").classList.remove("show"); wtCtx = null; }
@@ -2062,6 +2144,68 @@ function wtCreate() {
   const branch = ($("wtBranch") as HTMLInputElement).value.trim();
   if (!branch) { toast("Enter a branch name"); return; }
   createWorktreeOn(branch);
+}
+// Remove a worktree from the list. The dialog stays open — cleanup is usually a
+// sweep, not a single act.
+//
+// Everything the user needs to judge it goes in the prompt *before* the removal, and
+// the two kinds of loss are handled separately: uncommitted changes die with the
+// checkout (so they're named, and the backend still refuses until we force), while
+// commits live on the branch, which survives unless it's fully merged. Sessions
+// running inside are refused outright rather than killed — only the frontend knows
+// which panes point where, so this guard can't live in the backend.
+async function removeWorktree(path: string) {
+  if (!wtCtx) return;
+  const { repoDir } = wtCtx;
+  const w = wtCache.find((x) => x.path === path);
+  if (!w) return;
+  const live = sessionsIn(path);
+  if (live.length) { toast(`Close the ${live.length} session${live.length === 1 ? "" : "s"} running there first`); return; }
+  if (externals.some((e) => e.cwd === path)) { toast("A session outside Muster is running there"); return; }
+  if (w.locked) { toast("Locked — run `git worktree unlock` first"); return; }
+
+  const label = w.branch || basename(path);
+  // Only tidy the branch away when it holds nothing the repo doesn't already have;
+  // the backend's `branch -d` re-checks that, so a race can't lose commits.
+  const dropBranch = !!w.branch && w.branch !== "(detached)" && w.unmerged === 0;
+  const lines = [`${tilde(path)}`, ""];
+  if (!w.exists) lines.push("The folder is already gone — this just clears git's bookkeeping.");
+  else if (w.dirty) lines.push(`${w.dirty} uncommitted change${w.dirty === 1 ? "" : "s"} here will be lost.`);
+  else lines.push("The checkout is clean — nothing uncommitted to lose.");
+  lines.push(dropBranch
+    ? `The branch ${label} is fully merged, so it goes too.`
+    : w.unmerged
+      ? `The branch ${label} stays, keeping its ${w.unmerged} unmerged commit${w.unmerged === 1 ? "" : "s"}.`
+      : `The branch ${label} stays.`);
+  const ok = await ask(lines.join("\n"), {
+    title: `Remove the worktree ${label}?`,
+    kind: w.dirty ? "warning" : "info",
+    okLabel: dropBranch ? "Remove worktree & branch" : "Remove worktree",
+    cancelLabel: "Keep",
+  });
+  if (!ok) return;
+
+  try {
+    let r = await invoke<WtRemoval>("remove_worktree", { repoDir, path, force: w.dirty > 0, deleteBranch: dropBranch });
+    // It went dirty between listing and now — re-ask with the real count rather than
+    // forcing on the user's behalf.
+    if (r.needs_force) {
+      const sure = await ask(`${r.summary} — appeared since this list was drawn.\n\nRemove it anyway and discard them?`, {
+        title: `Remove the worktree ${label}?`, kind: "warning", okLabel: "Discard & remove", cancelLabel: "Keep",
+      });
+      if (!sure) return;
+      r = await invoke<WtRemoval>("remove_worktree", { repoDir, path, force: true, deleteBranch: dropBranch });
+    }
+    toast(r.summary);
+    dlog("info", `worktree removed · ${label} · ${path}`);
+    // The roster can still point at a folder that no longer exists; drop those so a
+    // dead worktree doesn't offer a restore that can only fail.
+    const before = dormants.length;
+    dormants = dormants.filter((d) => d.workdir !== path);
+    if (dormants.length !== before) flushRoster();
+    if (wtCtx?.repoDir === repoDir) loadWtLists(repoDir);
+    renderAll();
+  } catch (e) { toast("worktree: " + e); }
 }
 
 // ---------- events ----------
@@ -2123,11 +2267,16 @@ document.addEventListener("click", (e) => {
   if (dot) { const owner = dot.closest<HTMLElement>("[data-key]"); if (owner?.dataset.key) { openColorPopover(owner.dataset.key, e.clientX, e.clientY); return; } }
   // data-forget and data-resume sit INSIDE a data-past row, so they must be matched
   // (and dispatched) ahead of it or the row's own click would swallow them.
-  const el = t.closest<HTMLElement>("[data-perm],[data-git],[data-diff],[data-wt],[data-branch],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-sel],[data-launch],[data-pal],[data-rail],[data-toast]");
+  const el = t.closest<HTMLElement>("[data-perm],[data-git],[data-diff],[data-wtrm],[data-wtjump],[data-wtopen],[data-wt],[data-branch],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-sel],[data-launch],[data-pal],[data-rail],[data-toast]");
   if (!el) return;
   if (el.dataset.perm) resolvePermission(el.dataset.permid || "", el.dataset.perm);
   else if (el.dataset.git) runGit(el.dataset.gitsid || "", el.dataset.git);
   else if (el.dataset.diff) openDiff(el.dataset.diff, el.dataset.difftitle || "");
+  // The ✕ and the "n open" chip sit INSIDE a data-wt row, so they must be matched
+  // ahead of it or the row's own click (start a session) would swallow them.
+  else if (el.dataset.wtrm) removeWorktree(el.dataset.wtrm);
+  else if (el.dataset.wtjump) { const id = el.dataset.wtjump; closeWt(); setActive(id); }
+  else if (el.dataset.wtopen) openWt(el.dataset.proj || basename(el.dataset.wtopen), el.dataset.wtopen, false);
   else if (el.dataset.wt) openWorktreeSession(el.dataset.wt, el.dataset.wtbranch || "");
   else if (el.dataset.branch) createWorktreeOn(el.dataset.branch);
   else if (el.dataset.close) closeSession(el.dataset.close);
@@ -2139,7 +2288,9 @@ document.addEventListener("click", (e) => {
   else if (el.dataset.ext) openExternal(el.dataset.ext);
   else if (el.dataset.past) openDormant(el.dataset.past);
   else if (el.dataset.sel) { setActive(el.dataset.sel); closeAttnPop(); }
-  else if (el.dataset.launch) requestLaunch(el.dataset.proj || basename(el.dataset.launch), el.dataset.launch);
+  // On a project row data-launch sits on the whole header — spin its ＋ / "launch →"
+  // affordance rather than blanking the row.
+  else if (el.dataset.launch) requestLaunch(el.dataset.proj || basename(el.dataset.launch), el.dataset.launch, el.querySelector<HTMLElement>(".padd, .plaunch") || el);
   else if (el.dataset.pal) openPalette();
   else if (el.dataset.rail) toggleRail();
   else if (el.dataset.toast) toast(el.dataset.toast);
@@ -2532,9 +2683,9 @@ async function launchShell(project: string, workdir: string, opts: { colorKey?: 
 }
 // "+ Session" starts a session in the current project (offering a worktree if it
 // already has one). With no active session there's no project context → palette.
-$("btnNew").addEventListener("click", () => {
+$("btnNew").addEventListener("click", (e) => {
   const c = activeProjectCtx();
-  if (c) requestLaunch(c.project, c.path); else openPalette();
+  if (c) requestLaunch(c.project, c.path, e.currentTarget as HTMLElement); else openPalette();
 });
 $("btnWorktree").addEventListener("click", () => { const c = activeProjectCtx(); if (!c) { toast("No active session"); return; } openWt(c.project, c.path, false); });
 $("btnTerm").addEventListener("click", openPlainTerminal);

--- a/src/styles.css
+++ b/src/styles.css
@@ -67,6 +67,10 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .label { font-size: 9px; letter-spacing: .11em; text-transform: uppercase; color: var(--muted-2); font-weight: 700; }
 .lit { background: linear-gradient(180deg, var(--lift), transparent 42%), var(--surface); border: 1px solid var(--hair); box-shadow: inset 0 1px 0 var(--lift); }
 [hidden] { display: none !important; }
+/* Inline placeholder for a word that arrives late (the branch in "start here on <b>"),
+   sized like the text it stands in for so the line doesn't reflow when it lands. */
+.sk-inline { display: inline-block; width: 4.5em; height: .72em; border-radius: 5px; background: var(--surface-2); }
+@media (prefers-reduced-motion: no-preference) { .sk-inline { animation: pulse 1.5s ease-in-out infinite; } }
 
 /* top bar */
 .top { grid-area: top; display: flex; align-items: center; gap: 11px; padding: 0 12px; background: linear-gradient(180deg, var(--lift), transparent 60%), var(--panel); border-bottom: 1px solid var(--hair); }
@@ -192,6 +196,11 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .pdirty { flex: none; width: 6px; height: 6px; border-radius: 50%; background: var(--st-working); box-shadow: 0 0 5px color-mix(in srgb, var(--st-working) 70%, transparent); }
 .padd { flex: none; font-size: 13px; color: var(--muted-2); padding: 0 2px; }
 .padd:hover { color: var(--text); }
+/* worktrees of this project — revealed on row hover (like .premove) so the resting
+   header keeps a single obvious action, ＋ */
+.pwtb { flex: none; font-size: 11px; color: var(--muted-2); padding: 0 1px; cursor: pointer; opacity: 0; transition: opacity .12s, color .12s; }
+.phead:hover .pwtb { opacity: .75; }
+.pwtb:hover { color: var(--text); opacity: 1; }
 .phead.empty-p .pname { color: var(--muted-2); font-weight: 550; }
 .phead.empty-p .pdot { opacity: .5; }
 .plaunch { flex: none; margin-left: auto; font-size: 10px; color: var(--muted-2); opacity: 0; transition: opacity .12s; }
@@ -535,8 +544,40 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .wt-list .wt-lbl { margin-bottom: 4px; }
 .wt-item { display: flex; align-items: center; gap: 8px; width: 100%; padding: 7px 10px; border-radius: 8px; cursor: pointer; border: 1px solid var(--hair); background: var(--surface); color: var(--text); text-align: left; }
 .wt-item:hover { border-color: var(--hair-strong); background: var(--surface-2); }
-.wt-br { font: 12px var(--font-mono); }
+.wt-br { font: 12px var(--font-mono); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .wt-open { margin-left: auto; font-size: 9.5px; letter-spacing: .06em; text-transform: uppercase; color: var(--muted-2); }
+
+/* existing-worktree rows: a row is a target (start a session here) carrying its own
+   state and a remove button, so the list doubles as the worktree manager */
+.wt-wt .wt-bmeta { margin-left: auto; display: flex; align-items: center; gap: 7px; flex: none; }
+.wt-wt .wt-open { margin-left: 0; }
+.wt-open.on { color: var(--st-done); cursor: pointer; }
+.wt-open.on:hover { text-decoration: underline; }
+.wt-tag { font: 9.5px var(--font-mono); color: var(--muted-2); padding: 0 5px; border-radius: 5px; border: 1px solid var(--hair); line-height: 16px; }
+.wt-tag.gone { color: var(--st-error); border-color: color-mix(in srgb, var(--st-error) 35%, transparent); }
+/* uncommitted work — the one thing removal would actually destroy, so it reads warm */
+.wt-dirty { font: 10px var(--font-mono); color: var(--st-working); }
+.wt-item.gone { opacity: .6; }
+.wt-item.gone:hover { opacity: .85; }
+.wt-rm { font-size: 10px; color: var(--muted-2); opacity: 0; padding: 0 2px; cursor: pointer; transition: opacity .12s, color .12s; }
+.wt-item:hover .wt-rm { opacity: .75; }
+.wt-rm:hover { color: var(--st-attention); opacity: 1; }
+
+/* skeleton rows while git answers — same box as a real row so nothing jumps when the
+   list lands. Inert: no hover lift, no pointer. */
+.wt-item.skel, .wt-item.skel:hover { cursor: default; border-color: var(--hair); background: var(--surface); }
+.wt-item.skel .sk { height: 10px; border-radius: 5px; background: var(--surface-2); }
+.wt-item.skel .sk-br { width: 44%; }
+.wt-item.skel .sk-meta { margin-left: auto; width: 20%; }
+/* stagger the widths so a stack of placeholders doesn't read as a rendered table */
+.wt-item.skel:nth-child(3) .sk-br { width: 32%; }
+.wt-item.skel:nth-child(4) .sk-br { width: 52%; }
+.wt-item.skel:nth-child(4) .sk-meta { width: 14%; }
+@media (prefers-reduced-motion: no-preference) {
+  .wt-item.skel .sk { animation: pulse 1.5s ease-in-out infinite; }
+  .wt-item.skel:nth-child(3) .sk { animation-delay: .12s; }
+  .wt-item.skel:nth-child(4) .sk { animation-delay: .24s; }
+}
 
 /* "Start here — no worktree" — the escape hatch, styled as a real primary-ish option
    (accent wash, full width, leads the dialog) so a worktree doesn't read as the only
@@ -717,3 +758,18 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 ::-webkit-scrollbar-thumb { background: var(--hair-strong); border-radius: 6px; border: 3px solid transparent; background-clip: content-box; }
 
 @media (max-width: 1080px) { .app, .app.insp-off { grid-template-columns: 224px minmax(0,1fr); } .insp { display: none; } }
+
+/* A control whose click kicked off an async decision — `requestLaunch` has to ask git
+   whether the folder is a repo before it knows whether to launch or offer worktrees,
+   and until that lands the click looks like it did nothing. The label goes transparent
+   rather than away, so the control keeps its exact size and nothing around it shifts,
+   and a spinner takes its place. Last in the file on purpose: it has to out-rank the
+   colour every one of those controls sets for itself, without reaching for !important. */
+.busy { position: relative; pointer-events: none; color: transparent; }
+.plaunch.busy { opacity: 1; }   /* hover-revealed at rest — but a spinner must be seen */
+.busy::after {
+  content: ""; position: absolute; left: 50%; top: 50%; width: 11px; height: 11px; margin: -6px 0 0 -6px;
+  border-radius: 50%; border: 1.5px solid var(--hair-strong); border-top-color: var(--accent);
+}
+@media (prefers-reduced-motion: no-preference) { .busy::after { animation: spin .7s linear infinite; } }
+@keyframes spin { to { transform: rotate(360deg); } }


### PR DESCRIPTION
The worktree dialog could only **create**. That left three gaps:

- **No removal at all** — cleanup meant dropping to a shell, so worktrees and their branches piled up in the picker forever.
- **No second session in an existing worktree** — clicking an existing row jumped to the session already there.
- **Unreachable without a running session** — both ways in (the `⑃ Worktree` toolbar button and `＋ Session`) require one, so a repo with nothing open had no route to its own worktrees.

## Backend

- `list_worktrees` now reports the state that decides what's safe: `dirty` (uncommitted entries), `unmerged` (commits the repo's HEAD lacks), `locked`, `exists`.
- **`remove_worktree`**, the inverse of `create_worktree`. Same design rule as `git_action` — *never destroy work the UI can't explain* — with the two kinds of loss guarded separately:
  - Uncommitted changes exist **only** in the checkout → removal is refused (`needs_force`) until the caller has been told the count.
  - Commits live on the **branch**, which `worktree remove` never touches → the branch is deleted only on request and only via `git branch -d`, **never `-D`**. Git stays the authority on mergedness; our `unmerged` count is just a UI hint.
  - Main worktree and locked worktrees are refused; a hand-deleted folder falls back to `prune`.

## Frontend

- Rows carry their own state — `n open`, `ext`, `●n` dirty, `↑n` unmerged, `locked`, `missing`, path in the tooltip — plus a hover `✕`.
- Removal asks first, spelling out what happens to the checkout **and** the branch, and refuses while sessions run inside. That guard has to be frontend-side: only it knows which panes point where.
- Clicking a row always starts a **new** session there (a second agent on one branch is a normal thing to want); the `n open` chip is what jumps to a running one.
- A per-project `⑃` on every sidebar header opens the manager with no session needed.
- **Loading is visible now:** skeleton rows while git answers (both lists cost several git calls — the worktree list probes each checkout, the branch list runs a `rev-list` per branch), a spinner on whichever control kicked off an async decision, and `Start here on <branch>` takes the branch `requestLaunch` already fetched instead of asking again and popping in a beat late.

## Testing

`cargo test` 8/8 — the new one covers dirty-refusal, forced removal, unmerged-branch survival, merged-branch cleanup and main-worktree refusal. `tsc` clean, `vite build` ok, vitest 12/12.

Also fixes a **latent flake** found on the way: parallel tests were deleting the *shared* `temp/.cc-worktrees` tree out from under each other, so `create_worktree_attaches_an_existing_branch` could make another test's checkout vanish mid-assertion.

⚠️ **Not verified visually** — per CLAUDE.md, anything touching the DOM needs the app run and exercised. The spin, the pulse and the skeleton widths are unconfirmed; the logic above is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
