### PR TITLE
site: chain the deploy off release.yml, since `release: published` cannot fire

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,16 +1,33 @@
 name: site
 
 # Deploys the episko.dev marketing site (site/ -> the episko-site Worker) and keeps
-# its baked-in version label in sync with the latest release. Three ways in:
+# its baked-in version label in sync with the latest release. Four ways in:
 #
-#   release published  -> stamp the release tag, deploy      (the automated path)
-#   push to main       -> stamp package.json's version, deploy  (site/ content edits)
-#   manual dispatch    -> optional version input, else package.json
+#   release.yml finished -> stamp its tag, deploy            (the automated path)
+#   release published    -> stamp the release tag, deploy    (a hand-published one)
+#   push to main         -> stamp package.json's version, deploy  (site/ content edits)
+#   manual dispatch      -> optional version input, else package.json
+#
+# **Why the automated path chains off the workflow instead of the release.** The
+# release is created by tauri-action using GITHUB_TOKEN, and GitHub will not start a
+# workflow run from an event that token raised — so `release: [published]` never
+# fires for our own releases. It fired for none of v0.10.0 … v0.11.1, and v0.11.1
+# had to be deployed by hand. `workflow_run` is the documented exemption: it keys off
+# a *run completing*, whatever token drove it. `release: [published]` stays anyway,
+# for a release published by a human from the UI, which workflow_run would not see.
+# Both firing for one release is harmless — the concurrency group below serialises
+# them, and the second finds nothing to stamp.
+#
+# For a tag push, `workflow_run.head_branch` is the tag name (`v0.11.1`), which is
+# exactly what the stamp script wants; it strips the leading `v` itself.
 #
 # Always checks out `main`, never the tag: a release deploys whatever the site says
 # *now*, and the commit-back below needs a branch to push to. The app bundles are a
 # separate concern — see release.yml, which this deliberately does not touch.
 on:
+  workflow_run:
+    workflows: [release]
+    types: [completed]
   release:
     types: [published]
   push:
@@ -23,7 +40,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to stamp (e.g. 0.12.0). Blank = use package.json."
+        description: "Version to stamp (e.g. 0.11.2). Blank = use package.json."
         required: false
         type: string
 
@@ -39,6 +56,10 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # `workflow_run` fires on *completed*, which includes a failed or cancelled build.
+    # Deploying then would advertise a version whose assets do not exist. Every other
+    # trigger passes straight through.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -59,10 +80,12 @@ jobs:
           node-version: 22
           package-manager-cache: false
 
-      # No arg on push/dispatch-without-input -> the script falls back to
-      # package.json, which main already carries at the released version.
+      # One expression, in trigger order: a hand-published release's tag, then the tag
+      # release.yml built, then a dispatch input. All three are empty on a push (and on
+      # a dispatch with a blank input), leaving the script its package.json fallback —
+      # main already carries the released version by then.
       - name: Stamp the version into site/index.html
-        run: node scripts/stamp-site-version.mjs "${{ github.event.release.tag_name || inputs.version }}"
+        run: node scripts/stamp-site-version.mjs "${{ github.event.release.tag_name || github.event.workflow_run.head_branch || inputs.version }}"
 
       # Keeps the repo honest: what's deployed is what's committed. [skip ci] stops
       # this push from re-triggering the workflow through the paths filter above.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -198,3 +198,12 @@ cannot pin a release and "always in the newest one" is the equivalent.
       the one whose failure is silently permanent for everyone already installed.
 - [ ] On Windows, SmartScreen warns but **More info → Run anyway** works. On macOS the
       quarantine steps in the release body clear it.
+- [ ] **episko.dev shows the new version.** `site.yml` deploys it, chained off
+      `release.yml` finishing — *not* off the release being published, because
+      tauri-action creates that with `GITHUB_TOKEN` and GitHub will not start a
+      workflow from an event that token raised. It fired for none of v0.10.0 … v0.11.1
+      for exactly that reason, so if the chain ever goes quiet again, the fallback is
+      `gh workflow run site.yml -f version=<x.y.z>`. The label the page *fetches* comes
+      from the releases API at runtime, so a stale deploy only shows with JS off or
+      when that unauthenticated API rate-limits — check the served HTML, not the
+      rendered page: `curl -s https://episko.dev | grep -o 'data-ver>v[0-9.]*'`.


### PR DESCRIPTION
The "automated path" in `site.yml`'s own header has never once run.

tauri-action creates the GitHub Release with `GITHUB_TOKEN`, and GitHub will not start a workflow run from an event that token raised — so `release: [published]` was dead on arrival. It fired for none of v0.10.0 … v0.11.1; v0.11.1's site deploy had to be dispatched by hand after the release was already public.

## The fix

`workflow_run` is the documented exemption — it keys off a **run completing**, whatever token drove it. Verified against the real v0.11.1 build before writing it:

- `release.yml` is `name: release`, so `workflows: [release]` matches
- its `head_branch` is `v0.11.1` — the tag, which is exactly what the stamp script wants (it strips the leading `v`)
- `release.yml` only triggers on `push: tags: v*`, so that field can never arrive as a branch name and hand the script something it would reject

Two details:

- **The conclusion is guarded.** `workflow_run`/`completed` includes a failed or cancelled build, and deploying then would advertise a version whose assets don't exist. Every other trigger passes straight through the `if`.
- **`release: [published]` stays**, for a release published by hand from the UI — which `workflow_run` wouldn't see. Both firing for one release is harmless: the concurrency group serialises them and the second finds nothing to stamp.

`RELEASE.md` gains the post-tag check, with the `gh workflow run site.yml -f version=<x.y.z>` fallback and the reason the *rendered* page can look right while the deploy is stale (the label is fetched from the releases API at runtime; the stamp is only the JS-off / rate-limited fallback).

Can't be proven until the next release cuts — re-running release.yml to test it would re-upload v0.11.1's assets, which isn't worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)