### PR TITLE
Release 0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "episko",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.11.1",
   "type": "module",
   "packageManager": "pnpm@10.33.2",
   "engines": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Episko",
-  "version": "0.12.0",
+  "version": "0.11.1",
   "identifier": "io.respeak.episko",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Corrects the version for this release: **0.11.1**, not 0.12.0.

The 88 commits behind it are a module split, a test suite and CI gates — real work, and invisible from the app. What a user actually gets is `⌘⏎` to reveal a session's folder, and a symlinked project no longer showing an empty restore list. That's a patch.

Both `package.json` and `src-tauri/tauri.conf.json` carry `0.11.1`, so the footer will agree with the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)