### PR TITLE
New session: one searchable list of destinations, not four widgets

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,20 +108,38 @@
       <div class="pal-foot" id="palFoot"></div>
     </div>
 
-    <div class="wtdlg" id="wtDlg" role="dialog" aria-modal="true">
-      <div class="wt-h" id="wtH">New session</div>
-      <div class="wt-sub" id="wtSub"></div>
-      <!-- The no-worktree option leads, so a worktree reads as one choice, not the only one -->
-      <button class="wt-here" id="wtMain" hidden>Start here — no worktree</button>
-      <div class="wt-or" id="wtOr" hidden>or in a worktree</div>
-      <div class="wt-list" id="wtList" hidden></div>
-      <div class="wt-branches" id="wtBranchList" hidden></div>
-      <label class="wt-lbl" for="wtBranch">New branch <span class="wt-hint">or type any existing one</span></label>
-      <input class="wt-in" id="wtBranch" spellcheck="false" placeholder="feature-x" autocomplete="off" list="wtBranches" />
-      <datalist id="wtBranches"></datalist>
-      <div class="wt-btns">
-        <button class="wt-cancel" id="wtCancel">Cancel</button>
-        <button class="wt-go" id="wtGo">Create worktree ▸</button>
+    <!--
+      New session. Every answer to "where should this session run" is a directory, so
+      every answer is a row: the repo itself, its worktrees, its branches, and whatever
+      you type. One scroll region on the left, the consequences of the highlighted row
+      on the right. Head and foot are pinned — the list is the only thing that scrolls.
+    -->
+    <div class="wtdlg" id="wtDlg" role="dialog" aria-modal="true" aria-label="New session">
+      <div class="wt-head">
+        <div class="wt-title"><b>New session</b><span class="wt-proj" id="wtProj"></span></div>
+        <div class="wt-headrow">
+          <span class="wt-path" id="wtPath"></span>
+          <span class="wt-eng" id="wtEng"></span>
+          <button class="wt-chip" id="wtRefresh" type="button" title="Re-read worktrees and branches">
+            <span class="ic">⟳</span><span id="wtAge">now</span>
+          </button>
+        </div>
+      </div>
+      <div class="wt-q">
+        <span class="wt-caret">❯</span>
+        <input id="wtQ" spellcheck="false" autocomplete="off" aria-label="Filter destinations, or type a new branch name"
+               placeholder="Filter, or type a new branch name…" />
+        <span class="wt-count" id="wtCount"></span>
+      </div>
+      <div class="wt-body">
+        <div class="wt-list" id="wtList" role="listbox" aria-label="Session destinations"></div>
+        <div class="wt-detail" id="wtDetail" aria-live="polite"></div>
+      </div>
+      <div class="wt-foot">
+        <span><span class="k">↑</span><span class="k">↓</span> move</span>
+        <span><span class="k">⏎</span> <span class="wt-verb" id="wtVerb">start session</span></span>
+        <span class="sp"></span>
+        <span><span class="k">esc</span> close</span>
       </div>
     </div>
 
@@ -164,5 +182,9 @@
     <div class="menupop attnpop" id="attnPop"></div>
     <div class="menupop usagepop" id="usagePop"></div>
     <div class="menupop shortpop" id="shortPop"></div>
+    <!-- branch chooser for the new-session dialog (worktree base / root switch target).
+         Lives out here with its siblings, not inside #wtDlg: that dialog is
+         overflow:hidden, so an in-dialog popover would be clipped. -->
+    <div class="menupop bpop" id="bPop"></div>
   </body>
 </html>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1080,8 +1080,8 @@ fn set_caffeinate(state: State<AppState>, active: bool, flags: Vec<String>) -> R
 /// Create a git worktree with a new (or existing) branch off `repo_dir`.
 /// Returns the absolute worktree path. Worktrees live in a sibling
 /// `.cc-worktrees/<repo>/<branch>` folder so the repo stays clean.
-#[tauri::command]
-fn create_worktree(repo_dir: String, branch: String) -> Result<String, String> {
+#[tauri::command(async)]
+fn create_worktree(repo_dir: String, branch: String, base: Option<String>) -> Result<String, String> {
     // Every git call forces LC_ALL=C: we must never depend on localized output.
     // A German git says "existiert bereits", not "already exists" — parsing error
     // text for control flow (as this used to) silently broke worktree creation on
@@ -1121,8 +1121,26 @@ fn create_worktree(repo_dir: String, branch: String) -> Result<String, String> {
         .map(|o| o.status.success())
         .unwrap_or(false);
 
+    // `base` only means anything when we're CREATING the branch — attaching an existing
+    // one takes its own tip. Without it `worktree add -b` cuts from the repo's HEAD,
+    // which quietly makes whatever the root folder is parked on the parent of every new
+    // branch; passing a start-point is how the caller escapes that.
+    let base = base.map(|b| b.trim().to_string()).filter(|b| !b.is_empty());
+    if let Some(b) = base.as_deref() {
+        if !branch_exists {
+            let ok = git(&["-C", &root, "rev-parse", "--verify", "--quiet", &format!("{b}^{{commit}}")])
+                .map(|o| o.status.success())
+                .unwrap_or(false);
+            if !ok {
+                return Err(format!("can't branch from {b} — no such commit"));
+            }
+        }
+    }
+
     let add = if branch_exists {
         git(&["-C", &root, "worktree", "add", &wt_str, &safe])
+    } else if let Some(b) = base.as_deref() {
+        git(&["-C", &root, "worktree", "add", "-b", &safe, &wt_str, b])
     } else {
         git(&["-C", &root, "worktree", "add", "-b", &safe, &wt_str])
     }.map_err(|e| e.to_string())?;
@@ -1155,12 +1173,20 @@ struct Worktree {
     /// commits are an ancestor). Removing such a worktree — and safe-deleting its
     /// branch — loses nothing, so the UI can surface it as the obvious cleanup.
     merged: bool,
+    /// `git worktree lock` was used on this checkout. Git refuses to remove a locked
+    /// worktree even with `--force`, so without this flag the UI would hand the user
+    /// a `--force` command that also fails. Always false for the main worktree.
+    locked: bool,
+    /// The checkout directory is still on disk. A hand-deleted folder stays in
+    /// `.git/worktrees` until pruned, so it keeps appearing in this list — the UI must
+    /// not launch a PTY into it, and removal has to fall back to `prune`.
+    exists: bool,
 }
 
 /// List the git worktrees for a repo (parsed from `git worktree list --porcelain`).
 /// The first entry is the main working tree. Each linked worktree is enriched with
 /// `dirty` / `merged` cues so the picker can tell which are safe to clean up.
-#[tauri::command]
+#[tauri::command(async)]
 fn list_worktrees(repo_dir: String) -> Vec<Worktree> {
     let out = sys_command("git")
         .arg("-C").arg(&repo_dir).args(["worktree", "list", "--porcelain"])
@@ -1173,23 +1199,32 @@ fn list_worktrees(repo_dir: String) -> Vec<Worktree> {
     let mut res: Vec<Worktree> = Vec::new();
     let mut cur_path: Option<String> = None;
     let mut cur_branch = String::new();
-    let flush = |res: &mut Vec<Worktree>, path: Option<String>, branch: String| {
+    let mut cur_locked = false;
+    let flush = |res: &mut Vec<Worktree>, path: Option<String>, branch: String, locked: bool| {
         if let Some(path) = path {
             let is_main = res.is_empty();
-            res.push(Worktree { path, branch, is_main, dirty: false, merged: false });
+            let exists = std::path::Path::new(&path).is_dir();
+            res.push(Worktree {
+                path, branch, is_main, dirty: false, merged: false,
+                locked: locked && !is_main,
+                exists,
+            });
         }
     };
     for line in text.lines() {
         if let Some(p) = line.strip_prefix("worktree ") {
-            flush(&mut res, cur_path.take(), std::mem::take(&mut cur_branch));
+            flush(&mut res, cur_path.take(), std::mem::take(&mut cur_branch), std::mem::take(&mut cur_locked));
             cur_path = Some(p.to_string());
         } else if let Some(b) = line.strip_prefix("branch ") {
             cur_branch = b.strip_prefix("refs/heads/").unwrap_or(b).to_string();
         } else if line.starts_with("detached") {
             cur_branch = "(detached)".to_string();
+        } else if line == "locked" || line.starts_with("locked ") {
+            // `locked` appears bare, or as `locked <reason>`.
+            cur_locked = true;
         }
     }
-    flush(&mut res, cur_path.take(), cur_branch);
+    flush(&mut res, cur_path.take(), cur_branch, cur_locked);
 
     // Second pass: cleanliness cues for the linked worktrees. `merged` is measured
     // against the main worktree's branch. Every git call here is best-effort — any
@@ -1246,7 +1281,7 @@ fn same_path(a: &str, b: &str) -> bool {
 /// (close it first), and refuse the repo's main worktree. Beyond that, plain
 /// `git worktree remove` is the safety net — it declines a dirty/untracked tree on
 /// its own, so committed work is never at risk from a click.
-#[tauri::command]
+#[tauri::command(async)]
 fn remove_worktree(
     state: State<AppState>,
     repo_dir: String,
@@ -1274,12 +1309,38 @@ fn remove_worktree_impl(
 ) -> Result<GitActionResult, String> {
     let label = if branch.is_empty() { "worktree".to_string() } else { branch.to_string() };
 
-    if list_worktrees(repo_dir.to_string()).iter().any(|w| w.is_main && same_path(&w.path, path)) {
+    let listed = list_worktrees(repo_dir.to_string());
+    if listed.iter().any(|w| w.is_main && same_path(&w.path, path)) {
         return Err("that's the repo's main worktree — it can't be removed".into());
+    }
+    // A locked worktree is refused by git even WITH --force, so suggesting the force
+    // command (as the generic failure path below does) would just fail again. Name
+    // the actual next step instead.
+    if listed.iter().any(|w| w.locked && same_path(&w.path, path)) {
+        return Ok(GitActionResult {
+            ok: false,
+            summary: format!("{label} is locked — unlock it first"),
+            output: String::new(),
+            suggest: Some(format!("git worktree unlock \"{path}\" && git worktree remove \"{path}\"")),
+        });
     }
 
     let out = git_run(git_cmd(repo_dir, &["worktree", "remove", path]), 30)?;
     if !out.status.success() {
+        // The folder was deleted by hand: nothing to remove, only an administrative
+        // record in .git/worktrees. `prune` is the operation git actually wants here,
+        // and it can't lose work — the tree is already gone.
+        if !std::path::Path::new(path).is_dir() {
+            let pruned = git_run(git_cmd(repo_dir, &["worktree", "prune"]), 15)?;
+            if pruned.status.success() {
+                return Ok(GitActionResult {
+                    ok: true,
+                    summary: format!("Pruned {label} — its folder was already gone"),
+                    output: String::new(),
+                    suggest: None,
+                });
+            }
+        }
         let combined = [
             String::from_utf8_lossy(&out.stdout).trim().to_string(),
             String::from_utf8_lossy(&out.stderr).trim().to_string(),
@@ -1322,33 +1383,201 @@ fn remove_worktree_impl(
     Ok(GitActionResult { ok: true, summary: format!("Removed worktree {label}"), output: String::new(), suggest: None })
 }
 
+/// The tip commit of a checkout or a ref — what the new-session dialog's detail
+/// pane shows for whichever destination is highlighted.
+#[derive(serde::Serialize)]
+struct CommitInfo {
+    /// Abbreviated sha (`%h`).
+    short: String,
+    /// Subject line (`%s`).
+    subject: String,
+    /// Author name (`%an`).
+    author: String,
+    /// Committer date, relative (`%cr`) — "2 hours ago".
+    rel: String,
+}
+
+/// Tip commit of `rev` (a branch name, or HEAD when empty) as seen from `dir`.
+///
+/// Fetched for the *highlighted* row only, never for the whole list — a repo can
+/// have `BRANCH_LIST_CAP` branches plus every worktree, and one `git log` per row
+/// would cost far more than the pane is worth. NUL-separated so a subject
+/// containing any printable character still parses.
+#[tauri::command(async)]
+fn git_commit_info(dir: String, rev: String) -> Option<CommitInfo> {
+    let rev = if rev.trim().is_empty() { "HEAD".to_string() } else { rev };
+    let out = sys_command("git")
+        .env("LC_ALL", "C")
+        .arg("-C").arg(&dir)
+        .args(["--no-optional-locks", "log", "-1", "--format=%h%x00%s%x00%an%x00%cr", &rev])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    let mut parts = text.trim_end_matches('\n').split('\0');
+    let short = parts.next()?.to_string();
+    if short.is_empty() {
+        return None; // an unborn branch has no tip
+    }
+    Some(CommitInfo {
+        short,
+        subject: parts.next().unwrap_or("").to_string(),
+        author: parts.next().unwrap_or("").to_string(),
+        rel: parts.next().unwrap_or("").to_string(),
+    })
+}
+
+/// Move the repo's main working tree to another branch.
+///
+/// Muster's whole model is "don't switch, branch out" — worktrees exist so two pieces
+/// of work never fight over one checkout. But the root folder's branch is also the
+/// default parent of every new worktree, so a root parked somewhere stale is a real
+/// problem, and a terminal was the only way out. This is that lever, with the guards
+/// that make it safe to expose:
+///
+/// - Refused while Muster sessions run in the root: switching moves the ground under a
+///   live agent's cwd mid-edit.
+/// - Refused when the target is checked out in another worktree (git refuses too, but
+///   this says which one).
+/// - Refused on a dirty tree. `git switch` would silently CARRY uncommitted changes to
+///   the new branch — not destructive, but a state change the UI never explained, which
+///   is the same rule `git_action` and `remove_worktree` follow. Handed to a terminal.
+#[tauri::command(async)]
+fn switch_branch(state: State<AppState>, repo_dir: String, branch: String) -> Result<GitActionResult, String> {
+    if branch.trim().is_empty() {
+        return Err("no branch given".into());
+    }
+    if state.sessions.lock().unwrap().values().any(|s| same_path(&s.workdir, &repo_dir)) {
+        return Err("sessions are running in this folder — close them first".into());
+    }
+    if list_worktrees(repo_dir.clone()).iter()
+        .any(|w| !same_path(&w.path, &repo_dir) && w.branch == branch)
+    {
+        return Err(format!("{branch} is already checked out in another worktree"));
+    }
+
+    let status = git_run(git_cmd(&repo_dir, &["--no-optional-locks", "status", "--porcelain"]), 20)?;
+    if status.status.success() && !status.stdout.is_empty() {
+        return Ok(GitActionResult {
+            ok: false,
+            summary: "uncommitted changes — switching would carry them across".into(),
+            output: String::new(),
+            suggest: Some(format!("git switch \"{branch}\"")),
+        });
+    }
+
+    let out = git_run(git_cmd(&repo_dir, &["switch", &branch]), 30)?;
+    if out.status.success() {
+        return Ok(GitActionResult {
+            ok: true,
+            summary: format!("Switched to {branch}"),
+            output: String::new(),
+            suggest: None,
+        });
+    }
+    let combined = [
+        String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        String::from_utf8_lossy(&out.stderr).trim().to_string(),
+    ].iter().filter(|s| !s.is_empty()).cloned().collect::<Vec<_>>().join("\n");
+    let first = combined.lines().find(|l| !l.trim().is_empty()).unwrap_or("git refused").to_string();
+    Ok(GitActionResult {
+        ok: false,
+        summary: first,
+        output: combined,
+        suggest: Some(format!("git switch \"{branch}\"")),
+    })
+}
+
+/// Delete a local branch, the counterpart to the picker's worktree removal.
+///
+/// Same rule as `remove_worktree`: the destructive variant is NEVER run from a click.
+/// `git branch -d` refuses anything not fully merged, and on refusal we hand back the
+/// exact `-D` command for a terminal instead of running it.
+///
+/// Worth knowing about the common case this exists for — a branch whose upstream is
+/// `gone` (the PR merged, the remote branch was deleted). If that PR was **squash**-
+/// merged, the branch's commits never became ancestors of HEAD, so `-d` refuses even
+/// though the work is safely in main. That refusal is correct and the `-D` handoff is
+/// the honest answer; the UI warns about it before the click rather than after.
+#[tauri::command(async)]
+fn delete_branch(repo_dir: String, branch: String) -> Result<GitActionResult, String> {
+    if branch.trim().is_empty() {
+        return Err("no branch given".into());
+    }
+    // git refuses to delete a branch that some worktree holds; say so in our own words
+    // instead of surfacing its message, and name the fix.
+    if list_worktrees(repo_dir.clone()).iter().any(|w| w.branch == branch) {
+        return Err(format!("{branch} is checked out — remove its worktree first"));
+    }
+
+    let out = git_run(git_cmd(&repo_dir, &["branch", "-d", &branch]), 15)?;
+    if out.status.success() {
+        return Ok(GitActionResult {
+            ok: true,
+            summary: format!("Deleted branch {branch}"),
+            output: String::new(),
+            suggest: None,
+        });
+    }
+    let combined = [
+        String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        String::from_utf8_lossy(&out.stderr).trim().to_string(),
+    ].iter().filter(|s| !s.is_empty()).cloned().collect::<Vec<_>>().join("\n");
+    let first = combined.lines().find(|l| !l.trim().is_empty()).unwrap_or("git refused").to_string();
+    Ok(GitActionResult {
+        ok: false,
+        summary: first,
+        output: combined,
+        suggest: Some(format!("git branch -D \"{branch}\"")),
+    })
+}
+
 /// One local branch, with enough context for the worktree picker to tell whether
-/// it's worth starting on. `current` is the branch the repo's HEAD is on (offered
-/// as the "start here" button, not in the pick list). `checked_out` means some
-/// worktree already holds it — git refuses a second checkout, so it can't take a
-/// new worktree and instead appears in the existing-worktrees list. `ahead`/`behind`
-/// are versus the current HEAD; `rel`/`unix` describe the last commit (staleness).
+/// it's worth starting on. `current` is the branch the repo's HEAD is on (the repo
+/// row, not the pick list). `checked_out` means some worktree already holds it — git
+/// refuses a second checkout, so it can't take a new worktree and appears in the
+/// existing-worktrees list instead. `rel`/`unix` describe the last commit (staleness).
+///
+/// `ahead`/`behind` are versus this branch's OWN upstream, not versus HEAD. Measuring
+/// every branch against whatever happens to be checked out answers a question nobody
+/// asked ("how far behind my current work is this old branch" — always "very"), while
+/// the useful one is "is my work pushed, and has the remote moved on".
 #[derive(serde::Serialize, Debug)]
 struct BranchInfo {
     name: String,
     current: bool,
     checked_out: bool,
+    /// The remote-tracking ref this branch follows ("origin/foo"), empty when the
+    /// branch is purely local.
+    upstream: String,
+    /// Commits this branch has that its upstream doesn't — unpushed work. 0 when
+    /// there is no upstream.
     ahead: u32,
+    /// Commits the upstream has that this branch doesn't — unpulled work. 0 when
+    /// there is no upstream.
     behind: u32,
+    /// An upstream is configured but no longer exists on the remote (branch deleted
+    /// after a merge, typically). `upstream` still names it.
+    gone: bool,
     rel: String,
     unix: i64,
 }
 
 /// Local branches for the worktree picker, most-recently-committed first, each with
-/// staleness + ahead/behind context (see `BranchInfo`). Nothing is filtered here —
-/// the frontend hides `current` and `checked_out` from the pickable list; returning
-/// them with flags keeps the command honest and testable. Capped at BRANCH_LIST_CAP
-/// so a repo with hundreds of refs can't spawn an unbounded rev-list-per-ref; the cap
-/// keeps the newest branches, which is what the picker shows first anyway.
-#[tauri::command]
+/// staleness + upstream context (see `BranchInfo`). Nothing is filtered here — the
+/// frontend hides `current` and `checked_out` from the pickable list; returning them
+/// with flags keeps the command honest and testable. Capped at BRANCH_LIST_CAP so a
+/// repo with hundreds of refs can't blow the list up.
+///
+/// Everything comes out of ONE `for-each-ref`: `%(upstream:track)` makes git do the
+/// ahead/behind arithmetic itself, so this no longer spawns a `rev-list` per branch.
+#[tauri::command(async)]
 fn git_branch_list(repo_dir: String) -> Vec<BranchInfo> {
     const BRANCH_LIST_CAP: usize = 80;
-    // LC_ALL=C for the same reason as create_worktree: never depend on localized output.
+    // LC_ALL=C for the same reason as create_worktree: never depend on localized
+    // output — and here it also pins `%(upstream:track)` to English "ahead"/"behind".
     let git = |args: &[&str]| sys_command("git").env("LC_ALL", "C").args(args).output();
 
     let taken: std::collections::HashSet<String> =
@@ -1374,7 +1603,7 @@ fn git_branch_list(repo_dir: String) -> Vec<BranchInfo> {
         "-C", &repo_dir,
         "for-each-ref",
         "--sort=-committerdate",
-        "--format=%(refname:short)\t%(committerdate:unix)\t%(committerdate:relative)",
+        "--format=%(refname:short)\t%(committerdate:unix)\t%(committerdate:relative)\t%(upstream)\t%(upstream:short)\t%(upstream:track,nobracket)",
         "refs/heads",
     ]) {
         Ok(o) if o.status.success() => o,
@@ -1384,43 +1613,43 @@ fn git_branch_list(repo_dir: String) -> Vec<BranchInfo> {
 
     let mut res = Vec::new();
     for line in text.lines().take(BRANCH_LIST_CAP) {
-        let mut parts = line.splitn(3, '\t');
+        let mut parts = line.split('\t');
         let name = match parts.next() {
             Some(n) if !n.is_empty() => n.to_string(),
             _ => continue,
         };
         let unix = parts.next().and_then(|s| s.trim().parse().ok()).unwrap_or(0);
         let rel = parts.next().unwrap_or("").to_string();
-        let is_current = current.as_deref() == Some(name.as_str());
-
-        // ahead/behind vs current HEAD. `--left-right --count HEAD...<b>` prints
-        // "<left>\t<right>": left = commits in HEAD not in the branch (branch is that
-        // far *behind*), right = commits in the branch not in HEAD (branch *ahead*).
-        // The current branch is definitionally 0/0, so skip the extra process for it.
-        let (mut ahead, mut behind) = (0u32, 0u32);
-        if !is_current {
-            if let Ok(o) = git(&["-C", &repo_dir, "rev-list", "--left-right", "--count",
-                &format!("HEAD...refs/heads/{name}")]) {
-                if o.status.success() {
-                    let s = String::from_utf8_lossy(&o.stdout);
-                    let mut it = s.split_whitespace();
-                    behind = it.next().and_then(|x| x.parse().ok()).unwrap_or(0);
-                    ahead = it.next().and_then(|x| x.parse().ok()).unwrap_or(0);
-                }
-            }
-        }
+        // An upstream is only interesting if it is a REMOTE. `git branch`/`checkout -b`
+        // off a local branch can set that local branch as the upstream (depending on
+        // branch.autoSetupMerge), and "2 commits not pushed to dev" is nonsense — dev is
+        // right here. Gate on the full refname; only refs/remotes/* counts.
+        let is_remote = parts.next().unwrap_or("").trim().starts_with("refs/remotes/");
+        let upstream = if is_remote { parts.next().unwrap_or("").trim().to_string() } else { parts.next(); String::new() };
+        // `%(upstream:track,nobracket)` is "" when in sync (or absent), "gone" when the
+        // upstream was deleted, else "ahead 2", "behind 3" or "ahead 2, behind 3".
+        let track = if is_remote { parts.next().unwrap_or("").trim() } else { parts.next(); "" };
+        let gone = track == "gone";
+        let field = |key: &str| -> u32 {
+            track.split(',')
+                .filter_map(|p| p.trim().strip_prefix(key))
+                .filter_map(|n| n.trim().parse().ok())
+                .next()
+                .unwrap_or(0)
+        };
+        let (ahead, behind) = if gone { (0, 0) } else { (field("ahead "), field("behind ")) };
 
         res.push(BranchInfo {
             checked_out: taken.contains(&name),
-            current: is_current,
-            name, ahead, behind, rel, unix,
+            current: current.as_deref() == Some(name.as_str()),
+            name, upstream, ahead, behind, gone, rel, unix,
         });
     }
     res
 }
 
 /// Current git branch for a working directory (None if not a repo / detached).
-#[tauri::command]
+#[tauri::command(async)]
 fn git_branch(workdir: String) -> Option<String> {
     let out = sys_command("git")
         .arg("-C")
@@ -1447,7 +1676,7 @@ struct HeadInfo {
 /// *actually* checked out rather than the one a worktree was created with (a
 /// worktree shows whatever branch is checked out, and that can change). Returns
 /// None if the dir isn't a git repo. LC_ALL=C keeps output locale-independent.
-#[tauri::command]
+#[tauri::command(async)]
 fn git_head(workdir: String) -> Option<HeadInfo> {
     let git = |args: &[&str]| {
         sys_command("git")
@@ -1615,7 +1844,7 @@ struct DiffStat {
 /// has no commits yet. LC_ALL=C + numeric numstat keep it locale-independent (the
 /// german-git-locale gotcha) and `--no-optional-locks` avoids fighting a running
 /// `git` in the same worktree.
-#[tauri::command]
+#[tauri::command(async)]
 fn git_diffstat(workdir: String) -> Option<DiffStat> {
     let git = |args: &[&str]| {
         sys_command("git")
@@ -1741,7 +1970,7 @@ struct GitActionResult {
 ///
 /// Every op is safe against a live Claude in the same worktree: fetch and push
 /// don't touch the working tree at all, and ff-only pull won't overwrite edits.
-#[tauri::command]
+#[tauri::command(async)]
 fn git_action(workdir: String, op: String) -> Result<GitActionResult, String> {
     if !std::path::Path::new(&workdir).is_dir() {
         return Err(format!("not a directory: {workdir}"));
@@ -1868,7 +2097,7 @@ struct Resources {
 /// session id's stored pid. Measures the `claude` process itself (not its whole
 /// subtree) — enough for the inspector's "what's this costing my machine" readout.
 /// None for external/shell sessions (no owned pid) or a process that has exited.
-#[tauri::command]
+#[tauri::command(async)]
 fn session_resources(state: State<AppState>, session_id: String) -> Option<Resources> {
     let pid = state.sessions.lock().unwrap().get(&session_id)?.pid?;
     let line = ps_one(pid, "%cpu=,rss=")?;
@@ -2172,7 +2401,7 @@ fn parse_registry_entry(txt: &str) -> Option<ExternalSession> {
 /// set of session ids Muster already owns (belt-and-suspenders — ours don't
 /// register anyway). Dead/stale registry files are filtered by verifying the pid
 /// is still a live `claude` process.
-#[tauri::command]
+#[tauri::command(async)]
 fn list_external_sessions(state: State<AppState>, exclude: Vec<String>) -> Vec<ExternalSession> {
     let home = home_dir();
     if home.is_empty() {
@@ -2346,7 +2575,7 @@ struct PastSession {
 /// chain: `ai-title` → `last-prompt` → first user message → "" (caller labels it).
 /// Only the tail is scanned — `ai-title` recurs throughout the file, so a bounded
 /// read reliably catches the latest one without paying for a 4MB transcript.
-#[tauri::command]
+#[tauri::command(async)]
 fn list_past_sessions(workdir: String) -> Result<Vec<PastSession>, String> {
     let dir = match project_transcript_dir(&workdir) {
         Some(d) => d,
@@ -2637,7 +2866,7 @@ fn scan_usage(days: u64) -> Result<Vec<DayUsage>, String> {
 /// cwd with every non-alphanumeric char replaced by `-`. Only the tail (≤512KB)
 /// is read; only human/assistant prose is extracted (tool calls, tool results and
 /// thinking are dropped), and the last `limit` messages are returned.
-#[tauri::command]
+#[tauri::command(async)]
 fn read_transcript(cwd: String, session_id: String, limit: usize) -> Result<Vec<TranscriptMsg>, String> {
     use std::io::{BufRead, BufReader, Seek, SeekFrom};
     let path = project_transcript_dir(&cwd)
@@ -3011,6 +3240,9 @@ pub fn run() {
             list_worktrees,
             remove_worktree,
             git_branch_list,
+            delete_branch,
+            switch_branch,
+            git_commit_info,
             spawn_ghostty,
             spawn_shell,
             available_terminals,
@@ -3118,6 +3350,18 @@ mod tests {
         dir
     }
 
+    /// Where `create_worktree` puts this repo's checkouts: `<parent>/.cc-worktrees/<repo>`.
+    ///
+    /// Tests MUST clean up via this and never via `<parent>/.cc-worktrees` — `scratch_dir`
+    /// hands every repo the same parent (the OS temp dir), so wiping the whole
+    /// `.cc-worktrees` tree deletes the checkouts of every test running in parallel,
+    /// which made these two flake against each other.
+    fn wt_root(repo: &Path) -> PathBuf {
+        repo.parent().unwrap()
+            .join(".cc-worktrees")
+            .join(repo.file_name().unwrap())
+    }
+
     /// Run a git command in `dir`, asserting success. Identity/signing are passed via
     /// `-c` so the test doesn't depend on (or touch) the developer's global gitconfig.
     fn git(dir: &Path, args: &[&str]) {
@@ -3165,26 +3409,39 @@ mod tests {
     /// The picker leans on these flags to decide what's pickable: it hides `current`
     /// (the "start here" button) and `checked_out` (git refuses a second checkout, so
     /// those sit in the existing-worktrees list instead). ahead/behind must be
-    /// oriented from the branch's point of view versus the current HEAD.
+    /// The picker's branch context: which branches are claimed, and how each stands
+    /// against ITS OWN upstream — not against whatever HEAD happens to be.
     #[test]
-    fn git_branch_list_flags_state_and_orients_ahead_behind() {
+    fn git_branch_list_flags_state_and_tracks_each_upstream() {
         let dir = scratch_dir();
+        let remote = scratch_dir();
+        git(&remote, &["init", "-q", "--bare", "-b", "dev"]);
         git(&dir, &["init", "-q", "-b", "dev"]);
         let commit = |dir: &Path, msg: &str| git(dir, &["-c", "user.email=t@example.com", "-c", "user.name=T", "-c", "commit.gpgsign=false", "commit", "-q", "--allow-empty", "-m", msg]);
         commit(&dir, "base");
-        git(&dir, &["branch", "test"]);
-        git(&dir, &["branch", "feature-x"]);
+        git(&dir, &["remote", "add", "origin", remote.to_str().unwrap()]);
+        git(&dir, &["push", "-q", "-u", "origin", "dev"]);
 
-        // feature-x gains 2 commits; dev then gains 1 → feature-x is 2 ahead, 1 behind.
-        git(&dir, &["checkout", "-q", "feature-x"]);
-        commit(&dir, "fx1");
-        commit(&dir, "fx2");
+        // pushed-then-moved: tracks origin/pushed, 2 commits unpushed.
+        git(&dir, &["checkout", "-q", "-b", "pushed"]);
+        git(&dir, &["push", "-q", "-u", "origin", "pushed"]);
+        commit(&dir, "p1");
+        commit(&dir, "p2");
+
+        // local-only: never pushed, so no upstream at all.
+        git(&dir, &["checkout", "-q", "-b", "local-only"]);
+        commit(&dir, "l1");
+
+        // orphaned: had an upstream, which was then deleted on the remote.
+        git(&dir, &["checkout", "-q", "-b", "orphaned"]);
+        git(&dir, &["push", "-q", "-u", "origin", "orphaned"]);
+        git(&dir, &["push", "-q", "origin", "--delete", "orphaned"]);
+        git(&dir, &["fetch", "-q", "--prune", "origin"]);
+
         git(&dir, &["checkout", "-q", "dev"]);
-        commit(&dir, "dev1");
-
-        // Claim `test` with a worktree; `dev` is claimed by the main working tree.
-        let wt = dir.join("wt-test");
-        git(&dir, &["worktree", "add", "-q", wt.to_str().unwrap(), "test"]);
+        git(&dir, &["branch", "claimed"]);
+        let wt = dir.join("wt-claimed");
+        git(&dir, &["worktree", "add", "-q", wt.to_str().unwrap(), "claimed"]);
 
         let bs = git_branch_list(dir.to_str().unwrap().to_string());
         let by = |n: &str| bs.iter().find(|b| b.name == n).unwrap_or_else(|| panic!("{n} missing from {bs:?}"));
@@ -3192,11 +3449,105 @@ mod tests {
         // dev is `current`; it's also `checked_out` because the main working tree holds
         // it — the frontend hides it via `current`, so that overlap is harmless.
         assert!(by("dev").current, "dev should be current: {bs:?}");
-        assert!(by("test").checked_out && !by("test").current, "test should be checked_out: {bs:?}");
-        let fx = by("feature-x");
-        assert!(!fx.current && !fx.checked_out, "feature-x should be free: {bs:?}");
-        assert_eq!((fx.ahead, fx.behind), (2, 1), "feature-x should be 2 ahead / 1 behind dev: {bs:?}");
+        assert!(by("claimed").checked_out && !by("claimed").current, "claimed should be checked_out: {bs:?}");
+        assert!(!by("pushed").current && !by("pushed").checked_out, "pushed should be free: {bs:?}");
 
+        // Ahead is measured against origin/pushed, NOT against dev — dev has moved on
+        // its own and that must not leak into this branch's numbers.
+        let p = by("pushed");
+        assert_eq!(p.upstream, "origin/pushed", "pushed should track its own remote: {bs:?}");
+        assert_eq!((p.ahead, p.behind), (2, 0), "pushed should be 2 unpushed / 0 unpulled: {bs:?}");
+        assert!(!p.gone);
+
+        let l = by("local-only");
+        assert!(l.upstream.is_empty() && !l.gone, "local-only has no upstream: {bs:?}");
+        assert_eq!((l.ahead, l.behind), (0, 0), "no upstream means no counts: {bs:?}");
+
+        let o = by("orphaned");
+        assert!(o.gone, "orphaned's upstream was deleted: {bs:?}");
+        assert_eq!(o.upstream, "origin/orphaned", "a gone upstream is still named: {bs:?}");
+
+        let _ = std::fs::remove_dir_all(wt_root(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_dir_all(&remote);
+    }
+    /// Without a start-point, `worktree add -b` cuts from HEAD — which makes whatever
+    /// the root folder is parked on the silent parent of every new branch. Pin the
+    /// escape hatch down.
+    #[test]
+    fn create_worktree_branches_from_the_given_base() {
+        let dir = scratch_dir();
+        git(&dir, &["init", "-q", "-b", "main"]);
+        let commit = |msg: &str| git(&dir, &["-c", "user.email=t@example.com", "-c", "user.name=T", "-c", "commit.gpgsign=false", "commit", "-q", "--allow-empty", "-m", msg]);
+        commit("on main");
+        let repo = dir.to_str().unwrap().to_string();
+        let main_tip = String::from_utf8_lossy(
+            &Command::new("git").current_dir(&dir).args(["rev-parse", "HEAD"]).output().unwrap().stdout
+        ).trim().to_string();
+
+        // Park the root on a feature branch that has moved past main.
+        git(&dir, &["checkout", "-q", "-b", "parked"]);
+        commit("only on parked");
+
+        // No base → inherits HEAD, i.e. `parked`. This is the trap.
+        let inherit = create_worktree(repo.clone(), "from-head".into(), None).expect("default base");
+        let p = String::from_utf8_lossy(
+            &Command::new("git").current_dir(&inherit).args(["rev-parse", "HEAD"]).output().unwrap().stdout
+        ).trim().to_string();
+        assert_ne!(p, main_tip, "with no base the new branch cuts from the parked HEAD");
+
+        // Explicit base → main's tip, regardless of where the root is parked.
+        let based = create_worktree(repo.clone(), "from-main".into(), Some("main".into())).expect("explicit base");
+        let b = String::from_utf8_lossy(
+            &Command::new("git").current_dir(&based).args(["rev-parse", "HEAD"]).output().unwrap().stdout
+        ).trim().to_string();
+        assert_eq!(b, main_tip, "an explicit base wins over HEAD");
+
+        // A base that doesn't resolve is refused before git can emit anything cryptic.
+        let e = create_worktree(repo, "from-nowhere".into(), Some("no-such-ref".into())).expect_err("bad base refused");
+        assert!(e.contains("no such commit"), "the message should name the problem: {e}");
+
+        let _ = std::fs::remove_dir_all(wt_root(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Branch deletion mirrors worktree removal: safe-delete only, force handed off.
+    #[test]
+    fn delete_branch_safe_deletes_merged_and_refuses_the_rest() {
+        let dir = scratch_dir();
+        git(&dir, &["init", "-q", "-b", "dev"]);
+        let commit = |dir: &Path, msg: &str| git(dir, &["-c", "user.email=t@example.com", "-c", "user.name=T", "-c", "commit.gpgsign=false", "commit", "-q", "--allow-empty", "-m", msg]);
+        commit(&dir, "base");
+        let repo = dir.to_str().unwrap().to_string();
+
+        // merged: branched and never advanced, so its commits are all in dev.
+        git(&dir, &["branch", "merged-b"]);
+        // unmerged: has a commit dev doesn't.
+        git(&dir, &["checkout", "-q", "-b", "unmerged-b"]);
+        commit(&dir, "only-here");
+        git(&dir, &["checkout", "-q", "dev"]);
+        // held: claimed by a worktree.
+        git(&dir, &["branch", "held-b"]);
+        let wt = dir.join("wt-held");
+        git(&dir, &["worktree", "add", "-q", wt.to_str().unwrap(), "held-b"]);
+
+        let r = delete_branch(repo.clone(), "merged-b".into()).expect("merged deletes");
+        assert!(r.ok && r.suggest.is_none(), "a merged branch should just go: {r:?}");
+        let b = Command::new("git").current_dir(&dir).args(["branch", "--list", "merged-b"]).output().unwrap();
+        assert!(String::from_utf8_lossy(&b.stdout).trim().is_empty(), "merged-b should be gone");
+
+        // Unmerged: refused, branch survives, `-D` offered rather than run.
+        let r = delete_branch(repo.clone(), "unmerged-b".into()).expect("call returns");
+        assert!(!r.ok, "an unmerged branch must be refused: {r:?}");
+        assert!(r.suggest.as_deref().unwrap_or("").contains("branch -D"), "force should be handed off: {r:?}");
+        let b = Command::new("git").current_dir(&dir).args(["branch", "--list", "unmerged-b"]).output().unwrap();
+        assert!(!String::from_utf8_lossy(&b.stdout).trim().is_empty(), "unmerged-b must survive");
+
+        // Checked out somewhere: refused up front, in our words.
+        let e = delete_branch(repo, "held-b".into()).expect_err("a checked-out branch is refused");
+        assert!(e.contains("checked out"), "the message should name the reason: {e}");
+
+        let _ = std::fs::remove_dir_all(wt_root(&dir));
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -3209,7 +3560,7 @@ mod tests {
         git(&dir, &["-c", "user.email=t@example.com", "-c", "user.name=T", "-c", "commit.gpgsign=false", "commit", "-q", "--allow-empty", "-m", "init"]);
         git(&dir, &["branch", "test"]);
 
-        let path = create_worktree(dir.to_str().unwrap().to_string(), "test".into()).expect("attach failed");
+        let path = create_worktree(dir.to_str().unwrap().to_string(), "test".into(), None).expect("attach failed");
         let head = Command::new("git").current_dir(&path).args(["rev-parse", "--abbrev-ref", "HEAD"]).output().unwrap();
         assert_eq!(String::from_utf8_lossy(&head.stdout).trim(), "test");
 
@@ -3219,7 +3570,7 @@ mod tests {
         assert_eq!(String::from_utf8_lossy(&orig.stdout).trim(), "dev");
 
         // Worktrees land in a *sibling* .cc-worktrees tree, never inside the repo.
-        let _ = std::fs::remove_dir_all(dir.parent().unwrap().join(".cc-worktrees"));
+        let _ = std::fs::remove_dir_all(wt_root(&dir));
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -3237,10 +3588,10 @@ mod tests {
 
         // Three linked worktrees: one at dev's tip (merged, clean), one advanced past
         // dev (unmerged), and one with an untracked file (dirty).
-        let merged = create_worktree(repo.clone(), "merged-wt".into()).expect("merged worktree");
-        let ahead = create_worktree(repo.clone(), "ahead-wt".into()).expect("ahead worktree");
+        let merged = create_worktree(repo.clone(), "merged-wt".into(), None).expect("merged worktree");
+        let ahead = create_worktree(repo.clone(), "ahead-wt".into(), None).expect("ahead worktree");
         commit(Path::new(&ahead), "extra");
-        let dirty = create_worktree(repo.clone(), "dirty-wt".into()).expect("dirty worktree");
+        let dirty = create_worktree(repo.clone(), "dirty-wt".into(), None).expect("dirty worktree");
         std::fs::write(Path::new(&dirty).join("scratch.txt"), "wip\n").unwrap();
 
         let wts = list_worktrees(repo.clone());
@@ -3271,7 +3622,79 @@ mod tests {
         assert!(!r.ok && r.suggest.as_deref().unwrap_or("").contains("--force"), "dirty removal should be refused with a force handoff: {r:?}");
         assert!(Path::new(&dirty).exists(), "dirty worktree must not be clobbered");
 
-        let _ = std::fs::remove_dir_all(dir.parent().unwrap().join(".cc-worktrees"));
+        let _ = std::fs::remove_dir_all(wt_root(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The two states the new-session dialog needs but `git worktree remove` handles
+    /// badly on its own: a LOCKED worktree (git refuses it even with `--force`, so
+    /// suggesting force would just fail again) and a worktree whose folder was deleted
+    /// by hand (nothing to remove — `prune` is what git actually wants).
+    #[test]
+    fn worktree_locked_and_missing_are_reported_and_handled() {
+        let dir = scratch_dir();
+        git(&dir, &["init", "-q", "-b", "dev"]);
+        git(&dir, &["-c", "user.email=t@example.com", "-c", "user.name=T", "-c", "commit.gpgsign=false",
+                    "commit", "-q", "--allow-empty", "-m", "base"]);
+        let repo = dir.to_str().unwrap().to_string();
+
+        let locked = create_worktree(repo.clone(), "locked-wt".into(), None).expect("locked worktree");
+        let gone = create_worktree(repo.clone(), "gone-wt".into(), None).expect("gone worktree");
+        git(&dir, &["worktree", "lock", &locked]);
+        std::fs::remove_dir_all(&gone).expect("hand-delete the checkout");
+
+        let wts = list_worktrees(repo.clone());
+        let by = |b: &str| wts.iter().find(|w| w.branch == b).unwrap_or_else(|| panic!("{b} missing from {wts:?}"));
+        assert!(by("locked-wt").locked, "locked-wt should report locked: {wts:?}");
+        assert!(by("locked-wt").exists, "locked-wt is still on disk: {wts:?}");
+        assert!(!by("gone-wt").exists, "gone-wt's folder was deleted: {wts:?}");
+        assert!(!wts.iter().any(|w| w.is_main && w.locked), "the main worktree is never locked");
+
+        // Locked: refused with an unlock handoff, NOT a --force one that would also fail.
+        let r = remove_worktree_impl(&repo, &locked, "locked-wt", false).expect("call returns");
+        let suggest = r.suggest.as_deref().unwrap_or("");
+        assert!(!r.ok, "a locked worktree must be refused: {r:?}");
+        assert!(suggest.contains("worktree unlock") && !suggest.contains("--force"),
+            "locked handoff should unlock, not force: {r:?}");
+        assert!(Path::new(&locked).exists(), "locked worktree must survive the refusal");
+
+        // Hand-deleted folder: pruned, and it leaves the listing.
+        let r = remove_worktree_impl(&repo, &gone, "gone-wt", false).expect("call returns");
+        assert!(r.ok, "a vanished worktree should prune cleanly: {r:?}");
+        assert!(!list_worktrees(repo.clone()).iter().any(|w| w.branch == "gone-wt"),
+            "gone-wt should be pruned out of the listing");
+
+        git(&dir, &["worktree", "unlock", &locked]);
+        let _ = std::fs::remove_dir_all(wt_root(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The detail pane's HEAD line. Parsing is NUL-separated so a subject containing
+    /// spaces (or anything else printable) survives the round trip.
+    #[test]
+    fn git_commit_info_reads_the_tip_of_a_dir_or_a_ref() {
+        let dir = scratch_dir();
+        git(&dir, &["init", "-q", "-b", "dev"]);
+        let commit = |msg: &str| git(&dir, &["-c", "user.email=t@example.com", "-c", "user.name=Ada L",
+                                             "-c", "commit.gpgsign=false", "commit", "-q", "--allow-empty", "-m", msg]);
+        commit("base subject with spaces");
+        let repo = dir.to_str().unwrap().to_string();
+
+        let head = git_commit_info(repo.clone(), String::new()).expect("HEAD resolves");
+        assert_eq!(head.subject, "base subject with spaces", "the whole subject survives");
+        assert_eq!(head.author, "Ada L");
+        assert!(!head.short.is_empty() && !head.rel.is_empty(), "sha and relative date are filled: {head:?}",
+            head = (&head.short, &head.rel));
+
+        // A named ref resolves independently of what HEAD points at.
+        git(&dir, &["branch", "side"]);
+        commit("moved dev on");
+        let side = git_commit_info(repo.clone(), "side".into()).expect("side resolves");
+        assert_eq!(side.subject, "base subject with spaces", "side still points at the first commit");
+        assert_ne!(git_commit_info(repo.clone(), String::new()).unwrap().short, side.short,
+            "HEAD has moved past side");
+
+        assert!(git_commit_info(repo, "no-such-ref".into()).is_none(), "an unknown ref yields None");
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -536,10 +536,26 @@ async function launch(project: string, workdir: string, opts: { colorKey?: strin
 }
 
 // Offer a worktree when launching into a repo that already has a session.
-async function requestLaunch(project: string, path: string) {
-  if ([...sessions.values()].some((s) => s.colorKey === path)) {
-    const br = await invoke<string | null>("git_branch", { workdir: path });
-    if (br) { openWt(project, path, true); return; }
+// Deliberately synchronous: NOTHING may be awaited before the dialog is on screen.
+// This used to `await git_branch` first, and because Tauri runs non-async commands on
+// the main thread, that one call queued behind whatever git work was already in flight
+// (the 3s/4s/5s pollers, or worse a `fetch`) — so "+ Session" felt dead for as long as
+// that took. Everything needed to decide is already in memory:
+//   • a live session in this repo carries `branch` (set at launch, refreshed every 4s)
+//   • an external session carries the branch the registry reported
+//   • dirtyByFolder holds a non-null diffstat for anything that IS a git repo
+// so repo-ness and the branch label both come for free, with zero IPC.
+function requestLaunch(project: string, path: string) {
+  // "Is anything already running here?" must include EXTERNAL sessions: they live in
+  // their own array, not in `sessions`, so checking only the map sent a click straight
+  // to a bare launch in the repo root even when the dialog was the obvious answer.
+  const sess = [...sessions.values()].find((s) => s.colorKey === path);
+  const ext = externals.find((e) => (e.repo_root || e.cwd) === path);
+  if (sess || ext) {
+    const branch = sess?.branch || ext?.branch || "";
+    // Only offer the worktree dialog for an actual repo — otherwise there is nothing
+    // to branch and a plain launch is the honest answer, exactly as before.
+    if (branch || dirtyByFolder.get(path) != null) { openWt(project, path, branch); return; }
   }
   launch(project, path, { colorKey: path });
 }
@@ -1079,7 +1095,15 @@ function splitByWorktree(list: ProjGroup[]): ProjGroup[] {
   }
   return out;
 }
-function projectList(): ProjGroup[] {
+// Every project Muster knows about: the favourites, plus any repo discovered from a
+// live session, an external (non-Muster) session, or a dormant one. Unsorted and never
+// worktree-split — callers that need order or splitting layer it on.
+//
+// The sidebar and the launch palette MUST agree on this set. Building the palette from
+// FAVORITES alone silently hid every externally-detected project, so pressing
+// "+ Session" with nothing selected offered an arbitrary-looking subset of what the
+// sidebar was showing.
+function allProjects(): ProjGroup[] {
   const list: ProjGroup[] = FAVORITES.map((f) => ({ name: f.name, path: f.path, accent: accentFor(f.path), sessions: [], externals: [], dormants: [] }));
   const byName = new Map(list.map((p) => [p.name, p]));
   const byPath = new Map(list.map((p) => [p.path, p]));
@@ -1101,6 +1125,10 @@ function projectList(): ProjGroup[] {
     if (!p) { p = { name: d.project, path: d.colorKey, accent: accentFor(d.colorKey), sessions: [], externals: [], dormants: [] }; list.push(p); byName.set(d.project, p); byPath.set(d.colorKey, p); }
     p.dormants.push(d);
   }
+  return list;
+}
+function projectList(): ProjGroup[] {
+  const list = allProjects();
   // Sort sessions within each project first, then (in toplevel mode) split by
   // worktree so each split group inherits the sorted order, then order the groups.
   const sessCmp = sortMode === "active" ? (a: Sess, b: Sess) => b.lastActivity - a.lastActivity
@@ -2317,7 +2345,7 @@ function sessionActions(s: Sess): PalItem[] {
       a.push(mk(ah ? `Push ${ah} commit${ah === 1 ? "" : "s"}` : "Push", "↑", () => runGit(s.id, "push")));
     }
     a.push(mk("Open a terminal here", "❯", () => { setActive(s.id); openPlainTerminal(); }));
-    a.push(mk("New worktree from here", "⑃", () => openWt(s.project, s.colorKey, false)));
+    a.push(mk("New session here…", "⑃", () => openWt(s.project, s.colorKey)));
     // Only when this session lives in a worktree (not the repo's main checkout):
     // clean up its worktree (and merged branch) without dropping to a shell.
     if (s.worktree) a.push(mk("Remove this worktree…", "⌫", () => removeWorktreeSession(s)));
@@ -2355,7 +2383,10 @@ function buildPalGroups(raw: string): PalGroup[] {
     const sub = s.shell ? "shell" : `${verbFor(s).toLowerCase()}${s.ctxPct != null ? ` · ${Math.round(s.ctxPct)}% ctx` : ""}${s.cost != null ? ` · $${s.cost.toFixed(2)}` : ""}`;
     return { kind: "session", key: "session:" + s.id, label, labelHtml: esc(label), sub, sw: accentFor(s.colorKey), icon: iconFor(s.colorKey) || undefined, shortcut: i != null && i < 9 ? [MOD, String(i + 1)] : undefined, session: s, run: () => setActive(s.id) };
   });
-  const launchCands: PalItem[] = FAVORITES.map((f) => ({ kind: "launch", key: "launch:" + f.path, label: `Launch ${f.name}`, labelHtml: esc(`Launch ${f.name}`), sub: tilde(f.path), sw: accentFor(f.path), icon: iconFor(f.path) || undefined, run: () => requestLaunch(f.name, f.path) }));
+  // Same source as the sidebar (see allProjects) — a project detected from an external
+  // session is just as launchable as a favourite, and hiding it here made "+ Session"
+  // with nothing selected look like it was picking projects at random.
+  const launchCands: PalItem[] = allProjects().map((p) => ({ kind: "launch", key: "launch:" + p.path, label: `Launch ${p.name}`, labelHtml: esc(`Launch ${p.name}`), sub: tilde(p.path), sw: accentFor(p.path), icon: iconFor(p.path) || undefined, run: () => requestLaunch(p.name, p.path) }));
   const cmdCands: PalItem[] = PAL_CMDS.map((c) => ({ kind: "command", key: c.key, label: c.label, labelHtml: esc(c.label), sub: "command", glyph: c.glyph, shortcut: c.sc, run: c.run }));
   for (const id of availEngines) { const d = engineDef(id); cmdCands.push({ kind: "command", key: "engine:" + id, label: `New sessions in ${d.label}${id === termEngine ? " ✓" : ""}`, labelHtml: esc(`New sessions in ${d.label}${id === termEngine ? " ✓" : ""}`), sub: d.sub, glyph: id === "embedded" ? "▤" : "⧉", run: () => setEngine(id) }); }
 
@@ -2442,152 +2473,804 @@ function bumpFont(d: number) { termFontSize = Math.max(8, Math.min(28, termFontS
 let toastT: number | undefined;
 function toast(m: string) { const el = $("toast"); el.textContent = m; el.classList.add("show"); clearTimeout(toastT); toastT = window.setTimeout(() => el.classList.remove("show"), 1900); }
 
-// ---------- worktree dialog ----------
-let wtCtx: { project: string; repoDir: string } | null = null;
-type BranchInfo = { name: string; current: boolean; checked_out: boolean; ahead: number; behind: number; rel: string; unix: number };
-type WtInfo = { path: string; branch: string; is_main: boolean; dirty: boolean; merged: boolean };
+// ---------- new-session dialog ----------
+// Every answer to "where should this session run?" is a directory, so every answer
+// is a row: the repo itself, its worktrees, its branches, and whatever you type.
+// One list on the left; the consequences of the highlighted row on the right.
+//
+// The repo row is unconditional — the old dialog only offered the main checkout when
+// `requestLaunch` opened it, so the toolbar button, the context menu and the action
+// panel each led to a dialog that couldn't start a session in the project itself.
+// ahead/behind are versus this branch's OWN remote upstream (empty when it has none),
+// not versus whatever HEAD is on — see the BranchInfo doc comment in lib.rs.
+type BranchInfo = { name: string; current: boolean; checked_out: boolean; upstream: string; ahead: number; behind: number; gone: boolean; rel: string; unix: number };
+type WtInfo = { path: string; branch: string; is_main: boolean; dirty: boolean; merged: boolean; locked: boolean; exists: boolean };
+type CommitInfo = { short: string; subject: string; author: string; rel: string };
 
-async function openWt(project: string, repoDir: string, allowMain: boolean) {
+type DestKind = "repo" | "wt" | "branch" | "create";
+interface Dest {
+  kind: DestKind;
+  group: string;          // "" pins the row above every group (the create row)
+  ic: string;
+  label: string;          // primary line
+  sub: string;            // secondary line ("" = none)
+  dir: string;            // the directory this destination runs in (or would create)
+  branch: string;         // "" when the checkout is detached
+  tags: [string, string][];
+  meta: string;           // right-aligned html (ahead/behind + age, branches only)
+  stale: boolean;
+  verb: string;           // what ⏎ does, spelled out in the footer
+  wt?: WtInfo;
+  br?: BranchInfo;
+  clash?: WtInfo;         // a worktree already owns the folder this row would create
+}
+
+let wtCtx: { project: string; repoDir: string } | null = null;
+let wtWts: WtInfo[] = [];
+let wtBranches: BranchInfo[] = [];
+let wtRepoBranch = "";
+let wtLoading = true;          // git hasn't answered yet — draw skeleton rows
+let wtRows: Dest[] = [];
+let wtSel = 0;
+let wtArmed = "";              // path of the worktree whose removal is armed
+let wtBusy = false;            // a create/remove is in flight
+let wtBase = "";               // start-point for a NEW branch ("" = the repo's HEAD)
+let wtSwitchTo = "";           // target of an armed root-folder branch switch
+let wtGen = 0;                 // bumps on every open/refresh; stales in-flight fetches
+let wtAgeT: number | undefined;
+let wtLoadedAt = 0;
+const wtCommits = new Map<string, CommitInfo | null>();
+const wtDirty = new Map<string, DiffStat | null>();
+
+/** Mirror of the backend's path scheme (`create_worktree`): every character git
+ *  can't take becomes "-", then "/" does too. Lossy on purpose — and irreversibly
+ *  so, which is why nothing here ever tries to derive a branch back out of a folder. */
+function wtSlug(branch: string): string {
+  return branch.trim().replace(/[^\p{L}\p{N}\-_/.]/gu, "-").replace(/\//g, "-");
+}
+function parentOf(p: string) { const q = p.replace(/[/\\]+$/, ""); const i = Math.max(q.lastIndexOf("/"), q.lastIndexOf("\\")); return i > 0 ? q.slice(0, i) : q; }
+const wtNorm = (p: string) => p.replace(/\\/g, "/").replace(/\/+$/, "");
+/** Where `create_worktree` would put a checkout for `branch` in this repo. */
+function wtTargetDir(repoDir: string, branch: string) {
+  return `${parentOf(repoDir)}/.cc-worktrees/${basename(repoDir)}/${wtSlug(branch)}`;
+}
+
+// The four ways a checkout's folder and its branch can relate. The folder is the
+// identity (it's what exists, and what removal deletes); the branch is only a label,
+// and `git switch` inside a session rewrites it at will.
+type WtState = "aligned" | "diverged" | "detached" | "foreign";
+function wtStateOf(w: WtInfo, repoDir: string): WtState {
+  const base = wtNorm(`${parentOf(repoDir)}/.cc-worktrees/${basename(repoDir)}`);
+  if (!wtNorm(w.path).startsWith(base + "/")) return "foreign";
+  if (!w.branch || w.branch === "(detached)") return "detached";
+  return wtSlug(w.branch) === basename(w.path) ? "aligned" : "diverged";
+}
+/** What to call a checkout. Its branch when it has one; otherwise its folder,
+ *  because a row still has to be nameable. */
+function wtLabelOf(w: WtInfo) {
+  return w.branch && w.branch !== "(detached)" ? w.branch : basename(w.path) + "/";
+}
+const wtSessionsIn = (path: string) => [...sessions.values()].filter((s) => s.workdir === path);
+
+/** Head flexes and ellipsises, tail is pinned: sibling branches often differ only in
+ *  their suffix, so a plain tail-ellipsis would render two rows identically. */
+function wtName(name: string) {
+  const TAIL = 9;
+  if (name.length <= TAIL + 4) return `<span class="hd">${esc(name)}</span>`;
+  return `<span class="hd">${esc(name.slice(0, name.length - TAIL))}</span><span class="tl">${esc(name.slice(-TAIL))}</span>`;
+}
+
+/** A branch's standing against its own remote — the only comparison that answers a
+ *  question you'd actually ask here. A branch in sync with its upstream shows nothing;
+ *  silence is the clean state. */
+function wtSyncMeta(b: BranchInfo): string {
+  if (b.gone) return `<span class="wt-tag gone" title="${esc(b.upstream)} no longer exists on the remote — this branch is local-only now">gone</span>`;
+  if (!b.upstream) return `<span class="wt-tag det" title="No remote branch tracks this — it has never been pushed">local</span>`;
+  return (b.ahead ? `<span class="wt-ab wt-ahead" title="${b.ahead} commit(s) not yet pushed to ${esc(b.upstream)}">↑${b.ahead}</span>` : "")
+    + (b.behind ? `<span class="wt-ab wt-behind" title="${b.behind} commit(s) on ${esc(b.upstream)} not pulled yet">↓${b.behind}</span>` : "");
+}
+
+/** The same fact as wtSyncMeta, spelled out for the detail pane. */
+function wtUpstreamHtml(b: BranchInfo): string {
+  if (b.gone) return `<span class="em">${esc(b.upstream)}</span> — deleted on the remote; local-only now`;
+  if (!b.upstream) return `<span class="dim">none — never pushed</span>`;
+  if (!b.ahead && !b.behind) return `<span class="em">${esc(b.upstream)}</span> <span class="good">· in sync</span>`;
+  return `<span class="em">${esc(b.upstream)}</span>`
+    + (b.ahead ? ` · <span class="warn">↑${b.ahead} unpushed</span>` : "")
+    + (b.behind ? ` · ↓${b.behind} unpulled` : "");
+}
+
+async function openWt(project: string, repoDir: string, knownBranch?: string | null) {
   wtCtx = { project, repoDir };
-  const n = [...sessions.values()].filter((s) => s.project === project).length + 1;
-  ($("wtH") as HTMLElement).textContent = allowMain ? "New session" : "New worktree";
-  $("wtSub").textContent = allowMain
-    ? `${project} already has a running session — start another below.`
-    : `Start a session in a worktree of ${project}.`;
-  // The "start here — no worktree" escape hatch: what makes a worktree one option
-  // rather than the only path. Shown first, above the worktree options. Only in
-  // allowMain mode — the ⑃ Worktree button asked for a worktree explicitly. The label
-  // refines to the real branch once git answers; the branch stays a plain inline span
-  // so it shares the button's baseline (see the .wt-here note in styles.css).
-  const mainBtn = $("wtMain") as HTMLElement;
-  ($("wtOr") as HTMLElement).hidden = !allowMain;
-  mainBtn.hidden = !allowMain;
-  if (allowMain) {
-    mainBtn.innerHTML = "Start here — no worktree";
-    mainBtn.title = "Start a session in the repo itself — no new worktree";
-    invoke<string | null>("git_branch", { workdir: repoDir }).then((b) => {
-      if (!wtCtx || wtCtx.repoDir !== repoDir) return; // dialog moved on / closed
-      if (b) {
-        mainBtn.innerHTML = `Start here on <span class="wt-mainbr">${esc(b)}</span> — no worktree`;
-        mainBtn.title = `Start a session on the current branch (${b}) — no new worktree`;
-      }
-    }).catch(() => {});
-  }
-  const bi = $("wtBranch") as HTMLInputElement; bi.value = `agent-${n}`;
-  ($("wtList") as HTMLElement).hidden = true; $("wtList").innerHTML = "";
-  ($("wtBranchList") as HTMLElement).hidden = true; $("wtBranchList").innerHTML = "";
-  $("wtBranches").innerHTML = "";
+  wtSel = 0; wtArmed = ""; wtBusy = false; wtBase = ""; wtSwitchTo = ""; wtFetchedAt = 0;
+  wtRepoBranch = knownBranch || "";   // seeded by requestLaunch, which already asked
+  ($("wtQ") as HTMLInputElement).value = "";
+  $("wtProj").textContent = project;
+  $("wtPath").textContent = repoDir;
+  const eng = engineDef(termEngine);
+  $("wtEng").textContent = `${termEngine === "embedded" ? "▤" : "⧉"} ${eng.label}`;
+  ($("wtEng") as HTMLElement).title = `New sessions open in ${eng.label}`;
   $("scrim").classList.add("show"); $("wtDlg").classList.add("show");
-  setTimeout(() => { bi.focus(); bi.select(); }, 30);
-  const wts = await invoke<WtInfo[]>("list_worktrees", { repoDir }).catch(() => [] as WtInfo[]);
-  if (wtCtx && wtCtx.repoDir === repoDir) renderWtList(wts);
-  // Show the repo's branches so an existing one can be *picked* rather than recalled.
-  // The input has always accepted existing names (create_worktree probes the ref and
-  // attaches); the list makes that browsable, with a staleness + ahead/behind cue so
-  // it's obvious which branches are worth starting on.
-  const branches = await invoke<BranchInfo[]>("git_branch_list", { repoDir }).catch(() => [] as BranchInfo[]);
-  if (wtCtx && wtCtx.repoDir === repoDir) renderBranchList(branches);
+  setTimeout(() => ($("wtQ") as HTMLInputElement).focus(), 30);
+  clearInterval(wtAgeT); wtAgeT = window.setInterval(wtTickAge, 1000);
+  await wtLoad();
 }
-function renderWtList(wts: WtInfo[]) {
-  const nonMain = wts.filter((w) => !w.is_main);
-  const el = $("wtList");
-  if (!nonMain.length) { el.innerHTML = ""; (el as HTMLElement).hidden = true; return; }
-  (el as HTMLElement).hidden = false;
-  el.innerHTML = `<div class="wt-lbl">Existing worktrees</div>` + nonMain.map((w) => {
-    const isOpen = [...sessions.values()].some((s) => s.workdir === w.path);
-    // A cleanliness cue, most-important-first: merged (safe to clean) → dirty
-    // (uncommitted work) → nothing. `open` sessions get no cue; the tree is live.
-    const tag = isOpen ? "" : w.merged ? `<span class="wt-tag merged">merged</span>` : w.dirty ? `<span class="wt-tag dirty">uncommitted</span>` : "";
-    const open = `<button class="wt-item" data-wt="${esc(w.path)}" data-wtbranch="${esc(w.branch)}"><span class="wt-br">⑃ ${esc(w.branch)}</span>${tag}<span class="wt-open">${isOpen ? "open" : "→"}</span></button>`;
-    // Remove control — hidden while a session is live in the worktree (close it
-    // first). A merged row also drops its branch (safe-delete); a dirty row's ✕
-    // hands the --force command to a terminal rather than clobbering the tree.
-    const title = w.dirty ? "Uncommitted changes — removing needs --force in a terminal"
-      : w.merged ? "Remove this worktree and delete its merged branch"
-      : "Remove this worktree (keeps the branch)";
-    const rm = isOpen ? "" : `<button class="wt-rm" title="${esc(title)}" data-wtrm="${esc(w.path)}" data-wtrmbranch="${esc(w.branch)}" data-wtrmdel="${w.merged ? "1" : "0"}">✕</button>`;
-    return `<div class="wt-row">${open}${rm}</div>`;
-  }).join("");
+
+// Both lists cost several git calls (a status probe per checkout, a rev-list per ref),
+// so the dialog draws its shape first and fills in. The repo row is real from the
+// first frame — it's the path we were opened with — so ⏎ works at t=0.
+//
+// Two layers of freshness, because they cost different things:
+//   wtReadLocal — pure local git, instant, safe to run whenever.
+//   wtMaybeFetch — network. ahead/behind and `gone` come from %(upstream:track), which
+//     compares against refs/remotes/*, a cache only `git fetch` moves. Without this the
+//     panel's most useful signal would silently reflect whenever you last fetched.
+async function wtLoad(quiet = false) {
+  await wtReadLocal(quiet);
+  void wtMaybeFetch();
 }
-// Branches you could start a *new* worktree on. The current branch (the "start here"
-// button) and any already checked out in a worktree (the list above) are excluded —
-// git refuses to check either out a second time, so offering them would only error.
-function renderBranchList(bs: BranchInfo[]) {
-  const cur = bs.find((b) => b.current)?.name || "the current branch";
-  const pick = bs.filter((b) => !b.current && !b.checked_out);
-  $("wtBranches").innerHTML = pick.map((b) => `<option value="${esc(b.name)}"></option>`).join("");
-  const el = $("wtBranchList") as HTMLElement;
-  if (!pick.length) { el.innerHTML = ""; el.hidden = true; return; }
-  el.hidden = false;
-  const STALE = 45 * 86400, now = Date.now() / 1000;
-  el.innerHTML = `<div class="wt-lbl">Or pick a branch</div>` + pick.map((b) => {
-    const stale = b.unix > 0 && now - b.unix > STALE;
-    const ab = (b.ahead ? `<span class="wt-ab wt-ahead" title="${b.ahead} commit(s) ${esc(b.name)} has that ${esc(cur)} doesn't">↑${b.ahead}</span>` : "")
-      + (b.behind ? `<span class="wt-ab wt-behind" title="${b.behind} commit(s) behind ${esc(cur)}">↓${b.behind}</span>` : "");
-    return `<button class="wt-item wt-branch${stale ? " stale" : ""}" data-branch="${esc(b.name)}" title="Create a worktree on ${esc(b.name)} and start a session">`
-      + `<span class="wt-br">${esc(b.name)}</span>`
-      + `<span class="wt-bmeta">${ab}<span class="wt-when">${esc(b.rel || "")}</span></span>`
-      + `</button>`;
-  }).join("");
-}
-function openWorktreeSession(path: string, branch: string) {
-  if (!wtCtx) return;
-  const { project, repoDir } = wtCtx;
-  closeWt();
-  const existing = [...sessions.values()].find((s) => s.workdir === path);
-  if (existing) { setActive(existing.id); return; }
-  launch(project, path, { colorKey: repoDir, worktree: branch, branch });
-}
-function closeWt() { $("wtDlg").classList.remove("show"); dropScrim(); wtCtx = null; }
-// Create a worktree on `branch` (new or existing) and launch a session in it. Shared
-// by the free-text field (wtCreate) and one-click branch rows (data-branch).
-async function createWorktreeOn(branch: string) {
-  if (!wtCtx) return;
-  const { project, repoDir } = wtCtx;
-  closeWt();
+
+// Fetch is throttled and best-effort: it runs in the background, never blocks the list,
+// and stays silent on failure (offline, no remote, auth) — a stale number is a better
+// outcome than a toast every time you alt-tab with no network.
+const WT_FETCH_MIN_MS = 60_000;
+let wtFetchedAt = 0;
+let wtFetching = false;
+async function wtMaybeFetch(force = false) {
+  if (!wtCtx || wtFetching) return;
+  if (!force && Date.now() - wtFetchedAt < WT_FETCH_MIN_MS) return;
+  const gen = wtGen, { repoDir } = wtCtx;
+  wtFetching = true;
+  $("wtRefresh").classList.add("spin");
   try {
-    const path = await invoke<string>("create_worktree", { repoDir, branch });
+    await invoke<GitActionResult>("git_action", { workdir: repoDir, op: "fetch" });
+  } catch { /* offline / no remote / auth — the local read still stands */ }
+  wtFetching = false;
+  wtFetchedAt = Date.now();
+  $("wtRefresh").classList.remove("spin");
+  if (gen !== wtGen || !wtCtx || wtCtx.repoDir !== repoDir) return; // dialog moved on
+  await wtReadLocal(true);
+}
+
+// `quiet` = there is already a list on screen, so don't tear it down: no skeletons, no
+// "not a git repository" toast a second time, and one render at the end instead of two.
+// Skeletons are for the first paint only.
+async function wtReadLocal(quiet = false) {
+  if (!wtCtx) return;
+  const { repoDir } = wtCtx;
+  const gen = ++wtGen;
+  // The lazily-fetched facts (HEAD lines, the repo's dirty count) are re-derived: a
+  // quiet refresh usually follows something that moved them.
+  wtCommits.clear(); wtDirty.clear();
+  if (!quiet) { wtLoading = true; wtRender(); }
+  const [wts, branches, head] = await Promise.all([
+    invoke<WtInfo[]>("list_worktrees", { repoDir }).catch(() => [] as WtInfo[]),
+    invoke<BranchInfo[]>("git_branch_list", { repoDir }).catch(() => [] as BranchInfo[]),
+    invoke<string | null>("git_branch", { workdir: repoDir }).catch(() => null),
+  ]);
+  if (gen !== wtGen || !wtCtx || wtCtx.repoDir !== repoDir) return; // dialog moved on
+  wtWts = wts; wtBranches = branches; wtRepoBranch = head || wtRepoBranch;
+  wtLoading = false;
+  wtLoadedAt = Date.now();
+  if (!wts.length && !quiet) toast(`${basename(repoDir)} isn't a git repository`);
+  wtRender();
+}
+
+function wtTickAge() {
+  if (!$("wtDlg").classList.contains("show")) { clearInterval(wtAgeT); return; }
+  if (wtLoading) { $("wtAge").textContent = "…"; return; }
+  const s = Math.round((Date.now() - wtLoadedAt) / 1000);
+  $("wtAge").textContent = s < 5 ? "now" : s < 60 ? `${s}s` : `${Math.floor(s / 60)}m`;
+}
+
+// One array, four row kinds. Both the list and the detail pane read only from this.
+function wtBuild(): Dest[] {
+  if (!wtCtx) return [];
+  const { repoDir } = wtCtx;
+  const raw = ($("wtQ") as HTMLInputElement).value;
+  const q = raw.trim().toLowerCase();
+  const hit = (s: string) => !q || s.toLowerCase().includes(q);
+  const out: Dest[] = [];
+
+  const known = [...wtWts.map((w) => w.branch), ...wtBranches.map((b) => b.name), wtRepoBranch];
+  const exact = known.some((n) => n && n.toLowerCase() === q);
+
+  // The typed query, promoted to an action. This is what lets the branch field, its
+  // datalist and the fixed "Create worktree" button all disappear.
+  if (q && !exact) {
+    const want = wtSlug(raw);
+    const clash = wtWts.find((w) => !w.is_main && basename(w.path) === want);
+    out.push({
+      kind: "create", group: "", ic: "＋", label: raw.trim(),
+      sub: clash ? `folder ${basename(clash.path)}/ is already taken` : `new worktree off ${wtBase || wtRepoBranch || "HEAD"}`,
+      dir: wtTargetDir(repoDir, raw), branch: raw.trim(), tags: [], meta: "", stale: false, clash,
+      verb: clash ? "blocked — that folder exists" : "create worktree & start session",
+    });
+  }
+
+  const repoSess = wtSessionsIn(repoDir).length;
+  if (hit(wtRepoBranch) || hit(basename(repoDir)) || hit("repo")) {
+    out.push({
+      kind: "repo", group: "Repo", ic: "⌂",
+      label: wtRepoBranch || basename(repoDir), sub: repoDir,
+      dir: repoDir, branch: wtRepoBranch,
+      tags: repoSess ? [["open", `${repoSess} open`]] : [], meta: "", stale: false,
+      verb: "start session in the repo — no worktree",
+    });
+  }
+
+  for (const w of wtWts) {
+    if (w.is_main) continue;
+    // Searchable by the branch you want OR the folder you remember — after a
+    // `git switch` inside the checkout those are different strings.
+    if (!hit(`${w.branch} ${basename(w.path)} ${w.path}`)) continue;
+    const st = wtStateOf(w, repoDir);
+    const open = wtSessionsIn(w.path).length;
+    const tags: [string, string][] = [];
+    if (open) tags.push(["open", `${open} open`]);
+    if (!w.exists) tags.push(["missing", "missing"]);
+    if (w.locked) tags.push(["locked", "locked"]);
+    if (st === "diverged") tags.push(["moved", "moved"]);
+    if (st === "detached") tags.push(["det", "detached"]);
+    if (st === "foreign") tags.push(["ext", "outside"]);
+    if (w.dirty) tags.push(["dirty", "uncommitted"]);
+    // `merged` is computed against the main branch and skipped for (detached) — never
+    // imply a detached checkout is a safe cleanup.
+    if (w.merged && st !== "detached") tags.push(["merged", "merged"]);
+    out.push({
+      kind: "wt", group: "Worktrees", ic: "⑃", wt: w,
+      label: wtLabelOf(w),
+      sub: st === "diverged" ? `in ${basename(w.path)}/` : st === "foreign" ? w.path : "",
+      dir: w.path, branch: w.branch === "(detached)" ? "" : w.branch,
+      tags, meta: "", stale: false,
+      verb: !w.exists ? "folder is gone — remove it instead"
+        : open ? "start another session in this worktree"
+        : "start session in this worktree",
+    });
+  }
+
+  // Branches you could start a NEW worktree on. The current branch (the repo row) and
+  // any already checked out (the worktrees above) are excluded — git refuses either a
+  // second time, so offering them would only produce an error.
+  const STALE = 45 * 86400, now = Date.now() / 1000;
+  for (const b of wtBranches) {
+    if (b.current || b.checked_out || !hit(b.name)) continue;
+    const clash = wtWts.find((w) => !w.is_main && basename(w.path) === wtSlug(b.name));
+    out.push({
+      kind: "branch", group: "Branches", ic: "⌥", br: b, clash,
+      label: b.name, sub: "", dir: wtTargetDir(repoDir, b.name), branch: b.name,
+      tags: [], stale: b.unix > 0 && now - b.unix > STALE,
+      meta: wtSyncMeta(b) + `<span class="wt-when">${esc(b.rel || "")}</span>`,
+      verb: clash ? "blocked — that folder exists" : "create a worktree on this branch & start",
+    });
+  }
+  return out;
+}
+
+function wtRender() {
+  wtRows = wtBuild();
+  if (wtSel >= wtRows.length) wtSel = Math.max(0, wtRows.length - 1);
+  const cur = wtRows[wtSel];
+  if (!cur || cur.kind === "create" || cur.dir !== wtArmed) wtArmed = "";
+
+  let html = "", lastGroup: string | null = null;
+  wtRows.forEach((d, i) => {
+    if (d.group && d.group !== lastGroup) {
+      lastGroup = d.group;
+      const n = wtRows.filter((x) => x.group === d.group).length;
+      html += `<div class="wt-gh">${d.group}<span class="gc">${n}</span><span class="rule"></span></div>`;
+    }
+    html += `<button class="wt-item${d.kind === "create" ? " create" : ""}${d.stale ? " stale" : ""}${i === wtSel ? " on" : ""}"`
+      + ` type="button" role="option" aria-selected="${i === wtSel}" data-wti="${i}" title="${esc(d.dir)}&#10;Double-click to ${esc(d.verb)}">`
+      + `<span class="wt-ic">${d.ic}</span>`
+      + `<span class="wt-main"><span class="wt-br">${wtName(d.label)}</span>`
+      + (d.sub ? `<span class="wt-sub2">${esc(d.sub)}</span>` : "")
+      + `</span><span class="wt-meta">`
+      + d.tags.map(([k, t]) => `<span class="wt-tag ${k}">${esc(t)}</span>`).join("")
+      + `${d.meta}</span></button>`;
+  });
+  if (wtLoading) {
+    html += `<div class="wt-gh">Worktrees<span class="rule"></span></div>`
+      + [44, 62, 37].map((w) => `<div class="wt-sk"><i class="a"></i><i style="width:${w}%"></i></div>`).join("")
+      + `<div class="wt-gh">Branches<span class="rule"></span></div>`
+      + [55, 41].map((w) => `<div class="wt-sk"><i class="a"></i><i style="width:${w}%"></i></div>`).join("");
+  } else if (!wtRows.length) {
+    html += `<div class="wt-empty"><b>Nothing matches that</b>Clear the filter, or type a branch name to create one</div>`;
+  }
+  $("wtList").innerHTML = html;
+  $("wtCount").textContent = wtLoading ? "" : wtRows.length ? `${wtRows.length} destinations` : "";
+  $("wtVerb").textContent = cur ? cur.verb : "—";
+  $("wtDetail").innerHTML = wtDetailHtml(cur);
+  $("wtList").querySelector(".wt-item.on")?.scrollIntoView({ block: "nearest" });
+  void wtPrefetch(cur);
+}
+
+// The pane's git facts, fetched for the HIGHLIGHTED row only — a repo can hold
+// BRANCH_LIST_CAP branches plus every worktree, and one `git log` per row would cost
+// far more than the pane is worth.
+async function wtPrefetch(d: Dest | undefined) {
+  if (!d || !wtCtx) return;
+  const gen = wtGen, { repoDir } = wtCtx;
+  const jobs: Promise<unknown>[] = [];
+  const ck = wtCommitKey(d);
+  if (ck && !wtCommits.has(ck)) {
+    const [dir, rev] = ck.split("\n");
+    jobs.push(invoke<CommitInfo | null>("git_commit_info", { dir, rev }).catch(() => null)
+      .then((c) => { wtCommits.set(ck, c); }));
+  }
+  // list_worktrees skips `dirty` for the main worktree, so the repo row needs its own.
+  if (d.kind === "repo" && !wtDirty.has(repoDir)) {
+    jobs.push(invoke<DiffStat | null>("git_diffstat", { workdir: repoDir }).catch(() => null)
+      .then((g) => { wtDirty.set(repoDir, g); }));
+  }
+  if (!jobs.length) return;
+  await Promise.all(jobs);
+  if (gen !== wtGen) return;                    // refreshed under us
+  if (wtRows[wtSel] !== d) return;              // selection moved on
+  $("wtDetail").innerHTML = wtDetailHtml(d);
+}
+/** `<dir>\n<rev>` — the argument pair for git_commit_info, newline-joined because
+ *  git forbids newlines in ref names and a path may contain spaces. "" when there is
+ *  nothing to ask about (an unborn create row has no commit yet). */
+function wtCommitKey(d: Dest): string {
+  if (!wtCtx) return "";
+  if (d.kind === "repo") return `${d.dir}\n`;
+  if (d.kind === "wt") return d.wt!.exists ? `${d.dir}\n` : "";
+  if (d.kind === "branch") return `${wtCtx.repoDir}\n${d.branch}`;
+  return "";
+}
+
+function wtFacts(pairs: [string, string][]) {
+  return `<dl class="wt-facts">${pairs.map(([k, v]) => `<dt>${esc(k)}</dt><dd>${v}</dd>`).join("")}</dl>`;
+}
+function wtCommitHtml(d: Dest): string {
+  const ck = wtCommitKey(d);
+  if (!ck) return `<span class="dim">—</span>`;
+  if (!wtCommits.has(ck)) return `<span class="dim">reading…</span>`;
+  const c = wtCommits.get(ck);
+  if (!c) return `<span class="dim">no commits yet</span>`;
+  return `<span class="em">${esc(c.short)}</span> · ${esc(c.author)} · ${esc(c.rel)}<span class="subj">${esc(c.subject)}</span>`;
+}
+/** Dim the containing directory, emphasise the leaf — the leaf is the identity. */
+function wtPathHtml(p: string) {
+  const b = basename(p);
+  const i = p.lastIndexOf(b);
+  return i <= 0 ? `<span class="em">${esc(p)}</span>` : `<span class="dim">${esc(p.slice(0, i))}</span><span class="em">${esc(b)}</span>`;
+}
+function wtSessHtml(list: Sess[]) {
+  const col: Record<Phase, string> = { idle: "--st-idle", thinking: "--st-working", working: "--st-working", done: "--st-done", error: "--st-error", ended: "--st-idle" };
+  return `<div class="wt-sess">${list.map((s) =>
+    `<button class="wt-sessb" type="button" data-wtjump="${esc(s.id)}"><i style="background:var(${col[s.phase]})"></i>${esc(s.title || s.branch || "session")}</button>`).join("")}</div>`;
+}
+
+function wtDetailHtml(d: Dest | undefined): string {
+  if (wtLoading && !d) return `<div class="wt-empty">Reading the repo…</div>`;
+  if (!d || !wtCtx) return `<div class="wt-empty">Nothing selected.</div>`;
+
+  if (d.kind === "repo") {
+    const g = wtDirty.get(d.dir);
+    const sess = wtSessionsIn(d.dir);
+    if (wtArmed === d.dir) return wtSwitchHtml();
+    return `<div class="wt-dhead"><span class="wt-dkind">The repo itself</span><span class="wt-dname">${wtPathHtml(d.dir)}</span></div>`
+      + wtFacts([
+        ["Branch", `<span class="em">${esc(wtRepoBranch || "—")}</span>`],
+        ["HEAD", wtCommitHtml(d)],
+        ["Working tree", !wtDirty.has(d.dir) ? `<span class="dim">reading…</span>`
+          : g && g.dirty > 0 ? `<span class="warn">${g.dirty} file${g.dirty === 1 ? "" : "s"} uncommitted</span>`
+          : `<span class="good">clean</span>`],
+      ])
+      + (sess.length ? `<dl class="wt-facts"><dt>Sessions</dt><dd>${wtSessHtml(sess)}</dd></dl>` : "")
+      + `<div class="wt-acts"><button class="wt-go" type="button" data-wtact="go">Start session here</button>`
+      + `<button class="wt-rm" type="button" data-wtact="arm">Switch branch…</button></div>`;
+  }
+
+  if (d.kind === "wt") {
+    const w = d.wt!, st = wtStateOf(w, wtCtx.repoDir), sess = wtSessionsIn(w.path);
+    if (wtArmed === w.path) return wtConfirmHtml(d);
+    let warn = "";
+    if (!w.exists) {
+      warn = `<div class="wt-warn err"><span class="t">Folder is gone</span>`
+        + `Nothing is left at this path — only git's record of it. Removing prunes that record; there's nothing to launch into.</div>`;
+    } else if (st === "diverged") {
+      // Deliberately does NOT name the branch this folder was created for: wtSlug is
+      // lossy (both "/" and every odd character become "-"), so the folder can't be
+      // turned back into a branch name. Name the folder, which is what exists.
+      warn = `<div class="wt-warn"><span class="t">Folder and branch disagree</span>`
+        + `This checkout lives in <b>${esc(basename(w.path))}/</b>, a folder named after the branch it was created for. `
+        + `Its HEAD is now <b>${esc(w.branch)}</b> — something switched inside it. `
+        + `Removing it deletes the folder; the branch is a separate decision.</div>`;
+    } else if (st === "detached") {
+      warn = `<div class="wt-warn"><span class="t">No branch checked out</span>`
+        + `HEAD is detached here, so commits made in this checkout belong to no branch — Muster can't tell you whether they're merged, and won't offer to delete anything.</div>`;
+    } else if (st === "foreign") {
+      warn = `<div class="wt-warn"><span class="t">Outside .cc-worktrees</span>`
+        + `Muster didn't create this checkout, so it doesn't own the path. Removal still works; the folder just isn't where new worktrees go.</div>`;
+    }
+    if (w.locked) {
+      warn += `<div class="wt-warn"><span class="t">Locked</span>`
+        + `<b>git worktree lock</b> was used here. Git refuses to remove a locked worktree even with <b>--force</b>, so unlock it first.</div>`;
+    }
+    const facts: [string, string][] = [
+      ["Folder", wtPathHtml(w.path)],
+      ["Branch", w.branch && w.branch !== "(detached)" ? `<span class="em">${esc(w.branch)}</span>` : `<span class="warn">(detached)</span>`],
+      ["HEAD", wtCommitHtml(d)],
+      ["Working tree", !w.exists ? `<span class="dim">—</span>` : w.dirty ? `<span class="warn">uncommitted changes</span>` : `<span class="good">clean</span>`],
+    ];
+    if (w.branch && w.branch !== "(detached)") {
+      facts.push(["Branch state", w.merged ? `<span class="good">merged into ${esc(wtRepoBranch || "the main branch")}</span>`
+        : `<span class="em">has commits</span> ${esc(wtRepoBranch || "the main branch")} doesn't`]);
+    }
+    return `<div class="wt-dhead"><span class="wt-dkind">Existing worktree</span><span class="wt-dname">${esc(wtLabelOf(w))}</span></div>`
+      + warn + wtFacts(facts)
+      + (sess.length ? `<dl class="wt-facts"><dt>Sessions</dt><dd>${wtSessHtml(sess)}</dd></dl>` : "")
+      + `<div class="wt-acts">`
+      + `<button class="wt-go" type="button" data-wtact="go"${w.exists ? "" : " disabled"}>${sess.length ? "Start another session here" : "Start session here"}</button>`
+      + `<button class="wt-rm" type="button" data-wtact="arm"${sess.length ? " disabled title=\"Close its sessions first\"" : ""}>Remove worktree…</button>`
+      + `</div>`;
+  }
+
+  // branch / create — neither has a checkout yet, so both are about the folder that
+  // WOULD be made. Showing that path is what catches a collision before git does.
+  const clash = d.clash;
+  const clashWarn = clash
+    ? `<div class="wt-warn err"><span class="t">Folder already taken</span>`
+      + `<b>${esc(basename(clash.path))}/</b> exists and has <b>${esc(wtLabelOf(clash))}</b> checked out`
+      + `${clash.dirty ? ", with uncommitted changes" : ""}. The folder is derived from the branch name, so this branch has nowhere to go.</div>`
+    : "";
+  if (d.kind === "branch") {
+    const b = d.br!;
+    if (wtArmed === d.dir) return wtBranchConfirmHtml(d);
+    // No live remote is a fact about the branch, not a reason to avoid it — resuming a
+    // branch whose remote was deleted (and pushing a fresh one) is an ordinary thing to
+    // want. Say what will happen instead of leaving the red `gone` chip to imply doom.
+    const noRemote = (b.gone || !b.upstream) && !clash
+      ? `<div class="wt-warn note"><span class="t">No remote branch right now</span>`
+        + `${b.gone ? `<b>${esc(b.upstream)}</b> was deleted` : "This branch has never been pushed"} — starting a worktree here is fine. `
+        + `The first <b>git push -u</b> from it creates <b>origin/${esc(b.name)}</b> again.</div>`
+      : "";
+    return `<div class="wt-dhead"><span class="wt-dkind">Branch — no checkout yet</span><span class="wt-dname">${esc(b.name)}</span></div>`
+      + clashWarn + noRemote
+      + wtFacts([
+        ["Last commit", wtCommitHtml(d)],
+        ["Upstream", wtUpstreamHtml(b)],
+        [clash ? "Would be" : "Will create", wtPathHtml(d.dir)],
+      ])
+      + `<div class="wt-acts"><button class="wt-go" type="button" data-wtact="go"${clash ? " disabled" : ""}>Create worktree &amp; start</button>`
+      + (clash ? `<button class="wt-alt" type="button" data-wtact="openclash">Open that checkout instead</button>` : "")
+      + `<button class="wt-rm" type="button" data-wtact="arm">Delete branch…</button>`
+      + `</div>`;
+  }
+  return `<div class="wt-dhead"><span class="wt-dkind">New worktree</span><span class="wt-dname">${esc(d.label)}</span></div>`
+    + clashWarn
+    + wtFacts([
+      ["Branch from", wtBaseSelect()],
+      [clash ? "Would be" : "Will create", wtPathHtml(d.dir)],
+    ])
+    + `<div class="wt-acts"><button class="wt-go" type="button" data-wtact="go"${clash ? " disabled" : ""}>Create worktree &amp; start</button>`
+    + (clash ? `<button class="wt-alt" type="button" data-wtact="openclash">Open that checkout instead</button>` : "")
+    + `</div>`;
+}
+
+// Removal, confirmed in the pane rather than a modal on a modal. The checkout and the
+// branch are separate losses — `worktree remove` never touches the branch — so they
+// get separate sentences and separate buttons.
+function wtConfirmHtml(d: Dest): string {
+  const w = d.wt!;
+  const folder = `<b>${esc(basename(w.path))}/</b>`;
+  if (!w.exists) {
+    return `<div class="wt-danger"><span class="q">Prune ${folder}?</span>`
+      + `<span class="w">The folder is already gone; this only clears git's record of it. Nothing is lost.</span>`
+      + `<span class="row"><button class="wt-cbtn danger" type="button" data-wtact="rm0">Prune it</button>`
+      + `<button class="wt-cbtn ghost" type="button" data-wtact="cancel">Cancel</button></span></div>`;
+  }
+  if (w.dirty) {
+    return `<div class="wt-danger"><span class="q">Remove ${folder}?</span>`
+      + `<span class="w"><span class="em">Uncommitted changes</span> live only in this checkout — nothing else has them. `
+      + `Muster won't force it; it'll open a terminal in the repo root with the command ready.</span>`
+      + `<span class="row"><button class="wt-cbtn" type="button" data-wtact="rm0">Open a terminal there</button>`
+      + `<button class="wt-cbtn ghost" type="button" data-wtact="cancel">Cancel</button></span></div>`;
+  }
+  const hasBranch = !!w.branch && w.branch !== "(detached)";
+  const branchLine = !hasBranch
+    ? " It has no branch checked out, so only the folder goes."
+    : w.merged
+      ? ` Its branch <b>${esc(w.branch)}</b> is merged into ${esc(wtRepoBranch || "the main branch")} — deleting it loses nothing.`
+      : ` Its branch <b>${esc(w.branch)}</b> has commits ${esc(wtRepoBranch || "the main branch")} doesn't, so it's kept.`;
+  return `<div class="wt-danger"><span class="q">Remove ${folder}?</span>`
+    + `<span class="w">The checkout is clean.${branchLine}</span>`
+    + `<span class="row">`
+    + (hasBranch && w.merged ? `<button class="wt-cbtn danger" type="button" data-wtact="rm1">Remove + delete branch</button>` : "")
+    + `<button class="wt-cbtn" type="button" data-wtact="rm0">Remove${hasBranch ? ", keep branch" : ""}</button>`
+    + `<button class="wt-cbtn ghost" type="button" data-wtact="cancel">Cancel</button></span></div>`;
+}
+
+// Deleting a local branch, the counterpart to removing a worktree. The copy has to
+// carry one non-obvious fact: a `gone` upstream usually means the PR merged, but if it
+// was SQUASH-merged the commits never became ancestors of HEAD, so git's safe delete
+// refuses anyway. Say that before the click, not after it fails.
+function wtBranchConfirmHtml(d: Dest): string {
+  const b = d.br!;
+  const name = `<b>${esc(b.name)}</b>`;
+  let why: string;
+  if (b.gone) {
+    why = `<b>${esc(b.upstream)}</b> was deleted on the remote, so this branch is local-only now — often after its pull request merged, `
+      + `but not always. If you still want the work, cancel and start a worktree on it instead; a push from there recreates the remote branch.`;
+  } else if (!b.upstream) {
+    why = `<span class="em">It has never been pushed.</span> Its commits exist here and nowhere else — once it's gone, they're only reachable by sha.`;
+  } else if (b.ahead) {
+    why = `<span class="em">${b.ahead} commit${b.ahead === 1 ? "" : "s"} are not on <b>${esc(b.upstream)}</b></span> — deleting the branch leaves them only reachable by sha. The remote branch itself stays.`;
+  } else {
+    why = `It's in sync with <b>${esc(b.upstream)}</b>, which is not touched — the remote branch stays and this can be re-fetched.`;
+  }
+  return `<div class="wt-danger"><span class="q">Delete ${name}?</span>`
+    + `<span class="w">${why}</span>`
+    + `<span class="w">Muster only runs the safe <b>git branch -d</b>, so git refuses anything it can't see as merged`
+    + `${b.gone ? " — which includes a squash-merged branch" : ""}. If it does, you get a terminal with <b>-D</b> ready.</span>`
+    + `<span class="row"><button class="wt-cbtn danger" type="button" data-wtact="delbranch">Delete branch</button>`
+    + `<button class="wt-cbtn ghost" type="button" data-wtact="cancel">Cancel</button></span></div>`;
+}
+
+// Safe-delete only; on refusal the `-D` command goes to a terminal, never to a click.
+async function wtDeleteBranch() {
+  const d = wtRows[wtSel];
+  if (!d || d.kind !== "branch" || !wtCtx || wtBusy) return;
+  const { project, repoDir } = wtCtx, branch = d.br!.name;
+  wtBusy = true;
+  try {
+    const r = await invoke<GitActionResult>("delete_branch", { repoDir, branch });
+    dlog(r.ok ? "info" : "warn", `branch delete · ${branch} · ${r.summary}`);
+    toast(r.ok ? r.summary : `${r.summary} → opening a terminal`);
+    if (!r.ok && r.suggest) {
+      closeWt();
+      await handToTerminal(project, repoDir, r.suggest, { colorKey: repoDir });
+      return;
+    }
+    wtArmed = "";
+    await wtLoad(true);
+  } catch (e) {
+    dlog("error", `branch delete failed: ${e}`);
+    toast("branch: " + e);
+  } finally { wtBusy = false; renderAll(); }
+}
+
+// The start-point for a NEW branch. Defaults to the repo's HEAD, which is what git
+// does — but silently, and that silence is the problem: a root parked on a feature
+// branch makes every new worktree a child of it. Naming the parent (and letting it be
+// changed) is cheaper and far safer than switching the root just to branch elsewhere.
+function wtBaseSelect(): string {
+  const head = wtRepoBranch || "HEAD";
+  return wtPickBtn("base", wtBase || head) + (wtBase ? "" : ` <span class="dim">the repo's current branch</span>`);
+}
+/** Options for the base chooser: the repo's HEAD first, then every other local branch. */
+function wtBaseOptions(): BranchPick[] {
+  const head = wtRepoBranch || "HEAD";
+  return [{ name: head, note: "the repo's current branch" }]
+    .concat(wtBranches.filter((b) => !b.current).map((b) => ({ name: b.name, note: b.rel || "" })));
+}
+
+// Move the root folder itself to another branch. Muster's answer to "work on another
+// branch" is normally a worktree, and this stays deliberately secondary — but the root's
+// branch is the default parent of every new worktree, so a root parked somewhere stale
+// needed an escape that wasn't "drop to a shell".
+function wtSwitchHtml(): string {
+  if (!wtCtx) return "";
+  const running = wtSessionsIn(wtCtx.repoDir).length;
+  const pick = wtSwitchable();
+  if (running) {
+    return `<div class="wt-danger"><span class="q">Switch this folder's branch?</span>`
+      + `<span class="w"><span class="em">${running} session${running === 1 ? " is" : "s are"} running here.</span> `
+      + `Switching would move the ground under ${running === 1 ? "it" : "them"} mid-edit, so Muster won't. Close ${running === 1 ? "it" : "them"} first.</span>`
+      + `<span class="row"><button class="wt-cbtn ghost" type="button" data-wtact="cancel">Cancel</button></span></div>`;
+  }
+  if (!pick.length) {
+    return `<div class="wt-danger"><span class="q">Switch this folder's branch?</span>`
+      + `<span class="w">Every other branch is already checked out in a worktree, so there is nothing to switch to.</span>`
+      + `<span class="row"><button class="wt-cbtn ghost" type="button" data-wtact="cancel">Cancel</button></span></div>`;
+  }
+  const sel = wtSwitchTo || pick[0].name;
+  return `<div class="wt-danger"><span class="q">Switch <b>${esc(basename(wtCtx.repoDir))}</b> to another branch?</span>`
+    + `<span class="w">The repo's own folder moves — every worktree keeps its own branch, untouched. `
+    + `This also changes what new worktrees branch from by default.</span>`
+    + `<span class="row">${wtPickBtn("switch", sel)}</span>`
+    + `<span class="w">Muster only switches a <b>clean</b> tree: git would carry uncommitted changes across to the new branch, `
+    + `which is a change it never announced. If yours is dirty you get a terminal instead.</span>`
+    + `<span class="row"><button class="wt-cbtn danger" type="button" data-wtact="doswitch">Switch branch</button>`
+    + `<button class="wt-cbtn ghost" type="button" data-wtact="cancel">Cancel</button></span></div>`;
+}
+
+/** Branches the root can actually move to: not current, not held by a worktree. */
+function wtSwitchOptions(): BranchPick[] {
+  // git allows exactly one checkout per branch, so anything a worktree holds — or the
+  // root already has — can't be switched to. List them anyway, disabled and explained:
+  // silently omitting them is what made `dev` look like it had gone missing.
+  const held = new Map<string, string>();
+  for (const w of wtWts) if (!w.is_main && w.branch) held.set(w.branch, basename(w.path));
+  return wtBranches.map((b) => b.current
+    ? { name: b.name, note: "already checked out here", disabled: true }
+    : held.has(b.name)
+      ? { name: b.name, note: `checked out in ${held.get(b.name)}/`, disabled: true }
+      : { name: b.name, note: b.rel || "" });
+}
+const wtSwitchable = () => wtSwitchOptions().filter((o) => !o.disabled);
+async function wtDoSwitch() {
+  if (!wtCtx || wtBusy) return;
+  const { project, repoDir } = wtCtx;
+  const branch = wtSwitchTo || wtSwitchable()[0]?.name;
+  if (!branch) return;
+  wtBusy = true;
+  try {
+    const r = await invoke<GitActionResult>("switch_branch", { repoDir, branch });
+    dlog(r.ok ? "info" : "warn", `switch · ${basename(repoDir)} · ${r.summary}`);
+    toast(r.ok ? r.summary : `${r.summary} → opening a terminal`);
+    if (!r.ok && r.suggest) {
+      closeWt();
+      await handToTerminal(project, repoDir, r.suggest, { colorKey: repoDir });
+      return;
+    }
+    wtArmed = ""; wtSwitchTo = ""; wtRepoBranch = branch;
+    await wtLoad(true);
+  } catch (e) {
+    dlog("error", `switch failed: ${e}`);
+    toast("switch: " + e);
+  } finally { wtBusy = false; renderAll(); }
+}
+
+// ---------- branch chooser ----------
+// A picker for the two places the dialog needs one: the new-worktree base, and the
+// root-switch target. Built from the .menupop/.mp-item idiom the engine, caffeinate,
+// shortcuts, usage and colour menus already share, so it reads as part of the app
+// rather than as the one piece of system chrome on a fully custom surface.
+//
+// It lives at body level (#bPop) because .wtdlg is overflow:hidden — anchored inside,
+// it would be clipped. Typing filters, because a repo can hold BRANCH_LIST_CAP refs
+// and "scroll until you see it" is not a choice.
+interface BranchPick {
+  name: string;
+  note: string;
+  /** Shown, but not choosable — with `note` carrying the reason. A branch that simply
+   *  vanishes from the list reads as a bug: you go looking for `dev`, it isn't there,
+   *  and nothing tells you it's held by a worktree. */
+  disabled?: boolean;
+}
+let bPopItems: BranchPick[] = [];
+let bPopSel = 0;
+let bPopOn: ((name: string) => void) | null = null;
+let bPopAnchor: HTMLElement | null = null;
+
+function bPopOpen() { return $("bPop").classList.contains("show"); }
+function openBranchPop(anchor: HTMLElement, items: BranchPick[], current: string, onPick: (name: string) => void) {
+  bPopItems = items; bPopOn = onPick; bPopAnchor = anchor;
+  const at = items.findIndex((i) => i.name === current);
+  bPopSel = at >= 0 && !items[at].disabled ? at : bPopFirst(items);
+  const pop = $("bPop");
+  pop.innerHTML = `<div class="bp-q"><span>❯</span><input id="bPopQ" spellcheck="false" autocomplete="off" placeholder="Filter branches…" aria-label="Filter branches" /></div><div class="bp-list" id="bPopList" role="listbox"></div>`;
+  pop.classList.add("show");
+  anchor.classList.add("open");
+  renderBranchPop();
+  // Anchor below the trigger, flipping above when that would run off the bottom.
+  const r = anchor.getBoundingClientRect(), h = pop.offsetHeight;
+  pop.style.left = Math.max(8, Math.min(r.left, window.innerWidth - pop.offsetWidth - 8)) + "px";
+  pop.style.top = (r.bottom + 6 + h > window.innerHeight ? Math.max(8, r.top - h - 6) : r.bottom + 6) + "px";
+  setTimeout(() => ($("bPopQ") as HTMLInputElement)?.focus(), 20);
+}
+function renderBranchPop() {
+  const q = (($("bPopQ") as HTMLInputElement)?.value || "").trim().toLowerCase();
+  const shown = bPopItems.filter((i) => !q || i.name.toLowerCase().includes(q));
+  if (bPopSel >= shown.length) bPopSel = Math.max(0, shown.length - 1);
+  $("bPopList").innerHTML = shown.length
+    ? shown.map((i, n) => `<button class="mp-item${n === bPopSel ? " on" : ""}${i.disabled ? " dis" : ""}" type="button" role="option"`
+        + ` aria-selected="${n === bPopSel}" aria-disabled="${!!i.disabled}"${i.disabled ? " disabled" : ""} data-bpick="${esc(i.name)}">`
+        + `<span class="mp-ic">${i.disabled ? "⊘" : "⌥"}</span><span class="mp-main"><span class="mp-l">${esc(i.name)}</span>`
+        + (i.note ? `<span class="mp-s">${esc(i.note)}</span>` : "")
+        + `</span><span class="mp-check">✓</span></button>`).join("")
+    : `<div class="bp-none">No branch matches that.</div>`;
+  $("bPopList").querySelector(".mp-item.on")?.scrollIntoView({ block: "nearest" });
+}
+function bPopShown(): BranchPick[] {
+  const q = (($("bPopQ") as HTMLInputElement)?.value || "").trim().toLowerCase();
+  return bPopItems.filter((i) => !q || i.name.toLowerCase().includes(q));
+}
+/** Next choosable row in `dir`, or stay put if there is none — so arrow keys step over
+ *  the disabled entries instead of parking on something Enter can't take. */
+function bPopStep(shown: BranchPick[], from: number, dir: 1 | -1): number {
+  for (let i = from + dir; i >= 0 && i < shown.length; i += dir) if (!shown[i].disabled) return i;
+  return from;
+}
+const bPopFirst = (shown: BranchPick[]) => { const i = shown.findIndex((x) => !x.disabled); return i < 0 ? 0 : i; };
+function closeBranchPop(refocus = true) {
+  if (!bPopOpen()) return;
+  $("bPop").classList.remove("show");
+  bPopAnchor?.classList.remove("open");
+  bPopAnchor = null; bPopOn = null;
+  if (refocus && $("wtDlg").classList.contains("show")) ($("wtQ") as HTMLInputElement).focus();
+}
+function bPopPick(name: string) { const cb = bPopOn; closeBranchPop(); cb?.(name); }
+
+$("bPop").addEventListener("click", (e) => {
+  const b = (e.target as HTMLElement).closest<HTMLElement>("[data-bpick]");
+  if (b) bPopPick(b.dataset.bpick!);
+});
+$("bPop").addEventListener("input", () => { bPopSel = bPopFirst(bPopShown()); renderBranchPop(); });
+$("bPop").addEventListener("keydown", (e) => {
+  const shown = bPopShown();
+  if (e.key === "ArrowDown") { e.preventDefault(); bPopSel = bPopStep(shown, bPopSel, 1); renderBranchPop(); }
+  else if (e.key === "ArrowUp") { e.preventDefault(); bPopSel = bPopStep(shown, bPopSel, -1); renderBranchPop(); }
+  else if (e.key === "Enter") { e.preventDefault(); const p = shown[bPopSel]; if (p && !p.disabled) bPopPick(p.name); }
+  else if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); closeBranchPop(); }
+});
+
+/** The trigger: reads as a field holding a value, not as a button. */
+function wtPickBtn(kind: "base" | "switch", label: string): string {
+  return `<button class="wt-pick" type="button" data-wtpick="${kind}" aria-haspopup="listbox">`
+    + `<span class="v">${esc(label)}</span><span class="c">▾</span></button>`;
+}
+
+function closeWt() {
+  closeBranchPop(false);
+  $("wtDlg").classList.remove("show"); dropScrim();
+  clearInterval(wtAgeT); wtAgeT = undefined;
+  wtCtx = null; wtArmed = ""; wtGen++;
+}
+
+/** What ⏎ (and the pane's primary button) does for the highlighted row. */
+function wtRun(d: Dest | undefined) {
+  if (!d || !wtCtx || wtBusy) return;
+  const { project, repoDir } = wtCtx;
+  if (d.kind === "repo") { closeWt(); launch(project, repoDir, { colorKey: repoDir, branch: wtRepoBranch }); return; }
+  if (d.kind === "wt") {
+    const w = d.wt!;
+    if (!w.exists) { toast(`${basename(w.path)} is gone — remove it instead`); return; }
+    closeWt();
+    // Always a NEW session: a second agent on one branch is a normal thing to want.
+    // The session chips in the pane are what jump to a running one.
+    launch(project, w.path, { colorKey: repoDir, worktree: wtLabelOf(w), branch: d.branch });
+    return;
+  }
+  if (d.clash) { toast(`${basename(d.clash.path)}/ already exists`); return; }
+  void wtCreate(d.branch, d.kind === "create" ? wtBase : "");
+}
+
+async function wtCreate(branch: string, base = "") {
+  if (!wtCtx || wtBusy) return;
+  const { project, repoDir } = wtCtx;
+  wtBusy = true;
+  try {
+    const path = await invoke<string>("create_worktree", { repoDir, branch, base: base || null });
+    closeWt();
     launch(project, path, { colorKey: repoDir, worktree: branch, branch });
     toast(`Worktree ${branch} created`);
-  } catch (e) { toast("worktree: " + e); }
+  } catch (e) {
+    dlog("error", `worktree create failed (${branch}): ${e}`);
+    toast("worktree: " + e);
+  } finally { wtBusy = false; }
 }
-function wtCreate() {
-  const branch = ($("wtBranch") as HTMLInputElement).value.trim();
-  if (!branch) { toast("Enter a branch name"); return; }
-  createWorktreeOn(branch);
-}
-// Remove an existing worktree from the dialog's list (the ✕ on a row). The backend
-// never forces: a dirty tree is refused and its --force command handed to a
-// terminal, so nothing uncommitted is ever clobbered by the click. On success the
-// list is refreshed in place so the row disappears.
-let wtRmBusy = false;
-async function removeWorktreeRow(path: string, branch: string, deleteBranch: boolean) {
-  if (!wtCtx || wtRmBusy) return;
-  const { project, repoDir } = wtCtx;
-  wtRmBusy = true;
+
+// The backend never forces: a dirty tree is refused and its --force command handed to
+// a terminal, so nothing uncommitted is ever clobbered by a click here.
+async function wtDoRemove(deleteBranch: boolean) {
+  const d = wtRows[wtSel];
+  if (!d || d.kind !== "wt" || !wtCtx || wtBusy) return;
+  const w = d.wt!, { project, repoDir } = wtCtx;
+  wtBusy = true;
   try {
-    const r = await invoke<GitActionResult>("remove_worktree", { repoDir, path, branch, deleteBranch });
-    dlog(r.ok ? "info" : "warn", `worktree remove · ${branch || path} · ${r.summary}`);
-    if (r.ok) {
-      toast(r.summary);
-      const wts = await invoke<WtInfo[]>("list_worktrees", { repoDir }).catch(() => [] as WtInfo[]);
-      if (wtCtx && wtCtx.repoDir === repoDir) renderWtList(wts);
-    } else if (r.suggest) {
-      // The force handoff must run from the repo root, never the worktree we're
-      // deleting (git refuses to remove the tree you're standing in).
-      toast(`${r.summary} → opening a terminal`);
+    const r = await invoke<GitActionResult>("remove_worktree", { repoDir, path: w.path, branch: w.branch, deleteBranch });
+    dlog(r.ok ? "info" : "warn", `worktree remove · ${w.branch || w.path} · ${r.summary}`);
+    toast(r.ok ? r.summary : `${r.summary} → opening a terminal`);
+    if (!r.ok && r.suggest) {
+      // The handoff must run from the repo root, never the worktree being deleted —
+      // git refuses to remove the tree you're standing in.
+      closeWt();
       await handToTerminal(project, repoDir, r.suggest, { colorKey: repoDir });
-    } else {
-      toast(r.summary);
+      return;
     }
+    wtArmed = "";
+    await wtLoad(true);
   } catch (e) {
     dlog("error", `worktree remove failed: ${e}`);
     toast("worktree: " + e);
-  } finally {
-    wtRmBusy = false;
-    renderAll();
-  }
+  } finally { wtBusy = false; renderAll(); }
 }
+
 // The action-panel "Remove this worktree" flow: guard uncommitted work, then close
 // the session and remove its worktree (safe-deleting the branch if it's merged).
 async function removeWorktreeSession(s: Sess) {
@@ -2601,6 +3284,8 @@ async function removeWorktreeSession(s: Sess) {
     await handToTerminal(s.project, path, "git status", { colorKey: repoDir, worktree: s.worktree, branch });
     return;
   }
+  if (!await ask(`Remove the worktree at ${basename(path)}/?\n\nIts session closes, the folder goes, and its branch is deleted only if it's fully merged.`,
+    { title: "Remove worktree", kind: "warning", okLabel: "Remove", cancelLabel: "Cancel" })) return;
   closeSession(s.id);
   await invoke("kill_session", { sessionId: s.id }).catch(() => {}); // ensure the backend guard sees it gone
   try {
@@ -2855,19 +3540,16 @@ document.addEventListener("click", (e) => {
   if (!t.closest("#usagePop, #fUsageSeg")) closeUsagePop();
   if (!t.closest("#attnPop, #attnBadge")) closeAttnPop();
   if (!t.closest("#shortPop, #fShortSeg")) closeShortPop();
+  if (!t.closest("#bPop, [data-wtpick]")) closeBranchPop(false);
   const dot = t.closest<HTMLElement>(".pdot, .rm-dot");
   if (dot) { const owner = dot.closest<HTMLElement>("[data-key]"); if (owner?.dataset.key) { openColorPopover(owner.dataset.key, e.clientX, e.clientY + 6); return; } }
   // data-forget and data-resume sit INSIDE a data-past row, so they must be matched
   // (and dispatched) ahead of it or the row's own click would swallow them.
-  const el = t.closest<HTMLElement>("[data-perm],[data-git],[data-diff],[data-wtrm],[data-wt],[data-branch],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-sel],[data-launch],[data-pal],[data-rail],[data-toast]");
+  const el = t.closest<HTMLElement>("[data-perm],[data-git],[data-diff],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-sel],[data-launch],[data-pal],[data-rail],[data-toast]");
   if (!el) return;
   if (el.dataset.perm) resolvePermission(el.dataset.permid || "", el.dataset.perm);
   else if (el.dataset.git) runGit(el.dataset.gitsid || "", el.dataset.git);
   else if (el.dataset.diff) openDiff(el.dataset.diff, el.dataset.difftitle || "");
-  // data-wtrm (the ✕) sits beside the data-wt row button, so match it first.
-  else if (el.dataset.wtrm) removeWorktreeRow(el.dataset.wtrm, el.dataset.wtrmbranch || "", el.dataset.wtrmdel === "1");
-  else if (el.dataset.wt) openWorktreeSession(el.dataset.wt, el.dataset.wtbranch || "");
-  else if (el.dataset.branch) createWorktreeOn(el.dataset.branch);
   else if (el.dataset.close) closeSession(el.dataset.close);
   else if (el.dataset.remove) removeFavorite(el.dataset.remove);
   else if (el.dataset.add) addProject();
@@ -3062,7 +3744,7 @@ $("ctxMenu").addEventListener("click", (e) => {
   closeCtxMenu(); closeColorPop();
   switch (b.dataset.ctx) {
     case "launch": requestLaunch(name, key); break;
-    case "worktree": openWt(name, key, false); break;
+    case "worktree": openWt(name, key); break;
     case "terminal": openTerminalIn(name, key); break;
     case "folder": openProjectFolder(key); break;
     case "copypath": copyPath(key); break;
@@ -3450,17 +4132,80 @@ $("btnNew").addEventListener("click", () => {
   const c = activeProjectCtx();
   if (c) requestLaunch(c.project, c.path); else openPalette();
 });
-$("btnWorktree").addEventListener("click", () => { const c = activeProjectCtx(); if (!c) { toast("No active session"); return; } openWt(c.project, c.path, false); });
+$("btnWorktree").addEventListener("click", () => { const c = activeProjectCtx(); if (!c) { toast("No active session"); return; } openWt(c.project, c.path); });
 $("btnTerm").addEventListener("click", openPlainTerminal);
 $("fRepo").addEventListener("click", (e) => { e.preventDefault(); openUrl("https://github.com/respeak-io/muster").catch(() => {}); });
 $("fEngineSeg").addEventListener("click", (e) => { e.stopPropagation(); $("enginePop").classList.contains("show") ? closeEnginePop() : openEnginePopover(); });
 $("fUsageSeg").addEventListener("click", (e) => { e.stopPropagation(); $("usagePop").classList.contains("show") ? closeUsagePop() : openUsagePop(); });
 $("fShortSeg").addEventListener("click", (e) => { e.stopPropagation(); $("shortPop").classList.contains("show") ? closeShortPop() : openShortPop(); });
 $("btnClose").addEventListener("click", () => { if (activeId) closeSession(activeId); });
-$("wtGo").addEventListener("click", wtCreate);
-$("wtCancel").addEventListener("click", closeWt);
-$("wtMain").addEventListener("click", () => { if (!wtCtx) return; const { project, repoDir } = wtCtx; closeWt(); launch(project, repoDir, { colorKey: repoDir }); });
-$("wtBranch").addEventListener("keydown", (e) => { if (e.key === "Enter") { e.preventDefault(); wtCreate(); } else if (e.key === "Escape") closeWt(); });
+// The dialog handles its own clicks and keys: rows are addressed by index into
+// wtRows, so nothing leaks into the global [data-*] dispatcher.
+$("wtRefresh").addEventListener("click", () => { void wtReadLocal(true).then(() => wtMaybeFetch(true)); });
+// Coming back to the window is the moment the list is most likely to be wrong: you were
+// just in a terminal, or someone else pushed. Re-read locally and fetch (throttled).
+// Skipped while the branch chooser is open — re-rendering would swap the element its
+// popover is anchored to out from under a choice in progress.
+window.addEventListener("focus", () => {
+  if (!$("wtDlg").classList.contains("show") || bPopOpen()) return;
+  void wtReadLocal(true).then(() => wtMaybeFetch());
+});
+$("wtQ").addEventListener("input", () => { wtSel = 0; wtArmed = ""; wtRender(); });
+$("wtQ").addEventListener("keydown", (e) => {
+  if (e.key === "ArrowDown") { e.preventDefault(); wtSel = Math.min(wtSel + 1, wtRows.length - 1); wtRender(); }
+  else if (e.key === "ArrowUp") { e.preventDefault(); wtSel = Math.max(wtSel - 1, 0); wtRender(); }
+  else if (e.key === "Enter") { e.preventDefault(); wtRun(wtRows[wtSel]); }
+  else if (e.key === "Escape") {
+    e.preventDefault();
+    // Esc peels one layer at a time: an armed removal, then the filter, then the dialog.
+    if (wtArmed) { wtArmed = ""; wtRender(); }
+    else if (($("wtQ") as HTMLInputElement).value) { ($("wtQ") as HTMLInputElement).value = ""; wtSel = 0; wtRender(); }
+    else closeWt();
+  }
+});
+$("wtDlg").addEventListener("click", (e) => {
+  const t = e.target as HTMLElement;
+  const pick = t.closest<HTMLElement>("[data-wtpick]");
+  if (pick) {
+    if (bPopOpen()) { closeBranchPop(); return; }
+    const head = wtRepoBranch || "HEAD";
+    if (pick.dataset.wtpick === "base") {
+      openBranchPop(pick, wtBaseOptions(), wtBase || head, (n) => { wtBase = n === head ? "" : n; wtRender(); });
+    } else {
+      openBranchPop(pick, wtSwitchOptions(), wtSwitchTo || wtSwitchable()[0]?.name || "", (n) => { wtSwitchTo = n; wtRender(); });
+    }
+    return;
+  }
+  const jump = t.closest<HTMLElement>("[data-wtjump]");
+  if (jump) { const id = jump.dataset.wtjump!; closeWt(); setActive(id); return; }
+  const act = t.closest<HTMLElement>("[data-wtact]");
+  if (act) {
+    switch (act.dataset.wtact) {
+      case "go": wtRun(wtRows[wtSel]); break;
+      case "arm": wtArmed = wtRows[wtSel]?.dir || ""; wtRender(); break;
+      case "cancel": wtArmed = ""; wtRender(); break;
+      case "rm0": void wtDoRemove(false); break;
+      case "rm1": void wtDoRemove(true); break;
+      case "delbranch": void wtDeleteBranch(); break;
+      case "doswitch": void wtDoSwitch(); break;
+      case "openclash": {
+        const c = wtRows[wtSel]?.clash;
+        if (c && wtCtx) { const { project, repoDir } = wtCtx; closeWt(); launch(project, c.path, { colorKey: repoDir, worktree: wtLabelOf(c), branch: c.branch }); }
+        break;
+      }
+    }
+    ($("wtQ") as HTMLInputElement).focus();
+    return;
+  }
+  const row = t.closest<HTMLElement>("[data-wti]");
+  if (row) { wtSel = +row.dataset.wti!; wtArmed = ""; wtRender(); ($("wtQ") as HTMLInputElement).focus(); }
+});
+// Double-click a row to go, so the mouse path doesn't require crossing to the pane's
+// button. The first click of the pair already selected it, so this just runs it.
+$("wtList").addEventListener("dblclick", (e) => {
+  const row = (e.target as HTMLElement).closest<HTMLElement>("[data-wti]");
+  if (row) { e.preventDefault(); wtRun(wtRows[+row.dataset.wti!]); }
+});
 $("scrim").addEventListener("click", () => { closePalette(); closeWt(); closeDiff(); closeSettings(); });
 $("diffClose").addEventListener("click", closeDiff);
 // Collapse / expand a file section by clicking its header.
@@ -3691,3 +4436,4 @@ initFileDrop();
 // reconcileCaf() paints the button. Note this is the ONE place agent-mode could
 // auto-assert on launch — but cafArmed is false at boot, so it stays dormant.
 renderAll();
+

--- a/src/styles.css
+++ b/src/styles.css
@@ -535,65 +535,153 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .pal-foot .sp { flex: 1; }
 .pal-foot .pf-mode { color: var(--st-done); }
 
-/* worktree dialog */
-.wtdlg { position: fixed; top: 22vh; left: 50%; transform: translateX(-50%) translateY(-8px) scale(.98); width: min(420px, 92vw); max-height: 82vh; overflow-y: auto; z-index: 42; opacity: 0; pointer-events: none; transition: opacity .16s, transform .16s; border-radius: var(--radius-lg); padding: 18px; background: linear-gradient(180deg, rgba(255,255,255,.06), transparent 40%), color-mix(in srgb, var(--panel) 94%, transparent); backdrop-filter: blur(24px) saturate(1.4); border: 1px solid var(--hair-strong); box-shadow: 0 40px 100px -30px rgba(0,0,0,.8), inset 0 1px 0 rgba(255,255,255,.08); }
+/* new-session dialog — one question ("where should this session run?"), one list.
+   Head + query + foot are pinned; .wt-body is the only scroll region, so a repo with
+   ninety refs can never push the keyboard legend or the title off-screen (the old
+   dialog scrolled itself AND its branch list, which nested two scrollbars). */
+.wtdlg { position: fixed; top: 12vh; left: 50%; transform: translateX(-50%) translateY(-8px) scale(.98); width: min(880px, 94vw); max-height: 76vh; display: flex; flex-direction: column; overflow: hidden; z-index: 42; opacity: 0; pointer-events: none; transition: opacity .16s, transform .16s; border-radius: var(--radius-lg); background: linear-gradient(180deg, rgba(255,255,255,.06), transparent 40%), color-mix(in srgb, var(--panel) 92%, transparent); backdrop-filter: blur(24px) saturate(1.4); border: 1px solid var(--hair-strong); box-shadow: 0 40px 100px -30px rgba(0,0,0,.8), inset 0 1px 0 rgba(255,255,255,.08); }
 .wtdlg.show { opacity: 1; pointer-events: auto; transform: translateX(-50%) translateY(0) scale(1); }
-.wt-h { font-size: 14px; font-weight: 700; }
-.wt-sub { font-size: 11.5px; color: var(--muted); margin: 4px 0 14px; }
-.wt-lbl { font-size: 9px; letter-spacing: .11em; text-transform: uppercase; color: var(--muted-2); font-weight: 700; }
-/* Sub-label on the same line: says the field takes existing branches too, without
-   shouting it in caps alongside the label itself. */
-.wt-hint { text-transform: none; letter-spacing: 0; font-weight: 500; opacity: .62; margin-left: 5px; }
-.wt-in { width: 100%; height: 32px; margin-top: 6px; border-radius: 8px; border: 1px solid var(--hair-strong); background: var(--bg-2); color: var(--text); padding: 0 11px; font: 13px var(--font-mono); outline: none; }
-.wt-in:focus { border-color: var(--accent-line); }
-.wt-list { display: flex; flex-direction: column; gap: 4px; margin: 2px 0 14px; }
-.wt-list .wt-lbl { margin-bottom: 4px; }
-.wt-item { display: flex; align-items: center; gap: 8px; width: 100%; padding: 7px 10px; border-radius: 8px; cursor: pointer; border: 1px solid var(--hair); background: var(--surface); color: var(--text); text-align: left; }
-.wt-item:hover { border-color: var(--hair-strong); background: var(--surface-2); }
-.wt-br { font: 12px var(--font-mono); }
-.wt-open { margin-left: auto; font-size: 9.5px; letter-spacing: .06em; text-transform: uppercase; color: var(--muted-2); }
-/* An existing-worktree row: the open button + its ✕ remove control, side by side. */
-.wt-row { display: flex; align-items: center; gap: 6px; }
-.wt-row .wt-item { flex: 1 1 auto; min-width: 0; }
-.wt-rm { flex: none; width: 28px; align-self: stretch; display: grid; place-items: center; border-radius: 8px; border: 1px solid var(--hair); background: var(--surface); color: var(--muted-2); cursor: pointer; font-size: 12px; line-height: 1; }
-.wt-rm:hover { border-color: #f2555a; color: #f2555a; background: var(--surface-2); }
-/* Cleanliness cue chips inside a worktree row (merged = safe to clean, dirty = has work). */
-.wt-tag { font-size: 9px; letter-spacing: .06em; text-transform: uppercase; padding: 1px 6px; border-radius: 5px; border: 1px solid var(--hair); }
-.wt-tag.merged { color: #34d399; border-color: color-mix(in srgb, #34d399 40%, transparent); }
-.wt-tag.dirty { color: #d99b12; border-color: color-mix(in srgb, #facc15 45%, transparent); }
 
-/* "Start here — no worktree" — the escape hatch, styled as a real primary-ish option
-   (accent wash, full width, leads the dialog) so a worktree doesn't read as the only
-   path. The branch name stays a plain inline .wt-mainbr span, NOT an ellipsised block:
-   an inline-block with overflow:hidden takes its bottom margin edge as its baseline,
-   so `vertical-align` had to fake alignment, and the fake broke because the mono face
-   (JetBrains) and UI face (SF Pro) have different ascent/descent. As a plain inline it
-   shares the button's baseline for free. (Long branch names just wrap — no ellipsis.) */
-.wt-here { width: 100%; margin: 0 0 2px; padding: 9px 12px; border-radius: 9px; cursor: pointer; text-align: left; font: 600 12.5px var(--font-ui); color: var(--text); border: 1px solid var(--accent-line); background: var(--accent-wash); }
-.wt-here:hover { filter: brightness(1.08); }
-.wt-mainbr { font-family: var(--font-mono); }
-/* "or in a worktree" rule between the escape hatch and the worktree options */
-.wt-or { display: flex; align-items: center; gap: 8px; margin: 10px 0; font: 9px var(--font-mono); letter-spacing: .13em; text-transform: uppercase; color: var(--muted-2); }
-.wt-or::before, .wt-or::after { content: ""; flex: 1; height: 1px; background: var(--hair); }
+.wt-head { flex: none; padding: 13px 14px 11px; border-bottom: 1px solid var(--hair); }
+.wt-title { display: flex; align-items: baseline; gap: 8px; }
+.wt-title b { font-size: 13.5px; font-weight: 700; letter-spacing: -.01em; }
+.wt-proj { font: 11px var(--font-mono); color: var(--accent-ink); }
+.wt-headrow { display: flex; align-items: center; gap: 8px; margin-top: 5px; }
+.wt-path { font: 10.5px var(--font-mono); color: var(--muted-2); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.wt-eng, .wt-chip { flex: none; display: inline-flex; align-items: center; gap: 5px; font: 10px var(--font-mono); color: var(--muted); border: 1px solid var(--hair); border-radius: 6px; padding: 3px 7px; background: var(--surface); }
+.wt-chip { cursor: pointer; }
+.wt-chip:hover { border-color: var(--hair-strong); color: var(--text); }
+.wt-chip.spin { color: var(--accent-ink); border-color: var(--accent-line); }
 
-/* branch picker — same rows as .wt-list, capped + scrollable so a busy repo can't
-   push the input and buttons off-screen */
-.wt-branches { display: flex; flex-direction: column; gap: 4px; margin: 2px 0 14px; max-height: 184px; overflow-y: auto; }
-.wt-branches .wt-lbl { margin-bottom: 4px; }
-.wt-branch .wt-bmeta { margin-left: auto; display: flex; align-items: center; gap: 7px; flex: none; }
-.wt-when { font: 10px var(--font-mono); color: var(--muted-2); white-space: nowrap; }
-.wt-ab { font: 10px var(--font-mono); padding: 0 5px; border-radius: 5px; border: 1px solid var(--hair); line-height: 16px; }
+.wt-q { flex: none; display: flex; align-items: center; gap: 9px; padding: 0 14px; height: 44px; border-bottom: 1px solid var(--hair); }
+.wt-caret { flex: none; color: var(--accent); font: 13px var(--font-mono); }
+.wt-q input { flex: 1; min-width: 0; background: transparent; border: 0; outline: none; color: var(--text); font: 13px var(--font-mono); padding: 0; }
+.wt-q input::placeholder { color: var(--muted-2); font-family: var(--font-ui); font-size: 12.5px; }
+.wt-count { flex: none; font: 10px var(--font-mono); color: var(--muted-2); }
+
+/* list left, consequences right */
+.wt-body { flex: 1 1 auto; min-height: 0; display: grid; grid-template-columns: 366px minmax(0, 1fr); }
+.wt-list { min-height: 0; overflow-y: auto; padding: 6px; border-right: 1px solid var(--hair); scrollbar-width: thin; }
+.wt-gh { display: flex; align-items: center; gap: 7px; padding: 10px 8px 4px; font: 9px var(--font-mono); letter-spacing: .13em; text-transform: uppercase; color: var(--muted-2); }
+.wt-gh:first-child { padding-top: 4px; }
+.wt-gh .gc { letter-spacing: 0; color: var(--muted); background: var(--surface-2); border-radius: 4px; padding: 0 5px; }
+.wt-gh .rule { flex: 1; height: 1px; background: var(--hair); }
+
+.wt-item { display: flex; align-items: center; gap: 10px; width: 100%; padding: 7px 9px; border-radius: var(--radius-sm); background: transparent; border: 1px solid transparent; color: var(--text); text-align: left; cursor: pointer; font-family: inherit; }
+.wt-item:hover { background: var(--surface); }
+.wt-item.on, .wt-item.on:hover { background: var(--accent-wash); border-color: var(--accent-line); }
+/* the typed query, promoted to an action — pinned above every group */
+.wt-item.create { background: var(--accent-wash); border-color: var(--accent-line); }
+.wt-ic { flex: none; width: 20px; height: 20px; border-radius: 6px; display: grid; place-items: center; font-size: 10px; background: var(--surface); border: 1px solid var(--hair); color: var(--muted); }
+.wt-item.on .wt-ic, .wt-item.create .wt-ic { color: var(--accent-ink); border-color: var(--accent-line); }
+.wt-main { display: flex; flex-direction: column; gap: 1px; min-width: 0; flex: 1; }
+/* A long mono branch name must never widen the row — the old .wt-br had no
+   min-width/ellipsis, so `claude/implement-workflow-plugins-KKQKU` grew a horizontal
+   scrollbar. The head flexes and ellipsises; the last chars are pinned by .wt-tl,
+   because sibling branches often differ ONLY in their suffix. */
+.wt-br { display: flex; min-width: 0; font: 12px var(--font-mono); }
+.wt-br .hd { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.wt-br .tl { flex: none; white-space: pre; }
+.wt-sub2 { font: 10px var(--font-mono); color: var(--muted-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.wt-meta { margin-left: auto; flex: none; display: flex; align-items: center; gap: 6px; }
+
+/* state chips: what makes this destination different from a plain clean checkout */
+.wt-tag { font: 9px/16px var(--font-mono); letter-spacing: .05em; text-transform: uppercase; padding: 0 6px; border-radius: 5px; border: 1px solid var(--hair); color: var(--muted-2); white-space: nowrap; }
+.wt-tag.open { color: var(--st-done); border-color: color-mix(in srgb, var(--st-done) 42%, transparent); }
+.wt-tag.merged { color: var(--st-done); border-color: color-mix(in srgb, var(--st-done) 34%, transparent); }
+.wt-tag.dirty { color: var(--st-working); border-color: color-mix(in srgb, var(--st-working) 42%, transparent); }
+.wt-tag.moved { color: var(--st-working); border-color: color-mix(in srgb, var(--st-working) 42%, transparent); }
+.wt-tag.missing { color: var(--st-error); border-color: color-mix(in srgb, var(--st-error) 42%, transparent); }
+.wt-tag.det, .wt-tag.locked, .wt-tag.ext { color: var(--st-idle); }
+/* `gone` is INFORMATION, not a fault: the remote branch was deleted, which usually
+   follows a merged PR but just as often precedes picking the work back up. It must
+   not share .missing's error red — that reads as "broken, delete me" and argues
+   against the primary action on the row, which is still to start a worktree here. */
+.wt-tag.gone { color: var(--muted); border-color: var(--hair-strong); }
+.wt-ab { font: 10px/16px var(--font-mono); padding: 0 5px; border-radius: 5px; border: 1px solid var(--hair); }
 .wt-ahead { color: var(--st-done); }   /* has commits the current branch doesn't */
-.wt-behind { color: var(--muted); }    /* trails the current branch */
-/* stale = no commit in a while; dim it, but recover on hover so it stays selectable */
-.wt-branch.stale { opacity: .5; }
-.wt-branch.stale:hover { opacity: 1; }
+.wt-behind { color: var(--muted-2); }  /* trails the current branch */
+.wt-when { font: 10px var(--font-mono); color: var(--muted-2); white-space: nowrap; }
+/* stale = no commit in a while; dim it, but recover on hover/highlight so a dim row
+   is never a less reachable one */
+.wt-item.stale .wt-br, .wt-item.stale .wt-when, .wt-item.stale .wt-ab { opacity: .48; }
+.wt-item.stale:hover .wt-br, .wt-item.stale.on .wt-br,
+.wt-item.stale:hover .wt-when, .wt-item.stale.on .wt-when,
+.wt-item.stale:hover .wt-ab, .wt-item.stale.on .wt-ab { opacity: 1; }
 
-.wt-btns { display: flex; gap: 8px; margin-top: 16px; }
-.wt-btns button { height: 32px; padding: 0 13px; border-radius: 8px; cursor: pointer; font: 600 12px var(--font-ui); border: 1px solid var(--hair-strong); background: var(--surface); color: var(--text); }
-.wt-btns button:hover { filter: brightness(1.08); }
-.wt-cancel { margin-right: auto; }
-.wt-go { background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 88%, white 12%), var(--accent)); color: #16121f; border-color: transparent; }
+/* skeleton rows — both lists cost several git calls (a status probe per checkout, a
+   rev-list per ref), so the shape is drawn before the data lands */
+.wt-sk { display: flex; align-items: center; gap: 10px; padding: 7px 9px; }
+.wt-sk i { display: block; height: 9px; border-radius: 4px; background: var(--surface-2); animation: wtpulse 1.35s ease-in-out infinite; }
+.wt-sk i.a { width: 20px; height: 20px; border-radius: 6px; flex: none; }
+@keyframes wtpulse { 0%, 100% { opacity: .45; } 50% { opacity: .95; } }
+@media (prefers-reduced-motion: reduce) { .wt-sk i { animation: none; opacity: .6; } }
+.wt-empty { padding: 22px 12px; text-align: center; color: var(--muted-2); font-size: 12px; }
+.wt-empty b { display: block; color: var(--muted); font-size: 12.5px; margin-bottom: 3px; }
+
+/* the detail pane — what you're about to walk into */
+.wt-detail { min-width: 0; min-height: 0; overflow-y: auto; padding: 14px 16px 12px; display: flex; flex-direction: column; gap: 13px; scrollbar-width: thin; }
+.wt-dhead { display: flex; flex-direction: column; gap: 4px; }
+.wt-dkind { font: 9px var(--font-mono); letter-spacing: .14em; text-transform: uppercase; color: var(--muted-2); }
+.wt-dname { font: 13px var(--font-mono); color: var(--text); overflow-wrap: anywhere; line-height: 1.35; }
+.wt-dname .dim { color: var(--muted-2); }
+.wt-facts { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 7px 12px; align-items: baseline; margin: 0; }
+.wt-facts dt { font: 9px var(--font-mono); letter-spacing: .12em; text-transform: uppercase; color: var(--muted-2); white-space: nowrap; }
+.wt-facts dd { margin: 0; font: 11.5px var(--font-mono); color: var(--muted); min-width: 0; overflow-wrap: anywhere; }
+.wt-facts dd .em { color: var(--text); }
+.wt-facts dd .good { color: var(--st-done); }
+.wt-facts dd .warn { color: var(--st-working); }
+.wt-facts dd .subj { display: block; color: var(--text); margin-top: 2px; font-size: 11px; line-height: 1.4; }
+
+/* a consequence the row can't fit: divergence, detachment, a taken folder */
+.wt-warn { border-left: 2px solid var(--st-working); border-radius: 0 7px 7px 0; background: color-mix(in srgb, var(--st-working) 10%, transparent); padding: 9px 11px; font: 11px/1.5 var(--font-ui); color: var(--muted); }
+.wt-warn b { color: var(--text); font: 600 10.5px var(--font-mono); }
+.wt-warn .t { display: block; color: var(--st-working); font: 700 9px var(--font-mono); letter-spacing: .12em; text-transform: uppercase; margin-bottom: 4px; }
+.wt-warn.err { border-left-color: var(--st-error); background: color-mix(in srgb, var(--st-error) 9%, transparent); }
+/* neutral variant: explains a consequence without implying anything is wrong */
+.wt-warn.note { border-left-color: var(--accent-line); background: var(--accent-wash); }
+.wt-warn.note .t { color: var(--accent-ink); }
+.wt-warn.err .t { color: var(--st-error); }
+
+.wt-sess { display: flex; flex-wrap: wrap; gap: 5px; }
+.wt-sessb { display: inline-flex; align-items: center; gap: 5px; cursor: pointer; font: 10.5px var(--font-mono); color: var(--muted); background: var(--surface); border: 1px solid var(--hair); border-radius: 6px; padding: 3px 7px; }
+.wt-sessb:hover { border-color: var(--accent-line); color: var(--text); }
+.wt-sessb i { width: 6px; height: 6px; border-radius: 50%; display: block; }
+
+.wt-acts { margin-top: auto; padding-top: 6px; display: flex; align-items: center; gap: 7px; flex-wrap: wrap; }
+.wt-go { font: 600 12px var(--font-ui); padding: 7px 13px; border-radius: 8px; cursor: pointer; border: 1px solid transparent; color: #16121f; background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 88%, white 12%), var(--accent)); }
+.wt-go:hover { filter: brightness(1.08); }
+.wt-go[disabled] { opacity: .45; cursor: not-allowed; filter: none; }
+.wt-alt { font: 600 12px var(--font-ui); padding: 7px 11px; border-radius: 8px; cursor: pointer; border: 1px solid var(--hair-strong); background: var(--surface); color: var(--text); }
+.wt-alt:hover { border-color: var(--muted-2); }
+.wt-rm { margin-left: auto; font: 600 11.5px var(--font-ui); padding: 7px 10px; border-radius: 8px; cursor: pointer; border: 1px solid transparent; background: transparent; color: var(--muted-2); }
+.wt-rm:hover { color: var(--st-error); border-color: color-mix(in srgb, var(--st-error) 45%, transparent); }
+.wt-rm[disabled] { opacity: .4; cursor: not-allowed; }
+/* removal confirm, in the pane rather than a modal on a modal: the checkout and the
+   branch are separate losses, so they get separate sentences and separate buttons */
+.wt-danger { border: 1px solid color-mix(in srgb, var(--st-error) 40%, transparent); background: color-mix(in srgb, var(--st-error) 7%, transparent); border-radius: var(--radius-sm); padding: 10px 11px; display: flex; flex-direction: column; gap: 9px; }
+.wt-danger .q { font-size: 11.5px; color: var(--text); }
+.wt-danger .q b { font: 600 11px var(--font-mono); }
+.wt-danger .w { font: 10.5px/1.45 var(--font-ui); color: var(--muted); }
+.wt-danger .w .em { color: var(--st-working); }
+.wt-danger .row { display: flex; gap: 6px; flex-wrap: wrap; }
+.wt-cbtn { font: 600 11px var(--font-ui); padding: 5px 9px; border-radius: 6px; cursor: pointer; border: 1px solid var(--hair-strong); background: var(--surface); color: var(--text); }
+.wt-cbtn:hover { border-color: var(--muted-2); }
+.wt-cbtn.danger { border-color: color-mix(in srgb, var(--st-error) 55%, transparent); color: var(--st-error); }
+.wt-cbtn.danger:hover { background: color-mix(in srgb, var(--st-error) 14%, transparent); }
+.wt-cbtn.ghost { border-color: transparent; color: var(--muted); }
+
+.wt-foot { flex: none; display: flex; align-items: center; gap: 12px; flex-wrap: wrap; padding: 8px 13px; border-top: 1px solid var(--hair); font: 9.5px var(--font-mono); color: var(--muted-2); }
+.wt-foot .k { font: 9px var(--font-mono); color: var(--muted); border: 1px solid var(--hair-strong); border-radius: 4px; padding: 2px 5px; min-width: 15px; display: inline-block; text-align: center; }
+.wt-foot .sp { flex: 1; }
+.wt-verb { color: var(--accent-ink); }
+
+/* narrow window: drop to one column, list on top — the pane is the first thing to go */
+@media (max-width: 900px) {
+  .wt-body { grid-template-columns: minmax(0, 1fr); grid-template-rows: minmax(0, 1fr) auto; }
+  .wt-list { border-right: 0; border-bottom: 1px solid var(--hair); }
+  .wt-detail { max-height: 42vh; }
+}
 
 /* settings dialog — sidebar-tab layout on the shared #scrim overlay */
 /* Fixed footprint on purpose: one size shared by every tab, so switching tabs never
@@ -795,6 +883,29 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .menupop .mp-s { font-size: 10px; font-weight: 500; color: var(--muted-2); }
 .menupop .mp-check { margin-left: auto; color: var(--accent-ink); font-size: 11px; opacity: 0; }
 .menupop .mp-item.on .mp-check { opacity: 1; }
+/* branch chooser: the .menupop idiom plus a filter, because a repo can hold
+   BRANCH_LIST_CAP refs and scrolling to one is not a choice — typing is. */
+.bpop { min-width: 268px; max-width: 340px; }
+.bpop .bp-q { display: flex; align-items: center; gap: 7px; padding: 4px 7px 7px; border-bottom: 1px solid var(--hair); margin-bottom: 4px; }
+.bpop .bp-q span { color: var(--accent); font: 12px var(--font-mono); flex: none; }
+.bpop .bp-q input { flex: 1; min-width: 0; background: transparent; border: 0; outline: none; color: var(--text); font: 12px var(--font-mono); padding: 0; }
+.bpop .bp-q input::placeholder { color: var(--muted-2); }
+.bpop .bp-list { display: flex; flex-direction: column; gap: 2px; max-height: 264px; overflow-y: auto; scrollbar-width: thin; }
+.bpop .mp-l { font-family: var(--font-mono); font-weight: 500; font-size: 11.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.bpop .mp-main { flex: 1; }
+.bpop .bp-none { padding: 10px 9px; color: var(--muted-2); font-size: 11.5px; }
+/* listed but not choosable — git allows one checkout per branch. Dimmed rather than
+   hidden: a branch that silently vanishes reads as a bug, not as a rule. */
+.bpop .mp-item.dis { cursor: not-allowed; opacity: .5; }
+.bpop .mp-item.dis:hover { background: transparent; }
+.bpop .mp-item.dis .mp-s { color: var(--st-working); }
+/* the trigger reads as a field, not a button — it holds a value */
+.wt-pick { display: inline-flex; align-items: center; gap: 7px; max-width: 100%; cursor: pointer;
+  font: 11.5px var(--font-mono); color: var(--text); background: var(--surface);
+  border: 1px solid var(--hair-strong); border-radius: 6px; padding: 4px 8px; }
+.wt-pick:hover, .wt-pick.open { border-color: var(--accent-line); }
+.wt-pick .v { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.wt-pick .c { flex: none; color: var(--muted-2); font-size: 9px; }
 
 /* project context menu (right-click a project head / session row / rail button) */
 .ctxmenu { min-width: 244px; max-width: 300px; }


### PR DESCRIPTION
The worktree dialog grew a widget at a time — a button, a list, a second list, a text field with its own datalist — until it asked **four questions to answer one**: where should this session run? Every answer is a directory, so every answer is now a row, with the consequences of the highlighted one in a pane beside it.

## The defects it fixes

Each one is a line you can point at, not a matter of taste.

| | |
|---|---|
| **Horizontal scrollbar** on long branch names | `.wt-br` set a mono font and nothing else — no `min-width: 0`, no `text-overflow`. In a flex row `claude/implement-workflow-plugins-KKQKU` simply refused to shrink. |
| **Two nested scroll regions** | The dialog scrolled *and* the branch list scrolled inside it, so the header left the screen while the inner list trapped the wheel. |
| **The repo's own folder was unreachable** | From three of four entry points. `renderWtList` filtered `is_main`, and the "start here" button only rendered when `requestLaunch` was the opener. |
| **Data read once, never again** | Merge a branch or remove a worktree in a terminal and the dialog kept showing the world as it was when it opened. |
| **The primary button ignored the selection** | `Create worktree ▸` was fixed, but a worktree row and a branch row are different verbs. |
| **No keyboard, no filter** | ~90 rows, click-only, next to a command palette that does `↑↓⏎` over exactly this shape of list. |
| **Removal fired on the first click** | The ✕ called `remove_worktree` immediately, passing `deleteBranch: true` on a merged row. |

Head and foot pin; only the list scrolls. Long names truncate at the head with the last characters pinned, because sibling branches often differ only in their suffix.

## Branch context that answers a real question

`ahead`/`behind` were measured against whatever HEAD happened to be on. For an old branch that's always "very behind", which tells you nothing. They now track **each branch's own remote** via `%(upstream:track)` — which also removes the per-branch `rev-list`, so the list costs one `for-each-ref` instead of N+1 processes.

- `↑n` / `↓n` — unpushed / unpulled against `origin/<branch>`
- `GONE` — upstream configured but deleted on the remote
- `local` — never pushed
- in sync → nothing at all

One trap the tests caught: git will set a **local** branch as an upstream (`branch.autoSetupMerge`), and "2 commits not pushed to `dev`" is nonsense when `dev` is right there. An upstream only counts when the full refname is under `refs/remotes/`.

`GONE` is styled as neutral information, not error red — a branch whose remote was deleted is often one you want to pick back up, and the pane says so: *"starting a worktree here is fine; the first `git push -u` recreates `origin/<name>`."*

## When the folder and the branch disagree

`create_worktree` derives the directory from the branch name **once, at creation**: `<repo-parent>/.cc-worktrees/<repo>/<branch with / → ->`. Nothing keeps them in step, and an agent running `git switch` inside the checkout makes the folder name a lie.

**The directory is the identity; the branch is the label; both show when they differ.** Rows search by either. The slug is lossy (`/` and every odd character both become `-`), so nothing tries to reconstruct a branch name from a folder — the UI names the folder, which is the thing that exists.

That same derivation is why a new worktree can collide with a folder that's already taken. Both designs already compute the destination path to display it, so the collision is caught **while you type**, with the two real ways out — rather than surfacing git's *"already checked out at …"* pointing at a path that doesn't contain the branch name.

## New actions, and the guards that let them exist

- **Delete a local branch** — safe `git branch -d` only; on refusal the `-D` command goes to a terminal, never to a click. The confirm warns up front that a *squash*-merged PR won't safe-delete, since its commits never became ancestors of HEAD.
- **Switch the root folder's branch** — refused while sessions run there (it would move the ground under a live agent mid-edit), refused on a dirty tree (git would silently *carry* the changes across — not destructive, but a state change the UI never announced). Branches that can't be switched to are **listed and disabled with the reason**; one that silently vanishes reads as a bug.
- **Choose a new worktree's start-point** — `worktree add -b <new> <path> <base>`. Without it, whatever the root is parked on becomes the silent parent of every new branch. The new test pins that trap, not just the feature.

## Freshness

Two layers, split by what they cost. `wtReadLocal` is pure local git — instant, re-run on open, on window focus, and after every mutation. `wtMaybeFetch` is the network half: throttled to once a minute, backgrounded, and **silent on failure**, because a stale number beats a toast every time you alt-tab offline.

## Performance: a UI-blocking hazard, removed

Tauri runs non-`async` commands **on the main thread**, and 40 of 41 commands were sync — including `git_action`, i.e. `git fetch` with a 45s cap. Anything on the main thread serializes every other IPC call, which is why `+ Session` felt dead: `requestLaunch` awaited `git_branch` *before* showing the dialog, and that call queued.

Fifteen commands that only shell out to `git`/`ps` are now `#[tauri::command(async)]`, and `requestLaunch` awaits nothing — it decides from state already in memory. Measured after the change:

```
fetch=1650ms   branch-while-fetching=18ms
```

Concurrent. Previously that 18 ms call waited the full 1650 ms. The 3s/4s/5s pollers were contending for the same thread, so this should steady the whole app, not just this dialog.

## Also fixed on the way

- **A latent test flake**: `scratch_dir` gives every test repo the same parent, so two tests were `remove_dir_all`-ing the *shared* `temp/.cc-worktrees` tree and could delete each other's checkouts mid-assertion.
- **The launch palette listed only favourites**, hiding every externally-detected project the sidebar showed — so `+ Session` with nothing selected offered an arbitrary-looking subset. Both now read one `allProjects()`.
- `locked` / `exists` on `Worktree`: a locked worktree was handed a `--force` command that would also fail, and a hand-deleted folder would have had a PTY spawned into it.

## Testing

`cargo test` **19/19** (4 new: locked/missing handling, `git_commit_info`, branch deletion, worktree base) · `tsc` clean · `vitest` 12/12 · `vite build` ok.

⚠️ **Not verified by clicking.** Synthetic mouse events don't reach the WKWebView, so `Switch branch`, `Delete branch`, `Remove worktree`, row double-click and picking from the popover rest on Rust tests and `tsc` rather than on being exercised. Rendering of every state *is* confirmed against the real `muster` repo, and the data paths were verified via the debug log. The root switch is the one worth trying by hand first — it's the only action that mutates the folder you're standing in.

Two follow-ups deliberately left out: CLAUDE.md has no `## Worktrees` section, and this adds five backend commands that are now undocumented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
