### PR TITLE
feat: commit graph — a project's history, one page at a time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ pnpm coverage           # the same suites with v8 coverage
 ```
 
 Coverage is a **yardstick, not a target** — there is deliberately no gate, because the
-render and DOM-owning modules are untested by design. Current: **85.8%** statements
-over the modules the suites load, **17.4%** over all of `src/`, and **72.3%** Rust
+render and DOM-owning modules are untested by design. Current: **88.0%** statements
+over the modules the suites load, **19.4%** over all of `src/`, and **71.0%** Rust
 lines (`cargo llvm-cov --summary-only` from `src-tauri/`). Both gaps are the OS edge,
 which `RELEASE.md` covers by hand. Note vitest's `text` reporter **hides any file at
 100% in all four columns**, so a fully-covered module looks absent; use
@@ -41,9 +41,9 @@ in the block above before pushing, and match the toolchain CI uses (`stable` for
 
 **Package manager: `pnpm`** for this repo (there's a `pnpm-lock.yaml`; both CI workflows use `pnpm install --frozen-lockfile`, and `packageManager` in `package.json` pins the version for corepack/CI). Use pnpm here, not npm. Windows code-signing / release-signing setup lives in `src-tauri/SIGNING.md`.
 
-Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **368 vitest + cargo (82 on macOS, 79 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
+Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **405 vitest + cargo (85 on macOS, 82 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
 
-**vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which nine those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
+**vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which ten those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
 
 What is **untested by design**: the render, view and DOM-owning modules on both sides of the app — snapshotting template literals mostly re-asserts itself. Anything touching the DOM, PTYs, or live telemetry is still verified by **running the app and exercising it** — the statusLine half of telemetry only fires in interactive mode, so it cannot be checked end to end with `claude -p`. Split that one carefully, because the split is not where it looks: whether the generated statusLine command *works* is checked headlessly and in CI (the shell runs it for real — see the constraint above). What needs a live REPL is only whether **Claude still picks the shell and payload we expect**. That costs a TTY, not tokens: a session you launch and never prompt makes no API call, and the statusLine fires on start and every `refreshInterval` seconds regardless. It's a `RELEASE.md` click-through, and a cheap one. `tsc` (strict) is the real linter. Requires `claude` on PATH, the Node in `.nvmrc` (`nvm use`; `engines` floors it at 24), and Rust stable + Tauri system deps.
 
@@ -228,19 +228,140 @@ Four smaller P4 affordances, all in the frontend:
   button and the picker's ⌘⇧R both route through it. The escape hatch for the one
   thing the stamp can't see: a file an introspector imports itself.
 
+## Project history — the commit graph panel (`git_graph`, `graph.ts`, `graphview.ts`)
+
+A project's lanes, refs and recent commits, opened from the **project right-click menu**
+(`Commit graph…`) and from nowhere else. That placement is the design, not a shortcut:
+history answers a question you go looking for, so it earns a menu row rather than
+header space, and the row is dropped when the folder isn't a repo (one `git_head` probe
+already answers that for the worktree row beside it).
+
+**The invariant is "never read a whole history", and it holds at both ends.** Nothing in
+either module runs until that row is clicked, so app start and `renderAll()` are
+untouched. The panel then reads ONE page — `git log --skip=<n> -n <PAGE+1>` — and asks
+for the next only when the reader scrolls near the end of what it has, so a 300k-commit
+monorepo costs the same first paint as a week-old repo. Four consequences worth keeping:
+
+- **`more` is an observation, not a count.** The command asks for one commit past the
+  page and reports whether it was there; counting commits would mean the walk this
+  command exists to avoid.
+- **`--date-order`, not `--topo-order`.** Both keep a child ahead of its parents, which
+  is all the layout needs — but paging by recency means page 1 must be the newest
+  commits *across* refs, and topo-order pulls a stale branch's whole chain forward to
+  keep it contiguous.
+- **`--decorate=full`.** Short ref names can't be classified (`feat/x` and `origin/x`
+  are the same shape), so `parseRefs` reads `refs/heads/…` / `refs/remotes/…` /
+  `refs/tags/…` instead of guessing.
+- **Not a repo → `Err`; a repo with no commits → an empty page.** git is inconsistent
+  here (`log --all` exits 0 on an unborn HEAD, a bare `log` calls it fatal), and the
+  panel has to tell the two apart.
+
+The split is diff.ts/diffview.ts again: **`graph.ts` is pure and tested** (lane
+assignment, lane naming, ref chips, geometry, the row SVG — `sparkline`'s shape),
+**`graphview.ts` owns the dialog**, the IPC and the scroll. `layoutGraph` runs over the
+whole accumulated list after each page rather than incrementally: it is cheap, and it is
+what keeps the lanes consistent across a page boundary without mutable state living
+between fetches.
+
+**Naming the lanes is where the subtle wrongness lives**, and all three rules below were
+observed being wrong on this repo's own history before they were rules. Eight coloured
+lines are unreadable without them, so each row carries `label` (what line it is on) and
+`merged` (what it took in), surfaced as the node's tooltip and a line in the detail strip:
+
+- **A row's label is the nearest ref *above* it on its own line, not the line's first.**
+  When a feature branch's tip is simply the newest commit, the top of `dev`'s line
+  carries that feature's ref — "first ref on the line" then labels half of dev's history
+  with a branch cut from it.
+- **A tag never names a line.** A label propagates down every commit below it, so
+  accepting `v0.11.1` would read as a lineage that never existed. Tags stay chips.
+- **What a merge took in is read from a ref *below* it** (its commits are older than the
+  merge), falling back to the merge subject — which is the last place a merged-and-deleted
+  branch's name survives, and is therefore marked `from: "merge"` and attributed in the
+  wording. `mergeBranchName` matches only git's and GitHub's own phrasings; prose names
+  nothing, and a guessed lane name is worse than a blank one.
+
+**The chips are reduced, not just listed** (`refChips`), because a branchy repo puts
+four or five refs on one commit and the raw list was wider than everything else on the
+row: a local branch **absorbs its remote twins** (`main` + `origin/main` is one `main ⇡`
+chip, where the glyph means "also pushed"), a remote with no local counterpart keeps its
+`origin/` prefix because that prefix *is* the difference, **`origin/HEAD` is dropped** as
+a symref that always duplicates a sibling, the order is fixed **HEAD → local → remote →
+tag** (git's own order is not stable across repos, and the leftmost chip is the one that
+survives a narrow column), and the tail folds into a **`+N`** chip. Chips never shrink —
+flex would turn a 3-character `dev` into `dev…` to buy a long neighbour pixels it can't
+use — so each has its own ceiling with an ellipsis, and the column *fades* its overflow
+rather than slicing a name mid-word. Inside a chip, **only the name truncates**: the `⇡`
+sits in its own non-shrinking span, because a long branch losing the marker loses the one
+thing the collapse added.
+
+Three layout couplings to respect. **`.grow`'s CSS height must equal `ROW_H`** — lanes
+are drawn edge-to-edge per row, so any disagreement shows as a break at every boundary,
+which is also why nothing may add to a row's box (the selection is a background and an
+inset shadow, never a border). **The trailing columns are fixed-width on purpose**: each
+row is its own grid, so `auto` would let every row size to its own author name and the
+sha/date columns would stagger. And **the graph and the chips are ONE measured cell**
+(`sizeLeftColumn`): each row's SVG is drawn to its own `span` — the lanes *that row*
+touches, pass-throughs included — so the chips land against the graph's real silhouette,
+and only the block as a whole is pinned to a common width. Sizing the two separately is
+what put ~100px of empty column between a 2-lane row and its label in a 12-lane repo,
+and it is why the labels sit beside the lanes at all: a label belongs to the *line*, and
+inside the message column it reads as clutter attached to the wrong thing.
+
+**A row shows a subject; a commit message is prose.** So the strip below the list is a
+two-line *summary* — the commit (chips, subject, `⤢`) then its metadata (lane, author,
+date, a short sha that *is* the copy button, parents) — and the whole commit opens in an
+overlay *inside* the dialog (`⤢`, ⏎, or a double-click).
+
+**The message is fetched per commit (`git_commit_message`), not carried by the page.** It
+was a `%b` field on every commit once, which forced a length cap so 60 bodies wouldn't
+cross IPC as half a megabyte of JSON — and the cap then truncated the one message somebody
+had opened to read, which is the only message that was ever going to be read. One commit
+is open at a time, so one `git show -s --format=%B` answers it, cached by sha so ↑/↓ and
+back doesn't re-ask. The command refuses anything that isn't a hex object name: the sha
+goes to git as a revision argument, where a leading dash would be read as an option. It covers the list rather than
+being a second modal, so the graph stays behind it, ↑/↓ still walk commits with it open,
+and **Esc steps out one layer at a time** — which is why main.ts calls `graphEscape` and
+not `closeGraph`. Closing it takes no mouse travel **by construction**: the
+strip's `⤢ Full message` and the overlay's `✕ Close` share one footprint (`.gswap` — same
+width, same height, both hard right on the last line of their bar, and `.graph-detail`'s
+64px height is what makes the two land on the same pixels), so the button that closes a
+message appears exactly where the pointer already is. The header keeps a compact ✕ too,
+and Esc does the same thing. A body wrapped into a 40px box inside the footer was the version before
+this, and it left half the width empty while still being unreadable; a full 40-character
+sha on its own line was the loudest thing in the panel, and it also went.
+
+**One naming trap, since it cost a visible bug:** `gc-*` is the *ref-chip kind* prefix
+(`gc-head`, `gc-branch`, …), so the commit overlay's own classes are `gco-*`. Calling its
+header `.gc-head` gave every HEAD chip in the panel a header's `padding: 9px 13px` — a
+chip you could see was wrong but not say why.
+
+**What a narrow panel gives up, it gives up in order.** The collapse is CSS container
+queries on the dialog (not viewport media queries — the panel's own width is what the
+table lives in): the relative date shortens first (`2 days ago` → `2d`, both forms
+rendered, CSS picks), then the sha column goes, then the author and the header path. The
+subject is never the column that yields, which it *was* — an `fr` track gives up space
+before any fixed one, so a rigid left block made the message vanish first in a narrow
+window. It is now `minmax(0, var(--gleft-w))` with a floor under the subject, and the
+measured cap is also bounded by a share of the panel width, which is the one rung of the
+ladder that lives in JS (`sizeLeftColumn`, re-run on resize).
+
+Lane colours are `--gl-0…7`, re-stepped for the light theme like every other palette in
+`styles.css`. Scope (`all refs` / `this branch`) resets on each open and is deliberately
+**not** persisted — all-refs is the answer the panel exists to give.
+
 ## Backend (`src-tauri/src/`) — ten modules
 
-`main.rs` only calls `episko_lib::run()`. `lib.rs` is **bootstrap, not the backend**: 449 lines out of ~7,600. Dependencies point downward, `platform.rs` at the bottom.
+`main.rs` only calls `episko_lib::run()`. `lib.rs` is **bootstrap, not the backend**: 450 lines out of ~8,300. Dependencies point downward, `platform.rs` at the bottom.
 
 | Module | Lines | What |
 | --- | --- | --- |
-| `lib.rs` | 449 | `run()`, `AppState`/`Session`, the tray mirror, the panic hook, `write_debug_file`/`log_frontend`, `confirm_quit`, and the `invoke_handler!` list |
-| `tasks.rs` | 2,394 | runnable discovery — see Runnables above |
-| `git.rs` | 1,532 | worktrees, branches, the working-set diff, the toolbar's fetch/pull/push, commit info |
-| `usage.rs` | 819 | transcripts + the token ledger — everything read out of `~/.claude` |
+| `lib.rs` | 450 | `run()`, `AppState`/`Session`, the tray mirror, the panic hook, `write_debug_file`/`log_frontend`, `confirm_quit`, and the `invoke_handler!` list |
+| `tasks.rs` | 2,399 | runnable discovery — see Runnables above |
+| `git.rs` | 1,756 | worktrees, branches, the working-set diff, the paged commit graph, the toolbar's fetch/pull/push, commit info |
+| `usage.rs` | 896 | transcripts + the token ledger — everything read out of `~/.claude` |
+| `telemetry.rs` | 857 | `write_instrument_settings`, `run_telemetry_server`, `resolve_permission` |
 | `pty.rs` | 705 | the four launch engines, `stream_pty_session`, the PTY lifecycle |
-| `platform.rs` | 683 | OS leaves (top half) + OS integrations (bottom half) |
-| `telemetry.rs` | 469 | `write_instrument_settings`, `run_telemetry_server`, `resolve_permission` |
+| `platform.rs` | 690 | OS leaves (top half) + OS integrations (bottom half) |
 | `external.rs` | 339 | the `~/.claude/sessions` registry, `ProcTable`, terminal focus |
 | `icons.rs` | 184 | project favicon/logo probing |
 | `testutil.rs` | 24 | `scratch_dir`, `cfg(test)` only |
@@ -258,13 +379,13 @@ Four conventions hold across them:
 - **Telemetry server** (`run_telemetry_server`) forwards `/hook` and `/statusline` POSTs as one `telemetry` event each; `/permission` is the blocking path described above.
 - Commands are registered in the `invoke_handler![...]` list at the bottom of `run()` — add new `#[tauri::command]` fns there.
 
-## Frontend (`src/`, `index.html`, `src/styles.css`) — 34 modules
+## Frontend (`src/`, `index.html`, `src/styles.css`) — 36 modules
 
-**No framework, and no longer one file.** ~7,200 lines across 34 modules; `main.ts` is 642 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
+**No framework, and no longer one file.** ~8,300 lines across 36 modules; `main.ts` is 665 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (~70 lines — it is the seam map, and belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, and the nine `setInterval`s.
 
-**Tested logic modules** (nine — no DOM, no Tauri, no render imports; these are what the 368 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
+**Tested logic modules** (ten — no DOM, no Tauri, no render imports; these are what the 405 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
 
 | Module | What |
 | --- | --- |
@@ -277,16 +398,17 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 | `palette.ts` | ⌘K ranking: fuzzy match, scoring, prefix parsing, frecency |
 | `grouping.ts` | what the sidebar shows and in what order; `urgencyRank`, `needsYou`, `nextAfterClose` |
 | `tasks.ts` | the frontend half of Runnables: `stopRuleBlocked`, `launchWithDeps`, `applyRunner`, `${input:…}` glue |
+| `graph.ts` | the commit graph: `layoutGraph`'s lanes, what names a lane (`lineRef`, `lineTip`), `parseRefs`, the geometry and `rowSvg` |
 
 **Shared**: `state.ts` (the session map, the stage pointer, every persisted preference) and `dom.ts` (`$`, `toast`, the shared scrim, `IS_MAC`/`MOD`/`chord`).
 
 **Markup-only views**, untested by design: `usageview`, `inspectorview`, `sidebarview`.
 
-**DOM-owning / render**, untested by design: `sidebar`, `footer`, `tray`, `inspector`, `debug`, `worktree` (the new-session dialog, the biggest single module at 932 lines), `settings`, `taskui`, `palui`, `projmenu`, `caffeinate`, `diffview`, `mirror`, `update`.
+**DOM-owning / render**, untested by design: `sidebar`, `footer`, `tray`, `inspector`, `debug`, `worktree` (the new-session dialog, the biggest single module at 932 lines), `settings`, `taskui`, `palui`, `projmenu`, `caffeinate`, `diffview`, `graphview` (the paged commit-graph panel), `mirror`, `update`.
 
 **Behaviour** — IPC and DOM all the way down, so untested too, and therefore the thinnest ice in the app: `panes` (the three spawners + a pane's lifecycle), `terminal` (the xterm plumbing), `taskrun` (run on stop), `actions` (the app-level verbs), `icons` (the per-project glyph store).
 
-Four rules keep that graph honest. **There are no import cycles across the 34 modules; re-run a cycle check after any change that adds an import.**
+Four rules keep that graph honest. **There are no import cycles across the 36 modules; re-run a cycle check after any change that adds an import.**
 
 - **Dependency direction is state ← render ← wiring.** A logic module must not import render code or `main.ts`.
 - **When an extracted function needs something that lives further up**, resolve it in this order: (1) **move the callee down too** if it is itself leaf-shaped — that is why `icons.ts` sits below `sidebar.ts` and `usage.ts` below `phase.ts`; (2) **a settable hook defaulting to a no-op** (`setRlLogger`, `setPanesRenderAll`) when the callee genuinely belongs to the render layer; (3) **an extra parameter** only as a last resort, since it changes a signature the move was supposed to leave alone. A control panel touching many things it doesn't own may take **one host object** instead of N setters (`settings`, `palui`, `projmenu`); prefer per-callee setters below ~4.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - **Usage limits, before you hit them.** Your 5-hour and weekly limits with reset times, and a forecast that warms from amber to red when your current pace won't make it.
 - **A usage dashboard.** Daily spend as a contribution heatmap, tokens by model, token composition (cache reads vs. input vs. output), and cost attributed per project.
 - **Launch into worktrees.** The new-session dialog lists the repo, its worktrees and branches, and can create a worktree on the fly so parallel agents don't fight over one checkout.
+- **A commit graph per project.** Right-click a project → *Commit graph…* for its lanes, merges, branch and tag labels. It reads a page at a time and fetches the next as you scroll, so opening it on a huge repo costs the same as on a small one.
 - **Sessions started elsewhere show up too.** Claude Code sessions launched outside Episko are discovered and listed read-only, with jump-to-terminal on macOS.
 - **Survives a restart.** Episko's launch id *is* Claude's `--session-id`, so resuming replays Claude's own transcript — nothing to capture, nothing to lose.
 - **Run the project's own tasks** — VS Code tasks, a `justfile`, package scripts, a Makefile and more, in the same panes, with a run's exit code as its status. [See below](#run-your-projects-tasks-too).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,8 +15,8 @@ different lifetime — it changes when the OS edge changes, not when the app doe
 Every push and PR to `dev`/`main` runs, on **both macOS and Windows** (`ci.yml`):
 
 - `pnpm build` — `tsc --noEmit` (strict) plus the vite build
-- `pnpm test` — 368 vitest tests over the logic modules
-- `cargo check --locked` and `cargo test --locked` — 82 tests on macOS, 79 on
+- `pnpm test` — 405 vitest tests over the logic modules
+- `cargo check --locked` and `cargo test --locked` — 85 tests on macOS, 82 on
   Windows (the platform tests are `cfg`-gated, so the count differs by leg)
 - `cargo clippy --all-targets --locked -- -D warnings`
 
@@ -140,6 +140,40 @@ A regression in either is silent.
       non-zero shows `error` and raises attention.
 - [ ] **A run-on-stop rule fires** once per turn, does not steal the stage, and offers
       its output back to the session whose turn triggered it.
+
+### Reading the repo
+
+- [ ] **The commit graph draws a real history.** Right-click a project → `Commit
+      graph…` on a repo that has merges. The lanes must be unbroken from row to row
+      (a break means `.grow`'s height and `ROW_H` disagree), a merge must fork and
+      converge, and HEAD/branch/remote/tag chips must land on the right commits.
+      Then **scroll to the bottom**: the next page appends and the lanes continue
+      across the seam — the panel must never load a whole history, so a big repo is
+      the interesting case here. `This branch` narrows it; ⟳ re-reads it.
+- [ ] **The chips stay legible on a branchy repo.** On one with local branches, their
+      remote twins and a tag on a release commit: a branch and its remote must be ONE
+      chip (`main ⇡`, hover says "also on origin"), `origin/HEAD` must not appear, HEAD
+      must be the leftmost chip, and a commit carrying many refs must fold into `+N`
+      rather than slicing a name mid-word. Every subject in the panel starts at the same
+      x, while the chips hug the graph's own width row by row. A truncated chip keeps
+      its `⇡`, and hovering it names the branch.
+- [ ] **A whole commit message is readable — all of it.** Pick the longest commit message
+      in the repo (`git log --format='%H %b' | …`, or just a big merge write-up) and press ⏎
+      (or `⤢`, or double-click): the overlay shows the full message, ↑/↓ still move
+      through commits with it open, and **Esc closes the overlay first and the panel
+      second**. Both closes work — the header's ✕ and the
+      `✕ Close` at the bottom right, which must sit on **exactly** the pixels the
+      `⤢ Full message` button occupied, so opening and closing a message needs no mouse
+      movement at all. Check that by clicking one and then the other without moving. A truncated subject in a row is readable by hovering it.
+- [ ] **The table collapses in the right order.** Narrow the window: the date shortens
+      (`2d`), then the sha column goes, then the author — and the *subject* keeps a
+      usable width throughout, never squeezed to nothing.
+- [ ] **The lanes say what they are.** Hover a node, and select one: the tooltip and the
+      detail strip must name the branch that lane leads up to, and a merge must name what
+      it took in. Check a commit *below* a branch tip on a busy line — the label is the
+      nearest ref above it, so a stale side branch further up must not claim it, and a
+      release tag must not name a stretch of history at all. This wording is a claim
+      about ancestry; if it reads wrong, it is wrong.
 
 ### Sessions Episko doesn't own
 

--- a/index.html
+++ b/index.html
@@ -186,6 +186,26 @@
       <div class="diff-body" id="diffBody"></div>
     </div>
 
+    <!--
+      Project history. Opened from a project's right-click menu, and paged: the list
+      holds the newest 60 commits and asks for the next 60 only when you scroll to the
+      end of it (graphview.ts). Head and detail strip are pinned; the list scrolls.
+    -->
+    <div class="graphdlg" id="graphDlg" role="dialog" aria-modal="true" aria-label="Commit graph">
+      <div class="graph-head">
+        <div class="diff-title-wrap"><b id="graphTitle"></b><span class="diff-sub" id="graphSub"></span></div>
+        <span class="graph-path" id="graphPath"></span>
+        <div class="gseg" id="graphScope"></div>
+        <button class="graph-ref" id="graphRefresh" type="button" title="Re-read history from git">⟳</button>
+        <button class="diff-x" id="graphClose" title="Close (Esc)">✕</button>
+      </div>
+      <div class="graph-body" id="graphBody" tabindex="0"></div>
+      <div class="graph-detail" id="graphDetail"></div>
+      <!-- One commit, in full. Lives inside the dialog and covers its list, because the
+           strip below can only ever show a subject and a commit message is prose. -->
+      <div class="gcommit" id="graphCommit" tabindex="0" hidden></div>
+    </div>
+
     <div class="setdlg" id="setDlg" role="dialog" aria-modal="true" aria-label="Settings">
       <nav class="set-rail">
         <div class="set-title">Settings</div>

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -887,6 +887,168 @@ pub(crate) fn git_diff(workdir: String) -> Option<GitDiff> {
     Some(GitDiff { patch, truncated })
 }
 
+/// One commit, as the project graph panel draws it.
+///
+/// Deliberately flat, small and *underived*: a page of these crosses the IPC
+/// boundary as JSON, so nothing is computed here that the frontend can compute
+/// itself — the lane layout, the ref chips and the absolute date are all derived
+/// in `graph.ts`, where they can be unit-tested without a repo.
+#[derive(serde::Serialize)]
+pub(crate) struct GraphCommit {
+    /// Full sha. Not abbreviable: the parent links are matched on it, and an
+    /// abbreviation is only unique within the repo's current object count.
+    sha: String,
+    /// Abbreviated sha for display, at git's own chosen length (`%h`).
+    short: String,
+    /// Parent shas, first parent first — empty for a root, 2+ for a merge. This is
+    /// the only thing the graph's shape comes from.
+    parents: Vec<String>,
+    subject: String,
+    author: String,
+    /// Author date, epoch seconds — the panel's absolute timestamp.
+    unix: i64,
+    /// Committer date, relative ("3 days ago"), in git's own wording.
+    rel: String,
+    /// Raw decoration (`%D` in `--decorate=full` form): "HEAD -> refs/heads/main,
+    /// refs/remotes/origin/main, tag: refs/tags/v1.0", empty when the commit carries
+    /// no ref. Parsed into typed chips by the frontend (`parseRefs`), which needs the
+    /// full paths — the short forms can't be told apart.
+    refs: String,
+}
+
+/// One page of history.
+///
+/// `more` is what lets the panel offer "load more" without ever having counted the
+/// repo's commits: we ask git for one commit *past* the page and report whether it
+/// was there. A count would mean walking the whole history, which is precisely what
+/// this command exists not to do.
+#[derive(serde::Serialize)]
+pub(crate) struct GraphPage {
+    commits: Vec<GraphCommit>,
+    more: bool,
+}
+
+/// A page of commit history for a project's graph panel.
+///
+/// **The panel must never read a whole history**, so this command can't either: it
+/// is `git log --skip=<skip> -n <limit+1>` and nothing else. A big monorepo has
+/// hundreds of thousands of commits; the panel opens on the first ~60 and asks for
+/// the next page only when the user scrolls to the end of what it has. Everything
+/// else in the design follows from that:
+///
+/// - **`--date-order`, not `--topo-order`.** Both keep a child ahead of its parents,
+///   which is all the lane layout needs. But paging by recency means page 1 has to be
+///   the genuinely most recent commits *across* refs, and topo-order will pull a stale
+///   branch's whole chain forward to keep it contiguous — making the first page look
+///   like history from a month ago.
+/// - **`\x1e` records, NUL fields.** A subject may contain any printable character,
+///   tabs included, so neither delimiter may be something that can appear inside a
+///   field. (`git log -z` is not an option: it would collide with the NULs.)
+/// - **`scope`** is `"head"` for the checked-out branch alone, anything else for every
+///   ref (`--all`, which is refs/heads + refs/remotes + tags, never the stash). A graph
+///   with one lane isn't a graph, so the panel defaults to all refs and offers "this
+///   branch" as the narrowing.
+///
+/// Errs with git's own first line when the folder isn't a git repo. A repo with **no
+/// commits yet** is an empty page rather than an error, because that is the truthful
+/// answer and the panel can say it — note git itself disagrees with itself here:
+/// `log --all` on an unborn HEAD exits 0 with no output (no refs matched), while a
+/// bare `log` calls it fatal.
+#[tauri::command(async)]
+pub(crate) fn git_graph(workdir: String, skip: u32, limit: u32, scope: String) -> Result<GraphPage, String> {
+    /// Ceiling on one page, whatever the caller asks for — a runaway `limit` would
+    /// undo the entire point of the command.
+    const MAX_PAGE: u32 = 400;
+
+    if !std::path::Path::new(&workdir).is_dir() {
+        return Err(format!("not a directory: {workdir}"));
+    }
+    let limit = limit.clamp(1, MAX_PAGE);
+    let n = format!("-{}", limit as u64 + 1); // one past the page — see GraphPage::more
+    let sk = format!("--skip={skip}");
+    let mut args = vec![
+        "--no-optional-locks", "log", "--date-order", "--no-color",
+        // FULL ref paths in %D. Short ones can't be told apart — a local `feat/x` and a
+        // remote `origin/x` are the same shape — so the chips would be guesses.
+        "--decorate=full",
+        sk.as_str(), n.as_str(),
+        "--format=%x1e%H%x00%h%x00%P%x00%an%x00%at%x00%cr%x00%D%x00%s",
+    ];
+    if scope != "head" {
+        args.push("--all");
+    }
+    // 20s is generous for a bounded log; the timeout exists because git_run's does,
+    // and a repo mid-`gc` can block on the object store.
+    let out = git_run(git_cmd(&workdir, &args), 20)?;
+    if !out.status.success() {
+        // "not a git repository", a bad `scope`, an unreadable object store — git's own
+        // first line names which, so pass it through rather than inventing wording.
+        let err = String::from_utf8_lossy(&out.stderr);
+        return Err(err.lines().find(|l| !l.trim().is_empty()).unwrap_or("git log failed").to_string());
+    }
+
+    let text = String::from_utf8_lossy(&out.stdout);
+    let mut commits = Vec::new();
+    // The split's first slice is the empty string ahead of the first record; each
+    // record carries the newline git writes after it.
+    for rec in text.split('\u{1e}').skip(1) {
+        let mut f = rec.trim_matches('\n').split('\0');
+        let sha = f.next().unwrap_or("").trim().to_string();
+        if sha.is_empty() {
+            continue;
+        }
+        // These field expressions are read in the order they are *written*, which must
+        // stay the order of the format string above — not the struct's declaration order.
+        commits.push(GraphCommit {
+            sha,
+            short: f.next().unwrap_or("").to_string(),
+            parents: f.next().unwrap_or("").split_whitespace().map(str::to_string).collect(),
+            author: f.next().unwrap_or("").to_string(),
+            unix: f.next().unwrap_or("").trim().parse().unwrap_or(0),
+            rel: f.next().unwrap_or("").to_string(),
+            refs: f.next().unwrap_or("").to_string(),
+            subject: f.next().unwrap_or("").to_string(),
+        });
+    }
+    let more = commits.len() > limit as usize;
+    commits.truncate(limit as usize);
+    Ok(GraphPage { commits, more })
+}
+
+/// One commit's whole message (`%B` — subject and body), for the graph panel's commit
+/// overlay.
+///
+/// **Deliberately not part of `git_graph`'s page.** Bodies were once a field on every
+/// commit in the page, which meant a length cap so 60 of them wouldn't cross IPC as
+/// half a megabyte of JSON — and that cap then truncated the one message somebody was
+/// actually reading. Only ever one commit is open, so this fetches only that one, and
+/// the cap can be high enough never to matter in practice.
+///
+/// `sha` must be a hex object name: it goes to git as a revision argument, and anything
+/// else (a `--flag`, a `refname@{…}` expression) is refused rather than passed through.
+#[tauri::command(async)]
+pub(crate) fn git_commit_message(workdir: String, sha: String) -> Result<String, String> {
+    /// ~200KB of one commit message. Reached only by a machine-generated commit; a marker
+    /// is appended so a truncated message can never read as complete.
+    const CAP: usize = 200_000;
+
+    if sha.len() < 4 || sha.len() > 64 || !sha.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(format!("not an object name: {sha}"));
+    }
+    let out = git_run(git_cmd(&workdir, &["--no-optional-locks", "show", "-s", "--format=%B", &sha]), 15)?;
+    if !out.status.success() {
+        let err = String::from_utf8_lossy(&out.stderr);
+        return Err(err.lines().find(|l| !l.trim().is_empty()).unwrap_or("git show failed").to_string());
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    let msg = text.trim_end();
+    if msg.len() > CAP {
+        let cut = msg.char_indices().map(|(i, _)| i).take_while(|i| *i <= CAP).last().unwrap_or(0);
+        return Ok(format!("{}\n\n[… message truncated at {CAP} characters]", &msg[..cut]));
+    }
+    Ok(msg.to_string())
+}
+
 #[derive(serde::Serialize, Debug)]
 pub(crate) struct GitActionResult {
     ok: bool,
@@ -1235,6 +1397,140 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         let _ = std::fs::remove_dir_all(&other);
         let _ = std::fs::remove_dir_all(&remote);
+    }
+
+    /// The graph panel's contract with git, and the reason the command exists: it
+    /// pages. `more` must be an observation (one commit past the page was there), the
+    /// page must actually stop at `limit`, and `skip` must land on the next commit —
+    /// because the alternative is reading a monorepo's whole history to draw 60 rows.
+    #[test]
+    fn git_graph_pages_history_instead_of_reading_all_of_it() {
+        let dir = scratch_dir();
+        let path = dir.to_str().unwrap().to_string();
+        git(&dir, &["init", "-q", "-b", "main"]);
+
+        // Not a repo is an Err (the panel says so). A repo with no commits is an empty
+        // page — the truthful answer, and the one thing git is inconsistent about:
+        // `log --all` exits 0 on an unborn HEAD, a bare `log` calls it fatal.
+        assert!(git_graph(format!("{path}/gone"), 0, 10, "all".into()).is_err(), "missing dir");
+        let empty = git_graph(path.clone(), 0, 10, "all".into()).expect("unborn HEAD is an empty page");
+        assert!(empty.commits.is_empty() && !empty.more);
+        assert!(git_graph(path.clone(), 0, 10, "head".into()).is_err(), "git calls a bare log fatal here");
+
+        for i in 1..=5 {
+            commit(&dir, &format!("c{i}"));
+        }
+
+        let p = git_graph(path.clone(), 0, 2, "all".into()).unwrap();
+        assert_eq!(p.commits.len(), 2, "a page is `limit` commits, not limit+1");
+        assert!(p.more, "3 commits are still behind this page");
+        assert_eq!(p.commits[0].subject, "c5", "newest first");
+        assert_eq!(p.commits[1].subject, "c4");
+
+        // The next page starts exactly where the last one stopped.
+        let p2 = git_graph(path.clone(), 2, 2, "all".into()).unwrap();
+        assert_eq!(p2.commits[0].subject, "c3");
+        assert!(p2.more);
+
+        // The last page reports there is nothing behind it, so the panel can stop
+        // offering to load more.
+        let last = git_graph(path.clone(), 4, 2, "all".into()).unwrap();
+        assert_eq!(last.commits.len(), 1);
+        assert!(!last.more, "c1 is the root — nothing behind it");
+        assert!(last.commits[0].parents.is_empty(), "a root commit has no parents");
+
+        // Past the end: an empty page, not an error.
+        let past = git_graph(path.clone(), 99, 2, "all".into()).unwrap();
+        assert!(past.commits.is_empty() && !past.more);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The two fields the drawing is made of — `parents` (the graph's whole shape)
+    /// and `refs` (the chips) — plus the delimiter choice: a subject containing a tab
+    /// must survive, which is why records are \x1e-separated and fields NUL-separated
+    /// rather than the tab-separated format the branch list can afford.
+    #[test]
+    fn git_graph_carries_merge_parents_refs_and_awkward_subjects() {
+        let dir = scratch_dir();
+        let path = dir.to_str().unwrap().to_string();
+        git(&dir, &["init", "-q", "-b", "main"]);
+        commit(&dir, "base");
+        git(&dir, &["checkout", "-q", "-b", "side"]);
+        commit(&dir, "side\twork with\ttabs");
+        git(&dir, &["checkout", "-q", "main"]);
+        commit(&dir, "main work");
+        git(&dir, &["-c", "user.email=t@example.com", "-c", "user.name=T", "-c", "commit.gpgsign=false",
+                    "merge", "-q", "--no-ff", "-m", "merge side", "side"]);
+        git(&dir, &["tag", "v1"]);
+
+        let p = git_graph(path.clone(), 0, 10, "all".into()).unwrap();
+        let merge = &p.commits[0];
+        assert_eq!(merge.subject, "merge side");
+        assert_eq!(merge.parents.len(), 2, "a merge is the only thing that forks a lane");
+        // Full paths, not the short forms the frontend can't classify.
+        assert!(merge.refs.contains("HEAD -> refs/heads/main"), "{}", merge.refs);
+        assert!(merge.refs.contains("tag: refs/tags/v1"), "{}", merge.refs);
+        assert_eq!(merge.author, "T");
+        assert!(merge.unix > 0 && !merge.rel.is_empty());
+        assert_eq!(merge.short, merge.sha[..merge.short.len()], "%h abbreviates %H");
+
+        // Every parent of a loaded commit is either loaded too or past the frontier —
+        // the layout matches on full shas, so an abbreviation here would break lanes.
+        let tabbed = p.commits.iter().find(|c| c.subject.contains('\t')).expect("tab subject survived");
+        assert_eq!(tabbed.subject, "side\twork with\ttabs");
+
+        // The page carries no bodies at all — see git_commit_message, and the test below.
+        let p2 = git_graph(path.clone(), 0, 5, "all".into()).unwrap();
+        assert!(!p2.commits.is_empty());
+        assert!(merge.parents.iter().all(|sha| sha.len() == merge.sha.len()));
+
+        // `scope: "head"` is the narrowing: side's commit is not on main's first-parent
+        // history... it IS reachable through the merge, so use a repo state where the
+        // difference shows — an unmerged branch.
+        git(&dir, &["checkout", "-q", "-b", "unmerged"]);
+        commit(&dir, "only on unmerged");
+        git(&dir, &["checkout", "-q", "main"]);
+        let all = git_graph(path.clone(), 0, 20, "all".into()).unwrap();
+        let head = git_graph(path.clone(), 0, 20, "head".into()).unwrap();
+        assert!(all.commits.iter().any(|c| c.subject == "only on unmerged"), "--all sees every ref");
+        assert!(!head.commits.iter().any(|c| c.subject == "only on unmerged"), "head scope is the checkout alone");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The overlay's message, fetched one commit at a time. The multi-line body is the
+    /// whole point: it is why this is a separate command rather than a field on every
+    /// commit in a page, where it had to be length-capped and duly truncated the one
+    /// message a reader had opened.
+    #[test]
+    fn git_commit_message_returns_the_whole_thing_for_one_commit() {
+        let dir = scratch_dir();
+        let path = dir.to_str().unwrap().to_string();
+        git(&dir, &["init", "-q", "-b", "main"]);
+        let long = "para one, which is long enough to have mattered under the old cap.\n\n\
+                    - a bullet\n- another bullet\n\nCo-Authored-By: T <t@example.com>";
+        git(&dir, &["-c", "user.email=t@example.com", "-c", "user.name=T", "-c", "commit.gpgsign=false",
+                    "commit", "-q", "--allow-empty", "-m", "subject line", "-m", long]);
+        let head = git_cmd(&path, &["rev-parse", "HEAD"]).output().unwrap();
+        let sha = String::from_utf8_lossy(&head.stdout).trim().to_string();
+
+        let msg = git_commit_message(path.clone(), sha.clone()).unwrap();
+        assert!(msg.starts_with("subject line\n\n"), "subject then body:\n{msg}");
+        assert!(msg.contains("- a bullet\n- another bullet"), "structure survives:\n{msg}");
+        assert!(msg.ends_with("Co-Authored-By: T <t@example.com>"), "trailing newlines trimmed:\n{msg}");
+        // An abbreviation is a valid object name too.
+        assert_eq!(git_commit_message(path.clone(), sha[..8].to_string()).unwrap(), msg);
+
+        // Not an object name: refused here rather than handed to git as a revision
+        // argument, where a leading dash would be read as an option.
+        for bad in ["--help", "HEAD", "main@{0}", "", "zzzz"] {
+            assert!(git_commit_message(path.clone(), bad.to_string()).is_err(), "{bad} should be refused");
+        }
+        // Well-formed but unknown: git's own error, not a panic or an empty string.
+        assert!(git_commit_message(path.clone(), "0".repeat(40)).is_err());
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// The picker leans on these flags to decide what's pickable: it hides `current`

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -392,6 +392,8 @@ pub fn run() {
             git::git_head,
             git::git_diffstat,
             git::git_diff,
+            git::git_graph,
+            git::git_commit_message,
             git::git_action,
             pty::session_resources,
             git::create_worktree,

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -20,7 +20,7 @@ export function toast(m: string) { const el = $("toast"); el.textContent = m; el
 // Which overlays share the single #scrim backdrop. Dropping it is conditional
 // because several can be open at once (the palette over the settings window, say) —
 // the last one to close is the one that clears it.
-const SCRIM_DLGS = ["palette", "wtDlg", "diffDlg", "setDlg"];
+const SCRIM_DLGS = ["palette", "wtDlg", "diffDlg", "graphDlg", "setDlg"];
 export function dropScrim() {
   if (!SCRIM_DLGS.some((id) => $(id).classList.contains("show"))) $("scrim").classList.remove("show");
 }

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,0 +1,481 @@
+// The commit-graph panel's pure half: a page of commits in, lanes/edges/ref chips
+// out. No DOM, no Tauri, no render imports — so it is unit-tested in isolation
+// (test/graph.test.ts), and ./graphview owns the dialog that paints what this
+// returns. Same split as diff.ts / diffview.ts, for the same reason: the parsing and
+// the layout are where the bugs live, and neither needs a browser to check.
+
+import { esc } from "./format";
+
+/** One commit as `git_graph` hands it over (src-tauri/src/git.rs). */
+export interface GraphCommit {
+  /** Full sha — parent links are matched on it, so never the abbreviation. */
+  sha: string;
+  short: string;
+  /** Parent shas, first parent first. Empty for a root, 2+ for a merge. */
+  parents: string[];
+  subject: string;
+  author: string;
+  /** Author date, epoch seconds. */
+  unix: number;
+  /** Committer date, relative, in git's own wording ("3 days ago"). */
+  rel: string;
+  /** Raw `%D` with `--decorate=full`: "HEAD -> refs/heads/main, refs/tags/v1". */
+  refs: string;
+}
+
+/**
+ * A branch line touching a row: which lane (column) it sits in, and *which line it is*.
+ * `line` is an identity, minted once when the line opens and carried to the end of it —
+ * the colour is only `line % GRAPH_COLORS.length`, and the lane label is keyed off it.
+ */
+export interface Line { lane: number; line: number; }
+
+/**
+ * One drawn row. The three lists are what the SVG is made of, and they are split by
+ * *where the line meets the row's edges* rather than by what it means in git terms —
+ * that is the only distinction the drawing needs:
+ *
+ * - `above` — lanes at the row's TOP edge that end at this node (this commit's
+ *   children, which each opened a lane waiting for it).
+ * - `below` — lanes at the BOTTOM edge that start at this node (its parents).
+ * - `through` — lanes crossing the whole row without touching the node at all.
+ */
+export interface GraphRow {
+  c: GraphCommit;
+  lane: number;
+  line: number;
+  above: Line[];
+  below: Line[];
+  through: Line[];
+  /** What line this commit sits on — the nearest ref *above* it on that line, or the
+   *  branch the merge that opened the line named. Null when nothing names it. */
+  label: LineLabel | null;
+  /** Branch names this commit merged in, for a merge row; empty otherwise. The one
+   *  thing the drawing genuinely cannot say. */
+  merged: string[];
+  /** Lanes THIS row touches. The SVG is drawn to this width, not to the page's widest
+   *  row: a 12-lane repo would otherwise indent every 2-lane row by ten empty lanes,
+   *  and what follows the graph (the ref chips) should hug its actual silhouette. */
+  span: number;
+}
+
+export interface GraphLayout {
+  rows: GraphRow[];
+  /** Widest row's lane count. Rows are drawn to their OWN `span`; this is the ceiling,
+   *  useful for sizing decisions about the column as a whole. */
+  lanes: number;
+}
+
+/**
+ * What a lane is, so a reader can tell one anonymous coloured line from another.
+ *
+ * `from` is how we know, and it matters: `"ref"` means a branch/tag actually sits on a
+ * commit of this line, which is a fact; `"merge"` means the line was opened by a merge
+ * whose subject names the branch it took in ("Merge pull request #30 from foo/bar"),
+ * which is a *claim git no longer stores* — the branch itself is usually deleted by
+ * then. Keep the two distinguishable in any wording built from this.
+ */
+export interface LineLabel { name: string; from: "ref" | "merge"; }
+
+/** First free lane, appending a new one when every active lane is taken. */
+function freeLane(lanes: (string | null)[]): number {
+  const i = lanes.indexOf(null);
+  if (i >= 0) return i;
+  lanes.push(null);
+  return lanes.length - 1;
+}
+
+/**
+ * Assign every commit a lane and work out the segments that connect them.
+ *
+ * The walk is the classic one: a lane is "waiting" for the sha it must draw next, a
+ * commit takes the lane already waiting for it (its leftmost, if several children
+ * opened one each), then hands that lane to its first parent so a branch keeps one
+ * column and one colour for its whole length. A merge's other parents take further
+ * lanes — joining one that is already waiting for that parent, so two children of a
+ * commit share its line rather than drawing it twice.
+ *
+ * **Called on the whole accumulated list after each page arrives, not incrementally.**
+ * It is O(commits × lanes) over a few hundred rows, and recomputing is how the lanes
+ * either side of a page boundary stay consistent — carrying mutable lane state across
+ * fetches would be the same answer with a state bug waiting in it.
+ *
+ * A parent that isn't in `commits` (the frontier of the last loaded page, or a shallow
+ * clone's boundary) leaves its lane open, so the line runs off the bottom of the last
+ * row — which is exactly what "there is more history below" should look like.
+ */
+export function layoutGraph(commits: GraphCommit[]): GraphLayout {
+  const lanes: (string | null)[] = []; // lanes[i] = the sha lane i draws next
+  const ids: number[] = [];            // id of the line currently occupying lane i
+  const rows: GraphRow[] = [];
+  // Lines opened by a merge's second-and-later parent, and the subject of the merge
+  // that opened them — the only name a merged-and-deleted branch has left.
+  const byMerge = new Map<number, string>();
+  let nextLine = 0;
+  let widest = 0;
+
+  for (const c of commits) {
+    // Every lane waiting for this commit converges here. Two children on different
+    // lanes can each be waiting for the same parent, so this is a list, not a find.
+    const waiting: number[] = [];
+    for (let i = 0; i < lanes.length; i++) if (lanes[i] === c.sha) waiting.push(i);
+
+    let lane: number, line: number;
+    if (waiting.length) {
+      lane = waiting[0]; // leftmost keeps the node; the others fold into it
+      line = ids[lane];
+    } else {
+      lane = freeLane(lanes); // a tip — or the top of a page — starts a new line
+      line = nextLine++;
+    }
+    const above: Line[] = waiting.map((i) => ({ lane: i, line: ids[i] }));
+    const through: Line[] = [];
+    for (let i = 0; i < lanes.length; i++) {
+      if (lanes[i] === null || i === lane || waiting.includes(i)) continue;
+      through.push({ lane: i, line: ids[i] });
+    }
+
+    // Close every lane that ended here (including this node's own) before opening
+    // any, or a merge's extra parent could be handed the lane we are about to reuse.
+    for (const i of waiting) lanes[i] = null;
+    lanes[lane] = null;
+
+    const below: Line[] = [];
+    c.parents.forEach((p, k) => {
+      if (k === 0) {
+        // The line continues: same lane, same identity, all the way down the branch.
+        lanes[lane] = p;
+        ids[lane] = line;
+        below.push({ lane, line });
+        return;
+      }
+      const joining = lanes.indexOf(p);
+      if (joining >= 0) { below.push({ lane: joining, line: ids[joining] }); return; }
+      const l = freeLane(lanes);
+      lanes[l] = p;
+      ids[l] = nextLine++;
+      byMerge.set(ids[l], c.subject);
+      below.push({ lane: l, line: ids[l] });
+    });
+
+    // Every lane the row touches, including ones merely passing through: an SVG narrower
+    // than its widest line would clip that line.
+    let span = lane + 1;
+    for (const l of [...above, ...below, ...through]) if (l.lane + 1 > span) span = l.lane + 1;
+    if (span > widest) widest = span;
+    rows.push({ c, lane, line, above, below, through, label: null, merged: [], span });
+  }
+  nameLines(rows, byMerge);
+  return { rows, lanes: widest };
+}
+
+/**
+ * Say what each row's line is, so the graph is readable rather than eight anonymous
+ * colours. Fills `row.label` and `row.merged` in place.
+ *
+ * **The label is the nearest ref ABOVE the commit on its own line, not the topmost
+ * one.** That distinction is the whole correctness of this: in a repo where a feature
+ * branch's tip is simply the newest commit, the top of `dev`'s line carries that
+ * feature's ref — so "topmost" labels half of dev's history with a branch that was cut
+ * from it. The nearest ref above is the tightest ref the commit is genuinely an
+ * ancestor of, which is what someone reading a lane wants to know. (Not a claim of
+ * exclusivity: a commit is typically reachable from many refs.)
+ *
+ * Fallback for a line with no ref above it at all — a branch merged and then deleted
+ * leaves no ref anywhere — is the subject of the merge that opened the line, which is
+ * the last place its name survives. Marked `from: "merge"`, because a message is not a
+ * ref and the wording must not pretend otherwise.
+ */
+function nameLines(rows: GraphRow[], byMerge: Map<number, string>) {
+  // Backward pass — what a merge took in. `refBelow` holds, per line, the nearest ref at
+  // or BELOW the row being visited, which is the only place a merged-in branch's own ref
+  // can be: its commits are older than the merge. Reading the line's first ref instead
+  // would happily report a branch cut from the line *above* the merge as its source.
+  const refBelow = new Map<number, string>();
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const r = rows[i];
+    const own = lineRef(parseRefs(r.c.refs));
+    if (own) refBelow.set(r.line, own);
+    r.merged = r.below.slice(1)
+      .map((b) => refBelow.get(b.line) ?? mergeBranchName(r.c.subject))
+      .filter((n): n is string => !!n);
+  }
+  // Forward pass — what line each row is on: carry the last ref seen down each line, so
+  // a row gets the nearest ref ABOVE it. A line with none at all falls back to the
+  // subject of the merge that opened it (see the note above).
+  const cur = new Map<number, LineLabel>();
+  for (const r of rows) {
+    const own = lineRef(parseRefs(r.c.refs));
+    if (own) cur.set(r.line, { name: own, from: "ref" });
+    else if (!cur.has(r.line)) {
+      const merge = byMerge.get(r.line);
+      const named = merge ? mergeBranchName(merge) : null;
+      if (named) cur.set(r.line, { name: named, from: "merge" });
+    }
+    r.label = cur.get(r.line) ?? null;
+  }
+}
+
+/**
+ * The ref that best names the *line* a commit sits on: where HEAD is, then a local
+ * branch, then a remote one.
+ *
+ * **A tag is deliberately not one of them.** A tag marks a moment — `v0.11.1` is a
+ * commit, not a branch — and a line label propagates down every commit below it, so
+ * accepting tags would label a stretch of history "on v0.11.1", which reads as a
+ * lineage it never had. Tags still show as chips on their own commit.
+ */
+export function lineRef(chips: RefChip[]): string | null {
+  for (const kind of ["head", "branch", "remote"] as RefKind[]) {
+    const hit = chips.find((c) => c.kind === kind);
+    if (hit) return hit.label;
+  }
+  return null;
+}
+
+/**
+ * The branch name inside a merge subject, or null when it doesn't name one.
+ *
+ * Only git's own wordings and GitHub's are matched, quoted form first: `Merge branch
+ * 'x' into y`, `Merge remote-tracking branch 'origin/x'`, `Merge pull request #30 from
+ * owner/branch`. A hand-written "Merge everything" names nothing and must stay null —
+ * inventing a lane name from arbitrary prose would be worse than leaving it blank.
+ */
+export function mergeBranchName(subject: string): string | null {
+  const quoted = subject.match(/^Merge (?:remote-tracking )?branch '([^']+)'/);
+  if (quoted) return quoted[1];
+  const from = subject.match(/^Merge pull request #\d+ from (\S+)/);
+  if (from) return from[1];
+  return null;
+}
+
+/**
+ * The one-line answer to "what is this line?", for the node's tooltip and the detail
+ * strip. Wording tracks `label.from`: a ref is stated, a merge subject is attributed,
+ * and an unnamed line says why it has no name instead of going silent.
+ */
+export function lineTip(row: GraphRow): string {
+  const parts = [
+    row.label
+      ? row.label.from === "ref"
+        ? `On the line leading up to ${row.label.name}`
+        : `On the branch merged in as ${row.label.name} (from the merge's subject)`
+      : "No branch or tag above this commit on its line — usually a branch deleted after merging",
+  ];
+  if (row.merged.length) parts.push(`merges ${row.merged.join(", ")}`);
+  return parts.join(" · ");
+}
+
+// ---------- ref decorations ----------
+
+export type RefKind = "head" | "branch" | "remote" | "tag" | "more";
+export interface RefChip {
+  kind: RefKind;
+  label: string;
+  /** Remotes this chip absorbed: `main` + `origin/main` is ONE chip that says it is
+   *  pushed, not two chips saying the same name twice. Empty for a plain local ref. */
+  also?: string[];
+  /** For the `+N` chip: the refs it stands in for, so the title can list them. */
+  rest?: string[];
+}
+
+/**
+ * Turn a `%D` decoration into typed chips — the raw parse, one chip per ref, in git's
+ * own order. `refChips` is what the panel draws; this is what the layout reasons over.
+ *
+ * Read the FULL ref paths (`--decorate=full`), never the short ones: a local branch
+ * called `feat/graph` and a remote branch `origin/main` are indistinguishable once
+ * abbreviated, and mislabelling half of a branchy repo's chips as remotes is worse
+ * than showing no kind at all. `refs/heads/…`, `refs/remotes/…` and `refs/tags/…`
+ * answer it outright. (The one thing full mode does *not* spell out is a tag, which
+ * keeps its `tag: ` prefix — so that is stripped first.)
+ *
+ * Anything else under `refs/` (notes, stash, a foreign namespace) keeps its path minus
+ * `refs/` and reads as a plain branch chip — an unfamiliar chip is honest; dropping it
+ * silently isn't.
+ */
+export function parseRefs(decoration: string): RefChip[] {
+  const chips: RefChip[] = [];
+  for (const raw of decoration.split(",")) {
+    const t = raw.trim();
+    if (!t) continue;
+    if (t.startsWith("tag: ")) { chips.push({ kind: "tag", label: shortRef(t.slice(5)) }); continue; }
+    // "HEAD -> refs/heads/main" names both the checkout and the branch it is on.
+    const head = t.match(/^HEAD -> (.+)$/);
+    const path = head ? head[1] : t;
+    if (path === "HEAD") { chips.push({ kind: "head", label: "HEAD" }); continue; } // detached
+    const kind: RefKind = head ? "head"
+      : path.startsWith("refs/remotes/") ? "remote"
+      : path.startsWith("refs/tags/") ? "tag" // git prefixes tags, but don't rely on it
+      : "branch";
+    chips.push({ kind, label: shortRef(path) });
+  }
+  return chips;
+}
+
+/**
+ * git's relative date, shortened for a narrow panel: "2 days ago" → "2d", "3 weeks ago"
+ * → "3w", "1 year, 3 months ago" → "1y". Anything unrecognised is returned untouched —
+ * `%cr`'s wording is git's, not ours, and a date we can't parse must still be shown.
+ *
+ * Both forms are rendered and CSS picks one, so nothing is lost at a narrow width; this
+ * is the short one.
+ */
+export function shortRel(rel: string): string {
+  const m = rel.match(/^(\d+)\s+(second|minute|hour|day|week|month|year)s?/);
+  if (!m) return rel;
+  const unit: Record<string, string> = {
+    second: "s", minute: "m", hour: "h", day: "d", week: "w", month: "mo", year: "y",
+  };
+  return m[1] + unit[m[2]];
+}
+
+/** `refs/remotes/origin/main` → `origin/main`; a name we don't know keeps its shape. */
+export function shortRef(path: string): string {
+  for (const p of ["refs/heads/", "refs/remotes/", "refs/tags/"]) {
+    if (path.startsWith(p)) return path.slice(p.length);
+  }
+  return path.startsWith("refs/") ? path.slice(5) : path;
+}
+
+// ---------- geometry & colour ----------
+
+/** Row height in px. The SVG and the row's CSS height must agree exactly, or the
+ *  lane lines break at every row boundary — so both read this. */
+export const ROW_H = 26;
+/** Horizontal distance between lanes, and the left inset of lane 0. */
+export const LANE_W = 14;
+export const LANE_X0 = 11;
+export const laneX = (lane: number) => LANE_X0 + lane * LANE_W;
+export const graphWidth = (lanes: number) => LANE_X0 * 2 + Math.max(0, lanes - 1) * LANE_W;
+
+/**
+ * Lane colours, as CSS variables rather than literals: eight hues have to stay
+ * distinguishable from each other on *both* grounds, and a set that separates nicely
+ * on the dark panel goes pale on the light one — so `--gl-0…7` are re-stepped per
+ * theme in styles.css, next to every other palette that had the same problem.
+ *
+ * A colour follows a branch *line*, not a lane index, so a line keeps its colour for
+ * its whole length even when a neighbouring lane closes and is reused under it.
+ */
+export const GRAPH_COLORS = [
+  "var(--gl-0)", "var(--gl-1)", "var(--gl-2)", "var(--gl-3)",
+  "var(--gl-4)", "var(--gl-5)", "var(--gl-6)", "var(--gl-7)",
+];
+export const laneColor = (line: number) => GRAPH_COLORS[((line % GRAPH_COLORS.length) + GRAPH_COLORS.length) % GRAPH_COLORS.length];
+
+/**
+ * One row's lanes as an inline SVG — `sparkline`'s shape (data in, string out), so
+ * it is tested here rather than in the DOM module that paints it.
+ *
+ * Edges are S-curves between the row's edge and the node's centre line, which is what
+ * makes a merge read as a merge at 26px per row; a straight diagonal at this size
+ * looks like a line that missed its column.
+ */
+export function rowSvg(row: GraphRow, opts: { head?: boolean } = {}): string {
+  const w = graphWidth(row.span), h = ROW_H, mid = h / 2;
+  const x = laneX(row.lane);
+  const seg = (d: string, line: number) => `<path class="gline" d="${d}" stroke="${laneColor(line)}"></path>`;
+  const parts: string[] = [];
+  for (const t of row.through) parts.push(seg(`M${laneX(t.lane)},0V${h}`, t.line));
+  for (const a of row.above) {
+    const xa = laneX(a.lane);
+    parts.push(seg(xa === x ? `M${xa},0V${mid}` : `M${xa},0C${xa},${mid * 0.5} ${x},${mid * 0.5} ${x},${mid}`, a.line));
+  }
+  for (const b of row.below) {
+    const xb = laneX(b.lane);
+    parts.push(seg(xb === x ? `M${x},${mid}V${h}` : `M${x},${mid}C${x},${mid * 1.5} ${xb},${mid * 1.5} ${xb},${h}`, b.line));
+  }
+  const c = laneColor(row.line);
+  const node = opts.head
+    ? `<circle class="gnode ghead" cx="${x}" cy="${mid}" r="4.2" fill="${c}" stroke="${c}"></circle>`
+    : `<circle class="gnode" cx="${x}" cy="${mid}" r="3.4" fill="${c}"></circle>`;
+  return `<svg class="gsvg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">${parts.join("")}${node}</svg>`;
+}
+
+/**
+ * The chips a row actually shows: `parseRefs`, then everything needed to keep a busy
+ * repo's rows readable. Four reductions, each earned on a real repo where the raw list
+ * was unreadable:
+ *
+ * - **A local branch absorbs its remote twins.** `main` beside `origin/main` is the same
+ *   name twice and cost more width than everything else on the row; it becomes one
+ *   `main` chip that *says* it is pushed (`also: ["origin"]`). A remote with no local
+ *   counterpart keeps its `origin/` prefix, because "not checked out here" is the whole
+ *   difference between the two.
+ * - **`origin/HEAD` is dropped.** It is a symref to the remote's default branch — always
+ *   a duplicate of another chip on the same commit, and never the answer to anything.
+ * - **HEAD first, then local, remote, tags.** Git's own order is not stable across
+ *   repos (HEAD can come last), and the leftmost chip is the one that survives a narrow
+ *   column, so it must be the most important one rather than whichever git listed first.
+ * - **A hard cap, with a `+N` chip.** Ten refs on one commit is normal after a release;
+ *   the alternative to folding them is a column wide enough to swallow the subject, or
+ *   chips clipped mid-word.
+ */
+export function refChips(decoration: string, max = 3): RefChip[] {
+  const raw = parseRefs(decoration);
+  const locals = new Map<string, RefChip>();
+  const out: RefChip[] = [];
+  for (const r of raw) {
+    if (r.kind === "head" || r.kind === "branch") {
+      const chip: RefChip = { ...r, also: [] };
+      locals.set(r.label, chip);
+      out.push(chip);
+    }
+  }
+  for (const r of raw) {
+    if (r.kind === "head" || r.kind === "branch") continue;
+    if (r.kind === "remote") {
+      // `refs/remotes/<remote>/<branch>` — the remote name is the first segment (git
+      // does not allow one to contain a slash).
+      const cut = r.label.indexOf("/");
+      const remote = cut < 0 ? r.label : r.label.slice(0, cut);
+      const branch = cut < 0 ? "" : r.label.slice(cut + 1);
+      if (branch === "HEAD") continue; // the remote's default-branch pointer: noise
+      const local = locals.get(branch);
+      if (local) { local.also!.push(remote); continue; }
+    }
+    out.push(r);
+  }
+  const rank: Record<string, number> = { head: 0, branch: 1, remote: 2, tag: 3, more: 4 };
+  out.sort((a, b) => rank[a.kind] - rank[b.kind]);
+  if (out.length <= max) return out;
+  const rest = out.slice(max);
+  return [...out.slice(0, max), {
+    kind: "more",
+    label: `+${rest.length}`,
+    rest: rest.map((r) => chipText(r)),
+  }];
+}
+
+/** A chip's full name for a tooltip — `main (also on origin)`, `v1.0`, `origin/next`. */
+export function chipText(chip: RefChip): string {
+  if (chip.kind === "more") return (chip.rest ?? []).join(", ");
+  return chip.also?.length ? `${chip.label} (also on ${chip.also.join(", ")})` : chip.label;
+}
+
+/** Attribute-safe escaping. `esc` covers `&` and `<`, which is enough for text but not
+ *  for a quoted attribute, and a ref name may legally contain a double quote. */
+const attr = (s: string) => esc(s).replace(/"/g, "&quot;");
+
+/**
+ * Ref chips for a row. A chip that absorbed a remote carries a small `⇡` — "this branch
+ * is also on the remote" — which is a glyph's worth of width instead of a second chip's.
+ *
+ * The name sits in its own inner span so that **only the name is ever ellipsised**: with
+ * the marker inside the truncating text, a long branch loses the one bit of information
+ * the collapse added, which is worse than losing a few characters of a name you can
+ * still hover for.
+ */
+export function refChipsHtml(chips: RefChip[]): string {
+  return chips.map((r) => {
+    // Always titled: a chip can be ellipsised by a narrow column, and then its title is
+    // the only way to read the branch it names.
+    const title = ` title="${attr(chipText(r))}"`;
+    const mark = r.also?.length
+      ? `<span class="gr">⇡${r.also.includes("origin") && r.also.length === 1 ? "" : esc(r.also.join(" "))}</span>`
+      : "";
+    const name = `<span class="gn">${r.kind === "tag" ? "⚑ " : ""}${esc(r.label)}</span>`;
+    return `<span class="gchip gc-${r.kind}"${title}>${name}${mark}</span>`;
+  }).join("");
+}

--- a/src/graphview.ts
+++ b/src/graphview.ts
@@ -1,0 +1,435 @@
+// The project commit-graph panel: the lanes, the refs and the commits behind a
+// project folder. Reached from a project's right-click menu and nowhere else — history
+// is a "go and look" surface, not a figure the cockpit should carry, and the header has
+// no room left for a button that answers a question nobody asked yet.
+//
+// **The rule this module exists to keep: never read a whole history.** Nothing here
+// runs until that menu row is clicked (so app start and renderAll() are untouched),
+// and the panel then reads ONE page — the newest `PAGE` commits — asking for the next
+// only when the reader reaches the end of what it has. A monorepo with 300k commits
+// costs the same first paint as a week-old repo. The layout side is ./graph, which is
+// pure and tested; this module owns the dialog, the IPC and the scroll.
+
+import { invoke } from "@tauri-apps/api/core";
+import { $, dropScrim, toast } from "./dom";
+import { basename, esc, tilde } from "./format";
+import {
+  laneColor, layoutGraph, lineTip, refChips, refChipsHtml, rowSvg, shortRel,
+  type GraphCommit, type GraphLayout,
+} from "./graph";
+
+/** Commits per page. Enough to fill any window at 26px a row and to make the shape of
+ *  recent history legible; small enough that the panel is up in one git call. */
+const PAGE = 60;
+/** How close to the bottom (px) a scroll gets before the next page is fetched. */
+const PREFETCH_PX = 240;
+/** Ceiling on the graph+chips block, so a deep graph or a commit carrying nine refs can't
+ *  squeeze every subject in the panel into nothing. Past it the chips fade at the edge,
+ *  each keeping its full name in its own title. Also bounded by a share of the panel's
+ *  own width (`LEFT_COL_SHARE`) — the rest of the collapse ladder is CSS container
+ *  queries, but this one number is measured in JS, so it has to shrink here. */
+const LEFT_COL_MAX = 380;
+const LEFT_COL_SHARE = 0.42;
+
+type Scope = "all" | "head";
+type Page = { commits: GraphCommit[]; more: boolean };
+const EMPTY_LAYOUT: GraphLayout = { rows: [], lanes: 0 };
+
+let root = "";              // the project folder the panel is scoped to
+let label = "";
+// Resets to "all" on every open rather than persisting: one lane isn't a graph, so
+// all-refs is the answer the panel exists to give, and "this branch" is a narrowing
+// you make while reading — not a setting you want to inherit from last week.
+let scope: Scope = "all";
+let commits: GraphCommit[] = [];
+let layout: GraphLayout = EMPTY_LAYOUT;
+let more = false;
+let loading = false;
+// Whether any page has come back yet for the current question. Distinct from
+// `loading`: without it the first paint (which happens before the first request, so
+// the panel is up instantly) would say "No commits yet" for a frame — an answer, and
+// the wrong one.
+let settled = false;
+let err: string | null = null;
+let sel: string | null = null; // selected sha, for the detail strip
+// The full-message overlay, by sha. Separate from `sel` because closing it must leave the
+// selection alone — you open it to read one commit, not to move.
+let open1: string | null = null;
+// Messages, by sha. Fetched one at a time when the overlay opens rather than shipped with
+// every commit in the page: as a page field a body had to be length-capped, and the cap
+// then truncated the one message somebody had opened to read. Cached so walking ↑/↓
+// through commits and back doesn't re-ask git.
+const msgs = new Map<string, string>();
+// Bumped on every open, rescope, refresh and close: a page that lands after one of
+// those belongs to a question nobody is asking any more and must be dropped.
+let seq = 0;
+
+export let graphOpen = false;
+
+// ---------- opening & loading ----------
+
+export async function openGraph(dir: string, name: string) {
+  root = dir;
+  label = name || basename(dir);
+  scope = "all";
+  graphOpen = true;
+  reset();
+  $("scrim").classList.add("show");
+  $("graphDlg").classList.add("show");
+  $("graphTitle").textContent = label;
+  $("graphPath").textContent = tilde(dir);
+  // Focus the scroll region so ↑/↓ reach the panel rather than the terminal underneath.
+  $("graphBody").focus();
+  render();
+  await loadMore();
+}
+
+export function closeGraph() {
+  graphOpen = false;
+  open1 = null;
+  renderCommit();
+  seq++;
+  loading = false;
+  commits = [];
+  layout = EMPTY_LAYOUT;
+  $("graphDlg").classList.remove("show");
+  dropScrim();
+}
+
+function reset() {
+  seq++;
+  msgs.clear();
+  commits = [];
+  layout = EMPTY_LAYOUT;
+  more = false;
+  loading = false;
+  settled = false;
+  err = null;
+  sel = null;
+  $("graphBody").scrollTop = 0;
+}
+
+/** Fetch the next page and re-lay-out. The only path that talks to git. */
+async function loadMore() {
+  if (!graphOpen || loading) return;
+  loading = true;
+  const my = seq;
+  render(); // paint the "loading" foot before the call, not after it
+  try {
+    const page = await invoke<Page>("git_graph", { workdir: root, skip: commits.length, limit: PAGE, scope });
+    if (my !== seq) return; // closed, rescoped or refreshed while git was working
+    commits = commits.concat(page.commits);
+    more = page.more;
+    err = null;
+  } catch (e) {
+    if (my !== seq) return;
+    err = String(e);
+    more = false;
+  } finally {
+    if (my === seq) {
+      loading = false;
+      settled = true;
+      render();
+      // A tall window can hold more than one page, and then there is no scroll to
+      // trigger the next one — so top up until the reader has something to scroll.
+      const body = $("graphBody");
+      if (more && !loading && body.scrollHeight <= body.clientHeight) void loadMore();
+    }
+  }
+}
+
+async function rescope(s: Scope) {
+  if (s === scope) return;
+  scope = s;
+  reset();
+  render();
+  await loadMore();
+}
+
+async function refresh() {
+  reset();
+  render();
+  await loadMore();
+}
+
+// ---------- painting ----------
+
+function render() {
+  if (!graphOpen) return;
+  layout = layoutGraph(commits);
+  $("graphSub").innerHTML = err
+    ? `<span class="g-err">${esc(err)}</span>`
+    : `${commits.length}${more ? "+" : ""} commit${commits.length === 1 ? "" : "s"}`
+      + ` · <span class="g-dim">${scope === "all" ? "all refs" : "this branch"}</span>`;
+  $("graphScope").innerHTML = (["all", "head"] as Scope[])
+    .map((s) => `<button class="gseg-b ${s === scope ? "on" : ""}" data-gscope="${s}">${s === "all" ? "All branches" : "This branch"}</button>`)
+    .join("");
+
+  const rows = layout.rows.map((r) => {
+    const chips = refChips(r.c.refs);
+    const head = chips.some((x) => x.kind === "head");
+    // The lanes are eight colours and nothing else, so the node carries what line it is
+    // on — and, for a merge, what came in. It is the only place that can be read.
+    const tip = esc(lineTip(r));
+    // Graph and chips share ONE cell: the SVG is only as wide as this row's own lanes,
+    // so the chips land against the graph's actual silhouette, and the cell's fixed width
+    // still starts every subject at the same x.
+    return `<div class="grow${r.c.sha === sel ? " on" : ""}" data-gsha="${r.c.sha}" role="option" aria-selected="${r.c.sha === sel}">`
+      + `<span class="gleft">`
+      + `<span class="gcol" title="${tip}">${rowSvg(r, { head })}</span>`
+      + `<span class="grefs">${refChipsHtml(chips)}</span></span>`
+      + `<span class="gsubj" title="${esc(r.c.subject)}">${esc(r.c.subject) || "<em>no subject</em>"}</span>`
+      + `<span class="gsha">${esc(r.c.short)}</span>`
+      + `<span class="gwho">${esc(r.c.author)}</span>`
+      + `<span class="gwhen" title="${esc(r.c.rel)}"><span class="w-l">${esc(r.c.rel)}</span><span class="w-s">${esc(shortRel(r.c.rel))}</span></span>`
+      + `</div>`;
+  }).join("");
+
+  $("graphBody").innerHTML = rows
+    ? `<div class="grows" role="listbox" aria-label="Commits">${rows}</div>${footHtml()}`
+    : `<div class="diff-empty">${!settled || loading ? "Reading history…" : err ? esc(err) : "No commits yet."}</div>`;
+  $("graphDetail").innerHTML = detailHtml();
+  sizeLeftColumn();
+  if (open1) renderCommit(); // a page landing under the overlay may fill in its parents
+}
+
+/**
+ * Give every row the same graph+chips width: the widest one's, capped.
+ *
+ * The chips belong beside the lanes — a label is a property of the *line*, and inside the
+ * message column it reads as clutter attached to the wrong thing. Measuring one block
+ * (graph *and* chips together) rather than two is what stops a 12-lane repo from
+ * indenting every 2-lane row by ten empty lanes plus the widest ref column in the page;
+ * the slack is shared, so a wide graph and wide chips only cost width where they actually
+ * co-occur.
+ *
+ * Each row is its own grid (see the CSS note), so an `auto` track would be per-row and
+ * stagger. Rather than guess a width from character counts, let the browser lay each row
+ * out naturally, take the widest, and pin every row to it. Both style writes and the read
+ * happen inside this task, so nothing is painted mid-measurement.
+ */
+function sizeLeftColumn() {
+  const list = $("graphBody").querySelector<HTMLElement>(".grows");
+  if (!list) return;
+  list.style.setProperty("--gleft-w", "auto");
+  let max = 0;
+  for (const el of list.querySelectorAll<HTMLElement>(".gleft")) max = Math.max(max, el.offsetWidth);
+  const cap = Math.min(LEFT_COL_MAX, Math.round($("graphDlg").clientWidth * LEFT_COL_SHARE));
+  list.style.setProperty("--gleft-w", Math.min(max, cap) + "px");
+}
+
+/** The end of the list: what is left, and how to ask for it. */
+function footHtml(): string {
+  if (loading) return `<div class="gmore"><span class="g-dim">Reading history…</span></div>`;
+  if (err) return `<div class="gmore"><span class="g-err">${esc(err)}</span></div>`;
+  if (!more) return `<div class="gmore"><span class="g-dim">— the beginning of history —</span></div>`;
+  // Deliberately both: the scroll prefetch is the everyday path, the button is what
+  // makes it obvious that the panel is holding a page and not the whole repo.
+  return `<div class="gmore"><button class="gmore-b" data-gmore="1">Load ${PAGE} more</button></div>`;
+}
+
+function detailHtml(): string {
+  const c = commits.find((x) => x.sha === sel);
+  if (!c) return `<span class="g-dim">Pick a commit to see its branch, author and parents — ⏎ opens the whole message.</span>`;
+  const when = c.unix > 0 ? new Date(c.unix * 1000).toLocaleString() : "";
+  const parents = c.parents.length
+    ? c.parents.map((p) => {
+      const known = commits.some((x) => x.sha === p);
+      // A parent past the loaded frontier isn't a row yet, so it can't be jumped to —
+      // say so on the chip rather than offering a click that does nothing.
+      return known
+        ? `<button class="gp" data-gsha="${p}" title="Jump to this parent">${esc(p.slice(0, 7))}</button>`
+        : `<span class="gp gp-off" title="Not loaded yet — load more to reach it">${esc(p.slice(0, 7))}</span>`;
+    }).join("")
+    : `<span class="g-dim">root</span>`;
+  const row = layout.rows.find((r) => r.c.sha === c.sha);
+  const lane = row
+    ? `<span class="gd-lane" title="${esc(lineTip(row))}" style="--lc:${laneColor(row.line)}">`
+      + `${row.label ? `on ${esc(row.label.name)}` : "no branch on this line"}`
+      + `${row.merged.length ? ` · merges ${esc(row.merged.join(", "))}` : ""}</span>`
+    : "";
+  // Two lines: the commit, then its metadata. Everything here is a *summary* — the full
+  // sha and the message body are one keystroke away in the overlay, and putting them here
+  // as well made a 40-character sha the loudest thing in the panel while the lane label
+  // sat orphaned beside it. The short sha IS the copy button, so that is one control
+  // instead of two.
+  return `<div class="gd-l1">${refChipsHtml(refChips(c.refs, 99))}`
+    + `<span class="gd-subj" title="${esc(c.subject)}">${esc(c.subject)}</span></div>`
+    + `<div class="gd-l2">${lane}<span class="gd-sep">·</span><span>${esc(c.author)}</span>`
+    + `<span class="g-dim">${esc(when)}</span><span class="gd-sep">·</span>`
+    + `<button class="gd-sha-b" data-gcopy="${esc(c.sha)}" title="Copy the full sha\n${esc(c.sha)}">⧉ ${esc(c.short)}</button>`
+    + `<span class="gd-par">parents ${parents}</span>`
+    // Bottom right of the strip, which is where the overlay's own close button lands:
+    // open a message and the thing that closes it is already under the pointer. The
+    // shared `gswap` footprint is what makes that true rather than nearly true.
+    + `<button class="gd-b gswap" data-gopen="${esc(c.sha)}" title="Show the whole commit (⏎)">`
+    + `⤢ Full message</button></div>`;
+}
+
+/**
+ * One commit in full, over the list. The strip can show a subject; a message is prose,
+ * and a scrolling 40px box inside a footer is not where anyone reads prose.
+ *
+ * It covers the list rather than replacing the dialog, so the graph is still behind it and
+ * Esc steps back to it — the reason `graphEscape` exists rather than main.ts calling
+ * `closeGraph` directly.
+ */
+function renderCommit() {
+  const el = $("graphCommit");
+  const c = commits.find((x) => x.sha === open1);
+  if (!c) { el.hidden = true; el.innerHTML = ""; return; }
+  const row = layout.rows.find((r) => r.c.sha === c.sha);
+  // The whole message (subject included) once it lands. Until then the subject alone is
+  // shown — it is already known, so the overlay never opens empty.
+  const msg = msgs.get(c.sha);
+  const body = msg === undefined ? undefined : msg.slice(c.subject.length).trim();
+  const when = c.unix > 0 ? new Date(c.unix * 1000).toLocaleString() : "";
+  const parents = c.parents.length
+    ? c.parents.map((p) => {
+      const known = commits.some((x) => x.sha === p);
+      return known
+        ? `<button class="gp" data-gsha="${p}" data-gjump="1" title="Jump to this parent">${esc(p.slice(0, 12))}</button>`
+        : `<span class="gp gp-off" title="Not loaded yet — load more to reach it">${esc(p.slice(0, 12))}</span>`;
+    }).join("")
+    : `<span class="g-dim">none (root commit)</span>`;
+  el.hidden = false;
+  el.innerHTML = `<div class="gco-head">`
+    + `<code class="gco-sha">${esc(c.sha)}</code>`
+    + `<button class="gd-b" data-gcopy="${esc(c.sha)}">⧉ Sha</button>`
+    + `<button class="gd-b" data-gcopymsg="1">⧉ Message</button>`
+    + `<span class="gco-sp"></span>`
+    + `<button class="diff-x" data-gclose1="1" title="Back to the graph (Esc)">✕</button></div>`
+    + `<div class="gco-body">`
+    + `<div class="gco-refs">${refChipsHtml(refChips(c.refs, 99))}</div>`
+    + `<h3 class="gco-subj">${esc(c.subject)}</h3>`
+    + (body === undefined
+      ? `<div class="gco-nobody">Reading the message…</div>`
+      : body
+        ? `<pre class="gco-msg">${esc(body)}</pre>`
+        : `<div class="gco-nobody">No message body — the subject is the whole commit message.</div>`)
+    + `</div>`
+    + `<div class="gco-meta">`
+    + `<span><b>${esc(c.author)}</b></span><span class="g-dim">${esc(when)}</span>`
+    + (row ? `<span class="gd-lane" style="--lc:${laneColor(row.line)}" title="${esc(lineTip(row))}">`
+      + `${row.label ? `on ${esc(row.label.name)}` : "no branch on this line"}`
+      + `${row.merged.length ? ` · merges ${esc(row.merged.join(", "))}` : ""}</span>` : "")
+    + `<span class="gco-sp"></span><span class="gd-par">parents ${parents}</span>`
+    // A second close, bottom right. You finish reading at the *bottom* of a message, and
+    // the pointer is already down here — travelling back to the top-right ✕ is the whole
+    // reason this exists. Both buttons and Esc do the same thing.
+    + `<button class="gd-b gswap gco-x2" data-gclose1="1" title="Back to the graph (Esc)">✕ Close</button>`
+    + `</div>`;
+}
+
+function openCommit(sha: string | null) {
+  if (!sha) return;
+  open1 = sha;
+  renderCommit();
+  $("graphCommit").focus();
+  if (!msgs.has(sha)) void loadMessage(sha);
+}
+
+/** One commit's whole message. Uncapped in practice — see git_commit_message. */
+async function loadMessage(sha: string) {
+  try {
+    msgs.set(sha, await invoke<string>("git_commit_message", { workdir: root, sha }));
+  } catch (e) {
+    // Store the failure where the body would have been, and cache it: a broken object
+    // store must not be re-asked on every ↑/↓.
+    msgs.set(sha, `${commits.find((c) => c.sha === sha)?.subject ?? ""}\n\ncouldn't read this message — ${String(e)}`);
+  }
+  if (open1 === sha) renderCommit();
+}
+function closeCommit() {
+  open1 = null;
+  renderCommit();
+  $("graphBody").focus();
+}
+/** Esc steps out one layer: the commit overlay first, then the panel. */
+export function graphEscape() {
+  if (open1) { closeCommit(); return; }
+  closeGraph();
+}
+
+/** Select a commit, scrolling it into view when the move came from the keyboard. */
+function select(sha: string | null, reveal = false) {
+  sel = sha;
+  render();
+  if (reveal && sha) $("graphBody").querySelector<HTMLElement>(`.grow[data-gsha="${sha}"]`)?.scrollIntoView({ block: "nearest" });
+}
+
+function step(delta: number) {
+  const rows = layout.rows;
+  if (!rows.length) return;
+  const at = rows.findIndex((r) => r.c.sha === sel);
+  const next = at < 0 ? (delta > 0 ? 0 : rows.length - 1) : Math.max(0, Math.min(rows.length - 1, at + delta));
+  select(rows[next].c.sha, true);
+}
+
+// ---------- the panel's own wiring ----------
+
+$("graphClose").addEventListener("click", closeGraph);
+$("graphRefresh").addEventListener("click", () => { void refresh(); });
+$("graphScope").addEventListener("click", (e) => {
+  const b = (e.target as HTMLElement).closest<HTMLElement>("[data-gscope]");
+  if (b) void rescope(b.dataset.gscope as Scope);
+});
+// One delegated handler for the list and the detail strip: a parent chip in the strip
+// carries the same data-gsha a row does, so jumping to it needs no second path.
+for (const id of ["graphBody", "graphDetail", "graphCommit"]) {
+  $(id).addEventListener("click", (e) => {
+    const t = e.target as HTMLElement;
+    const copy = t.closest<HTMLElement>("[data-gcopy]");
+    if (copy) {
+      const sha = copy.dataset.gcopy!;
+      navigator.clipboard.writeText(sha).then(() => toast("Sha copied")).catch(() => toast(sha));
+      return;
+    }
+    if (t.closest("[data-gcopymsg]")) {
+      const c = commits.find((x) => x.sha === open1);
+      const text = (open1 && msgs.get(open1)) || c?.subject || "";
+      navigator.clipboard.writeText(text).then(() => toast("Message copied")).catch(() => toast("copy failed"));
+      return;
+    }
+    if (t.closest("[data-gclose1]")) { closeCommit(); return; }
+    if (t.closest("[data-gmore]")) { void loadMore(); return; }
+    const opener = t.closest<HTMLElement>("[data-gopen]");
+    if (opener) { openCommit(opener.dataset.gopen!); return; }
+    const row = t.closest<HTMLElement>("[data-gsha]");
+    if (!row) return;
+    // A parent chip in the strip or the overlay jumps; a row toggles its selection.
+    if (row.dataset.gjump) { select(row.dataset.gsha!, true); closeCommit(); return; }
+    select(row.dataset.gsha === sel ? null : row.dataset.gsha!, id !== "graphBody");
+  });
+}
+// The left block's cap is a share of the panel's width, so a window resize has to
+// re-measure it — nothing else re-renders on resize.
+window.addEventListener("resize", () => { if (graphOpen) sizeLeftColumn(); });
+// ↑/↓ keep working while a commit is open, so a message can be read one commit at a time
+// rather than open-Esc-move-open. (Esc is global — see graphEscape.)
+$("graphCommit").addEventListener("keydown", (e) => {
+  if (!open1) return;
+  if (e.key === "ArrowDown") { e.preventDefault(); step(1); openCommit(sel); }
+  else if (e.key === "ArrowUp") { e.preventDefault(); step(-1); openCommit(sel); }
+});
+// Double-click a row to read it in full — the same thing ⏎ and the strip's ⤢ do.
+$("graphBody").addEventListener("dblclick", (e) => {
+  const row = (e.target as HTMLElement).closest<HTMLElement>("[data-gsha]");
+  if (row) openCommit(row.dataset.gsha!);
+});
+// Load the next page as the reader approaches the end of this one. The `more` and
+// `loading` guards are in loadMore, so a fast scroll can't stack requests.
+$("graphBody").addEventListener("scroll", () => {
+  if (!graphOpen || loading || !more) return;
+  const b = $("graphBody");
+  if (b.scrollHeight - b.scrollTop - b.clientHeight < PREFETCH_PX) void loadMore();
+});
+// Arrow keys walk the list. Scoped to the open panel and stopped here, so they never
+// reach the terminal (or the sidebar) underneath.
+$("graphBody").addEventListener("keydown", (e) => {
+  if (!graphOpen) return;
+  if (e.key === "ArrowDown") { e.preventDefault(); step(1); }
+  else if (e.key === "ArrowUp") { e.preventDefault(); step(-1); }
+  else if (e.key === "Home") { e.preventDefault(); if (layout.rows.length) select(layout.rows[0].c.sha, true); }
+  else if (e.key === "Enter" && sel) { e.preventDefault(); openCommit(sel); }
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,6 +58,10 @@ import { basename, setHome } from "./format";
 import { setRlLogger } from "./rl";
 import { closeCafPop, reconcileCaf, setCafHost } from "./caffeinate";
 import { closeDiff, diffOpen, openDiff, setDiffCloseFootMenus } from "./diffview";
+// The commit-graph panel needs nothing from here — it is opened from the project
+// context menu (./projmenu) and owns its own handlers; this file only has to close it
+// with the shared scrim and Esc, like every other dialog.
+import { closeGraph, graphEscape, graphOpen } from "./graphview";
 import {
   closeInputPrompt, closeRunPicker, closeTaskManager, mgrEdit, openRunPicker,
   renderMgr, setMgrEdit, setTaskUiHost,
@@ -497,7 +501,7 @@ $("setClose").addEventListener("click", closeSettings);
 $("fRepo").addEventListener("click", (e) => { e.preventDefault(); openUrl("https://github.com/respeak-io/episko").catch(() => {}); });
 $("btnClose").addEventListener("click", () => { if (activeId) closeSession(activeId); });
 
-$("scrim").addEventListener("click", () => { closePalette(); closeWt(); closeDiff(); closeSettings(); closeRunPicker(); closeInputPrompt(); closeTaskManager(); });
+$("scrim").addEventListener("click", () => { closePalette(); closeWt(); closeDiff(); closeGraph(); closeSettings(); closeRunPicker(); closeInputPrompt(); closeTaskManager(); });
 window.addEventListener("keydown", (e) => {
   const meta = e.metaKey || e.ctrlKey;
   if (meta && e.key.toLowerCase() === "k") { e.preventDefault(); $("palette").classList.contains("show") ? closePalette() : openPalette(); }
@@ -512,6 +516,9 @@ window.addEventListener("keydown", (e) => {
   else if (meta && e.shiftKey && e.key.toLowerCase() === "r") { e.preventDefault(); void openRunPicker(); }
   else if (e.key === "Escape" && ctxMenuOpen()) { e.preventDefault(); closeColorPop(); closeCtxMenu(); }
   else if (e.key === "Escape" && diffOpen) { e.preventDefault(); closeDiff(); }
+  // graphEscape, not closeGraph: the panel can have a commit open over it, and Esc has to
+  // step out of that first.
+  else if (e.key === "Escape" && graphOpen) { e.preventDefault(); graphEscape(); }
   else if (e.key === "Escape" && settingsOpen()) { e.preventDefault(); closeSettings(); }
   else if (e.key === "Escape" && $("mgrDlg").classList.contains("show")) { e.preventDefault(); if (mgrEdit) { setMgrEdit(null); renderMgr(); } else closeTaskManager(); }
 });

--- a/src/projmenu.ts
+++ b/src/projmenu.ts
@@ -11,6 +11,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { $, FILE_MANAGER, toast } from "./dom";
 import { basename, esc, tilde } from "./format";
 import { closeFootMenus } from "./footer";
+import { openGraph } from "./graphview";
 import { clearIcon, customIcons, iconFor, pickCustomIcon, resetCustomIcon } from "./icons";
 import { openWt } from "./worktree";
 import { isAgent } from "./types";
@@ -137,6 +138,9 @@ function openCtxMenu(key: string, x: number, y: number) {
     { act: "worktree", ic: "⑃", label: "New worktree session…", sub: "on a branch of its own" },
     { act: "terminal", ic: "❯", label: "Open terminal here", sub: termEngine === "embedded" ? "shell pane inside Episko" : engineDef(termEngine).label },
     null,
+    // Dropped below unless the probe says this folder is a repo — a graph row on a
+    // plain directory would open a panel with nothing but an error in it.
+    { act: "graph", ic: "⑂", label: "Commit graph…", sub: "recent history, branches and merges" },
     { act: "folder", ic: "⌂", label: "Open project folder", sub: FILE_MANAGER },
     { act: "copypath", ic: "⧉", label: "Copy path" },
     null,
@@ -157,17 +161,18 @@ function openCtxMenu(key: string, x: number, y: number) {
     + `<span class="mp-hmain"><span class="mp-hname">${esc(projName(key))}</span><span class="mp-hpath">${esc(tilde(key))}</span></span></div>`
     + rows.map((r) => (r ? ctxRowHtml(r) : `<div class="mp-sep"></div>`)).join("");
   placePop(menu, x, y);
-  // A worktree only means something in a git repo. Ask *after* opening — the menu
-  // must feel instant — then either name the branch it would fork from or drop the
-  // row entirely. (A detached HEAD also answers None and loses the row; forking a
-  // worktree from one is a corner case not worth a second probe.)
-  invoke<string | null>("git_branch", { workdir: key }).then((b) => {
+  // Two rows only mean something in a git repo. Ask *after* opening — the menu must
+  // feel instant — then drop what doesn't apply and re-place the (now shorter) menu.
+  // One probe answers both: `git_head` returns None for anything that isn't a repo
+  // with a commit, and a null `branch` inside it means a detached HEAD, which still
+  // has a history to graph but no branch to fork a worktree from.
+  invoke<{ branch: string | null; short: string } | null>("git_head", { workdir: key }).then((h) => {
     if (ctxKey !== key) return; // menu closed or moved to another project meanwhile
-    const row = menu.querySelector<HTMLElement>('[data-ctx="worktree"]');
-    if (!row) return;
-    if (!b) { row.remove(); placePop(menu, x, y); return; }
-    const sub = row.querySelector(".mp-s");
-    if (sub) sub.textContent = `branch off ${b}`;
+    const drop = (act: string) => menu.querySelector<HTMLElement>(`[data-ctx="${act}"]`)?.remove();
+    if (!h) { drop("worktree"); drop("graph"); placePop(menu, x, y); return; }
+    if (!h.branch) { drop("worktree"); placePop(menu, x, y); return; }
+    const sub = menu.querySelector('[data-ctx="worktree"] .mp-s');
+    if (sub) sub.textContent = `branch off ${h.branch}`;
   }).catch(() => {});
 }
 export function closeCtxMenu() { $("ctxMenu").classList.remove("show"); ctxKey = null; }
@@ -214,6 +219,7 @@ $("ctxMenu").addEventListener("click", (e) => {
     case "launch": host.requestLaunch(name, key); break;
     case "worktree": openWt(name, key); break;
     case "terminal": openTerminalIn(name, key); break;
+    case "graph": void openGraph(key, name); break;
     case "folder": host.openProjectFolder(key); break;
     case "copypath": copyPath(key); break;
     case "addproj": host.addProjectPath(key); break;

--- a/src/styles.css
+++ b/src/styles.css
@@ -34,6 +34,10 @@
   --m-opus:#8f74ee; --m-sonnet:#c07d1e; --m-haiku:#149a73; --m-other:#8a8394; --m-unattr:#6b6478;
   --u-g0:#191622; --u-g1:#372e57; --u-g2:#544499; --u-g3:#7d63d8; --u-g4:#a78bfa;
   --u-t1:#2c2740; --u-t2:#4a3d7a; --u-t3:#7159c4; --u-t4:#a78bfa;
+  /* commit-graph lanes: eight hues that must stay apart from EACH OTHER (they carry no
+     meaning, only identity) and off the accent, which the selection already uses */
+  --gl-0:#7aa2f7; --gl-1:#f7768e; --gl-2:#9ece6a; --gl-3:#e0af68;
+  --gl-4:#bb9af7; --gl-5:#2ac3de; --gl-6:#ff9e64; --gl-7:#73daca;
   --radius:11px; --radius-sm:8px; --radius-lg:13px;
   --font-ui: -apple-system, "SF Pro Text", "Segoe UI", system-ui, sans-serif;
   --font-mono: "JetBrainsMono Nerd Font", ui-monospace, "SF Mono", "JetBrains Mono", "Berkeley Mono", Menlo, monospace;
@@ -50,6 +54,10 @@
   --m-opus:#7c5cf0; --m-sonnet:#b8760f; --m-haiku:#0c8f68; --m-other:#8a8598; --m-unattr:#b8b2c6;
   --u-g0:#eceaf2; --u-g1:#d8cff2; --u-g2:#b7a4ee; --u-g3:#9575e8; --u-g4:#7c5cf0;
   --u-t1:#e4def3; --u-t2:#c3b0ee; --u-t3:#9878e6; --u-t4:#7c5cf0;
+  /* lane hues re-stepped for the light ground — the dark set's pastels vanish on white
+     at 1.6px of stroke, which is the whole width a lane line has to work with */
+  --gl-0:#2563eb; --gl-1:#dc2626; --gl-2:#15803d; --gl-3:#b45309;
+  --gl-4:#7c3aed; --gl-5:#0e7490; --gl-6:#c2410c; --gl-7:#0f766e;
   color-scheme: light;
 }
 
@@ -449,6 +457,154 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .dline.add .dsign { color: var(--st-done); }
 .dline.del { background: color-mix(in srgb, var(--st-attention) 11%, transparent); }
 .dline.del .dsign { color: var(--st-attention); }
+
+/* --- project commit graph (modal) ---
+   Row height is the one number shared with TypeScript: .grow's height MUST equal
+   ROW_H in graph.ts, because the lane lines are drawn edge-to-edge per row and a
+   half-pixel of disagreement shows up as a break at every single boundary. Nothing
+   here may add to a row's box either — no padding, no border, hence the selection
+   being a background and the "current" marker an inset box-shadow. */
+.graphdlg { container-type: inline-size; position: fixed; top: 7vh; left: 50%; transform: translateX(-50%) translateY(-8px) scale(.985); width: min(1120px, 95vw); height: 80vh; z-index: 41; display: flex; flex-direction: column; border-radius: var(--radius-lg); overflow: hidden; opacity: 0; pointer-events: none; transition: opacity .16s, transform .16s; background: color-mix(in srgb, var(--panel) 92%, transparent); backdrop-filter: blur(24px) saturate(1.4); border: 1px solid var(--hair-strong); box-shadow: 0 40px 100px -30px rgba(0,0,0,.8), inset 0 1px 0 rgba(255,255,255,.06); }
+.graphdlg.show { opacity: 1; pointer-events: auto; transform: translateX(-50%) translateY(0) scale(1); }
+.graph-head { display: flex; align-items: center; gap: 10px; padding: 10px 13px; border-bottom: 1px solid var(--hair); flex: none; }
+.graph-head .diff-x { margin-left: 0; }
+.graph-path { font: 11px var(--font-mono); color: var(--muted-2); margin-left: auto; max-width: 34%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.graph-ref { width: 24px; height: 24px; border-radius: 7px; border: 1px solid var(--hair); background: var(--surface); color: var(--muted); cursor: pointer; font-size: 12px; flex: none; }
+.graph-ref:hover { color: var(--text); border-color: var(--hair-strong); }
+.gseg { display: flex; gap: 2px; padding: 2px; border-radius: 8px; background: var(--surface); border: 1px solid var(--hair); flex: none; }
+.gseg-b { border: 0; background: none; color: var(--muted); font: 600 10.5px var(--font-ui); padding: 3px 8px; border-radius: 6px; cursor: pointer; }
+.gseg-b:hover { color: var(--text); }
+.gseg-b.on { background: var(--surface-2); color: var(--text); }
+.graph-body { flex: 1; min-height: 0; overflow-y: auto; outline: none; padding: 5px 0; }
+/* A summary, not the commit: two single lines of fixed height — the commit, then its
+   metadata. It changes with the *selection*, so a strip that grew for a commit with a body
+   would make the list jump under the cursor mid-arrow-walk, and prose in a 40px box left
+   half the width empty anyway. `⤢` opens the whole thing. */
+/* 64px is not arbitrary: 9 + 17 (subject line) + 6 (gap) + 22 (the button's line) + 9.
+   At 58 the content overflowed by 3px and the ⤢ button sat 3px off the overlay's close
+   button — which has to land on the same pixels, so this height is load-bearing. */
+.graph-detail { flex: none; border-top: 1px solid var(--hair); padding: 9px 13px; height: 64px; display: flex; flex-direction: column; justify-content: center; gap: 6px; font-size: 11.5px; overflow: hidden; }
+.g-dim { color: var(--muted-2); }
+.g-err { color: var(--st-error); }
+
+/* `minmax(0, …)` on the graph+chips block and a floor under the subject: an `fr` track
+   yields space before any fixed one, so with a rigid left block the *message* was the
+   column that vanished in a narrow window — exactly backwards. The left block gives way
+   first, and the collapse rules below drop the sha and the author before the subject is
+   squeezed further. */
+.grow { display: grid; grid-template-columns: minmax(0, var(--gleft-w, auto)) minmax(90px, 1fr) auto auto auto; align-items: center; column-gap: 10px; height: 26px; padding: 0 13px 0 0; cursor: default; }
+.grow:hover { background: var(--lift); }
+.grow.on { background: var(--accent-wash); box-shadow: inset 2px 0 0 var(--accent); }
+/* Graph and chips are ONE cell of a fixed (measured) width, with the SVG sized to the
+   row's own lanes — so the chips sit against the graph's real silhouette instead of past
+   the widest row in the page, and the subject column still starts at one x. */
+.gleft { display: flex; align-items: center; gap: 3px; min-width: 0; overflow: hidden; }
+.gcol { flex: none; }
+.gsvg { display: block; }
+.gsvg .gline { fill: none; stroke-width: 1.7; }
+.gsvg .gnode { stroke: none; }
+.gsvg .ghead { stroke: var(--panel); stroke-width: 2.2; }
+/* Refs get a column of their own, between the graph and the subject: a label belongs to
+   the LINE, so it reads correctly beside the lanes and as message-clutter inside the
+   subject. Chips are shrinkable and ellipsis individually — the container must never
+   clip, which is what produced half-words like "igin/main". Width is measured once per
+   render (sizeRefColumn) rather than left `auto`, which would be per-row and stagger. */
+.grefs { display: flex; align-items: center; justify-content: flex-start; gap: 4px; overflow: hidden; min-width: 0; flex: 1 1 auto;
+  /* Whatever still doesn't fit fades out instead of being sliced. Chips are sorted by
+     importance, so the far end is the cheapest thing to lose — and a hard cut mid-name
+     ("igin/main") reads as breakage where a fade reads as "more, over there". */
+  mask-image: linear-gradient(to right, #000 calc(100% - 14px), transparent);
+  -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 14px), transparent); }
+.gsubj { font-size: 12px; color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.grow:not(.on) .gsubj { color: color-mix(in srgb, var(--text) 88%, transparent); }
+/* Every row is its own grid, so the three trailing columns need FIXED widths — with
+   `auto` each row sizes to its own author name and the columns stagger down the list.
+   (A single grid with `subgrid` rows would do it too, and cost a CSS feature for the
+   sake of three numbers.) */
+.gsha { width: 62px; text-align: right; font: 11px var(--font-mono); color: var(--muted-2); }
+.gwho { width: 132px; font-size: 11px; color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.gwhen { width: 92px; text-align: right; font-size: 11px; color: var(--muted-2); overflow: hidden; white-space: nowrap; }
+.gwhen .w-s { display: none; }
+
+/* ref chips — kind is the colour, so a remote never reads as a local branch */
+/* Never shrink: flex shrinks proportionally, which turns a 3-character `dev` into
+   `dev…` to buy a long neighbour a few pixels it also can't use. Each chip instead has
+   its own ceiling and ellipsises there; the column fades out the rest (above). */
+.gchip { display: inline-flex; align-items: center; flex: none; max-width: 190px; font: 600 10px var(--font-mono); padding: 1px 5px; border-radius: 5px; border: 1px solid transparent; white-space: nowrap; overflow: hidden; }
+/* Only the NAME truncates. With the marker inside the ellipsised text, a long branch
+   loses the very thing the collapse added. */
+.gchip .gn { overflow: hidden; text-overflow: ellipsis; min-width: 0; }
+/* "⇡" — this branch is also on its remote, so one chip stands for both refs */
+.gr { flex: none; margin-left: 3px; font-size: 9px; opacity: .65; }
+.gc-more { flex: none; color: var(--muted-2); background: var(--surface-2); }
+.gc-head { color: var(--accent-ink); background: var(--accent-wash); border-color: var(--accent-line); }
+.gc-branch { color: var(--tool-read); background: color-mix(in srgb, var(--tool-read) 13%, transparent); }
+.gc-remote { color: var(--muted); background: color-mix(in srgb, var(--muted) 13%, transparent); }
+.gc-tag { color: var(--st-working); background: color-mix(in srgb, var(--st-working) 14%, transparent); }
+
+/* What a narrow panel gives up, in order of what it can afford to lose. The full forms
+   stay in the title attributes and the detail strip, so nothing here loses information —
+   only width. Keyed off the dialog (container queries), not the viewport: the panel's
+   width is what the table actually has to live in. */
+@container (max-width: 1040px) {
+  .gwhen { width: 44px; }
+  .gwhen .w-l { display: none; }
+  .gwhen .w-s { display: inline; }
+}
+@container (max-width: 940px) { .gsha { display: none; } }
+@container (max-width: 830px) { .gwho { display: none; } .graph-path { display: none; } }
+@container (max-width: 700px) { .graph-head { gap: 7px; } }
+
+.gmore { display: flex; justify-content: center; padding: 10px; font-size: 11px; }
+.gmore-b { border: 1px solid var(--hair-strong); background: var(--surface); color: var(--text); font: 600 11px var(--font-ui); padding: 5px 12px; border-radius: 7px; cursor: pointer; }
+.gmore-b:hover { border-color: var(--accent-ink); }
+
+.gd-l1 { display: flex; align-items: center; gap: 7px; flex: none; min-width: 0; }
+/* which line the selection is on — the coloured tick ties the words to the lane */
+.gd-lane { display: flex; align-items: center; gap: 5px; font-size: 11px; color: var(--muted); }
+.gd-lane::before { content: ""; width: 9px; height: 2px; border-radius: 1px; background: var(--lc, var(--muted-2)); }
+.gd-sha { font: 11px var(--font-mono); color: var(--muted); overflow: hidden; text-overflow: ellipsis; }
+.gd-b { border: 1px solid var(--hair); background: var(--surface); color: var(--muted); font: 600 10.5px var(--font-ui); padding: 2px 7px; border-radius: 6px; cursor: pointer; flex: none; }
+.gd-b:hover { color: var(--text); border-color: var(--hair-strong); }
+.gd-l2 { display: flex; align-items: center; gap: 8px; min-width: 0; flex: none; color: var(--muted); overflow: hidden; }
+.gd-subj { flex: 1 1 auto; min-width: 0; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* The strip's "⤢ Full message" and the overlay's "✕ Close" share one footprint: same
+   width, same height, both hard right on the last line of their bar. Opening a message
+   therefore puts the button that closes it exactly where the pointer already is —
+   that only works if the two rectangles match, hence the min-width. */
+.gswap { flex: none; margin-left: auto; min-width: 116px; height: 22px; display: inline-flex; align-items: center; justify-content: center; gap: 4px; }
+.gd-sep { color: var(--muted-2); opacity: .6; }
+/* The short sha IS the copy control — one thing instead of a label plus a button. */
+.gd-sha-b { flex: none; border: 1px solid transparent; background: none; color: var(--muted-2); font: 11px var(--font-mono); padding: 1px 4px; border-radius: 5px; cursor: pointer; }
+.gd-sha-b:hover { color: var(--text); border-color: var(--hair-strong); background: var(--surface); }
+.gd-par { display: flex; align-items: center; gap: 5px; color: var(--muted-2); flex: none; white-space: nowrap; }
+.gp { font: 11px var(--font-mono); border: 1px solid var(--hair); background: var(--surface); color: var(--muted); padding: 1px 5px; border-radius: 5px; cursor: pointer; }
+.gp:hover { color: var(--text); border-color: var(--accent-ink); }
+.gp-off { opacity: .5; cursor: default; }
+
+/* One commit, over the list. NOTE the `gco-` prefix: `gc-` is taken by the ref-chip
+   kinds (gc-head / gc-branch / …), and naming this header `.gc-head` gave every HEAD chip
+   in the panel the header's padding — a bug you could see but not explain. */
+/* One commit, over the list. Inside the dialog (not a second modal) so the graph stays
+   behind it and Esc steps back rather than closing everything. */
+.gcommit { position: absolute; inset: 44px 0 0 0; z-index: 2; display: flex; flex-direction: column; background: color-mix(in srgb, var(--panel) 97%, transparent); backdrop-filter: blur(8px); }
+.gcommit[hidden] { display: none; }
+.gco-head { display: flex; align-items: center; gap: 8px; padding: 9px 13px; border-bottom: 1px solid var(--hair); flex: none; }
+.gco-sha { font: 11px var(--font-mono); color: var(--muted); overflow: hidden; text-overflow: ellipsis; }
+.gco-sp { margin-left: auto; }
+.gco-body { flex: 1; min-height: 0; overflow-y: auto; padding: 14px 16px; }
+.gco-refs { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 9px; }
+.gco-refs:empty { display: none; }
+.gco-subj { margin: 0 0 10px; font-size: 15px; font-weight: 650; line-height: 1.35; }
+/* A commit message is preformatted text — wrapping it is fine, reflowing its structure
+   (lists, indented blocks, trailers) is not. */
+.gco-msg { margin: 0; font: 12px/1.65 var(--font-mono); color: var(--text); white-space: pre-wrap; overflow-wrap: break-word; }
+.gco-nobody { color: var(--muted-2); font-size: 12px; }
+.gco-meta { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; padding: 9px 13px; border-top: 1px solid var(--hair); flex: none; font-size: 11.5px; color: var(--muted); }
+/* The bottom-right twin of the header's ✕ — pinned below the scrolling message, so a long
+   commit ends next to a close button instead of a trip back to the top. Padding here
+   matches the detail strip's bottom line so the two buttons land on the same pixels. */
+.gco-x2 { margin-left: 12px; }
 
 /* --- timeline (colour by tool, latency bar) --- */
 .tl2 { display: flex; flex-direction: column; }

--- a/test/graph.test.ts
+++ b/test/graph.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect } from "vitest";
+import {
+  chipText, GRAPH_COLORS, graphWidth, laneColor, laneX, layoutGraph, lineRef, lineTip,
+  mergeBranchName, parseRefs, refChips, refChipsHtml, rowSvg, shortRef, shortRel,
+  type GraphCommit,
+} from "../src/graph";
+
+// A commit as git_graph hands it over. Only sha/parents shape the graph, so the rest
+// is filled in once and ignored — every test here is about lanes or about refs.
+const c = (sha: string, parents: string[] = [], refs = "", subject = ""): GraphCommit => ({
+  sha, short: sha.slice(0, 7), parents, refs,
+  subject: subject || `subject ${sha}`, author: "T", unix: 1700000000, rel: "1 day ago",
+});
+/** The lanes a row's segments touch, as a compact shape to assert against. */
+const shape = (r: ReturnType<typeof layoutGraph>["rows"][number]) => ({
+  lane: r.lane,
+  above: r.above.map((l) => l.lane),
+  below: r.below.map((l) => l.lane),
+  through: r.through.map((l) => l.lane),
+});
+
+describe("layoutGraph", () => {
+  it("has nothing to draw for an empty page", () => {
+    expect(layoutGraph([])).toEqual({ rows: [], lanes: 0 });
+  });
+
+  it("keeps a linear history in one lane, one colour", () => {
+    const l = layoutGraph([c("a", ["b"]), c("b", ["d"]), c("d")]);
+    expect(l.lanes).toBe(1);
+    expect(l.rows.map(shape)).toEqual([
+      { lane: 0, above: [], below: [0], through: [] },      // tip: opens the lane
+      { lane: 0, above: [0], below: [0], through: [] },
+      { lane: 0, above: [0], below: [], through: [] },      // root: closes it
+    ]);
+    expect(new Set(l.rows.map((r) => r.line)).size).toBe(1);
+  });
+
+  it("forks a lane at a merge and folds it back in at the branch point", () => {
+    //  m ── merge of (main, side); both sides land on base
+    const l = layoutGraph([
+      c("m", ["main1", "side1"]),
+      c("main1", ["base"]),
+      c("side1", ["base"]),
+      c("base"),
+    ]);
+    expect(l.lanes).toBe(2);
+    expect(l.rows.map(shape)).toEqual([
+      // The merge opens a second lane for its second parent.
+      { lane: 0, above: [], below: [0, 1], through: [] },
+      // main1 takes lane 0; side1's lane crosses this row untouched.
+      { lane: 0, above: [0], below: [0], through: [1] },
+      // side1 keeps its own lane down to the shared parent rather than sidestepping
+      // into lane 0 here — the two lines converge at `base`, one row lower.
+      { lane: 1, above: [1], below: [1], through: [0] },
+      // base is that convergence: two lanes were waiting for it, both end here.
+      { lane: 0, above: [0, 1], below: [], through: [] },
+    ]);
+    // A merge's second parent starts a new line, so it gets its own identity (and so
+    // its own colour); the first parent inherits, which is what keeps a branch one
+    // colour down its whole length.
+    expect(l.rows[0].below[0].line).toBe(l.rows[0].line);
+    expect(l.rows[0].below[1].line).not.toBe(l.rows[0].line);
+    expect(l.rows[2].line).toBe(l.rows[0].below[1].line);
+  });
+
+  it("gives every root/tip its own lane and reuses one that closed", () => {
+    // Two unrelated histories, the first ending before the second starts.
+    const l = layoutGraph([c("a", ["a2"]), c("a2"), c("b", ["b2"]), c("b2")]);
+    expect(l.lanes).toBe(1); // lane 0 freed by a2 is reused by b
+    expect(l.rows.map((r) => r.lane)).toEqual([0, 0, 0, 0]);
+    // But identity (and so colour) follows the LINE, not the lane, so the reuse shows.
+    expect(l.rows[2].line).not.toBe(l.rows[0].line);
+  });
+
+  it("leaves the frontier's lanes open, so the last rows' lines run off the bottom", () => {
+    // `x` is the last loaded commit and its parent is on the next page.
+    const l = layoutGraph([c("t", ["x"]), c("x", ["notloaded"])]);
+    expect(shape(l.rows[1]).below).toEqual([0]);
+    // A parent nobody loaded is not a row, and must not invent one.
+    expect(l.rows).toHaveLength(2);
+  });
+
+  it("lets two tips with a shared parent run side by side and converge on it", () => {
+    // Both `a` and `b` have parent `p`: a opens lane 0, b opens lane 1 (lane 0 is
+    // already waiting for p), and p — waited for by both — closes the pair.
+    const l = layoutGraph([c("a", ["p"]), c("b", ["p"]), c("p")]);
+    expect(l.rows.map(shape)).toEqual([
+      { lane: 0, above: [], below: [0], through: [] },
+      { lane: 1, above: [], below: [1], through: [0] },
+      { lane: 0, above: [0, 1], below: [], through: [] },
+    ]);
+    expect(l.lanes).toBe(2);
+  });
+});
+
+describe("parseRefs", () => {
+  it("has no chips for an undecorated commit", () => {
+    expect(parseRefs("")).toEqual([]);
+    expect(parseRefs("  ")).toEqual([]);
+  });
+
+  it("types HEAD, branches, remotes and tags from their full paths", () => {
+    expect(parseRefs("HEAD -> refs/heads/dev, refs/remotes/origin/main, refs/remotes/origin/dev, tag: refs/tags/v1.2")).toEqual([
+      { kind: "head", label: "dev" },
+      { kind: "remote", label: "origin/main" },
+      { kind: "remote", label: "origin/dev" },
+      { kind: "tag", label: "v1.2" },
+    ]);
+  });
+
+  it("does not mistake a slashed local branch for a remote", () => {
+    // The whole reason the backend asks for --decorate=full: `feat/graph` and
+    // `origin/main` are the same shape once abbreviated.
+    expect(parseRefs("refs/heads/feat/graph, refs/remotes/origin/feat/graph")).toEqual([
+      { kind: "branch", label: "feat/graph" },
+      { kind: "remote", label: "origin/feat/graph" },
+    ]);
+  });
+
+  it("shows a detached HEAD as itself", () => {
+    expect(parseRefs("HEAD, refs/tags/v9")).toEqual([
+      { kind: "head", label: "HEAD" },
+      { kind: "tag", label: "v9" },
+    ]);
+  });
+
+  it("keeps a ref from a namespace it doesn't know rather than dropping it", () => {
+    expect(parseRefs("refs/notes/commits")).toEqual([{ kind: "branch", label: "notes/commits" }]);
+    expect(shortRef("refs/pull/12/head")).toBe("pull/12/head");
+    expect(shortRef("weird")).toBe("weird");
+  });
+});
+
+describe("line labels", () => {
+  it("labels a commit with the NEAREST ref above it on its line, not the topmost", () => {
+    // The real shape this gets wrong if you take the topmost: a feature branch's tip is
+    // simply the newest commit, sitting on top of dev's own line. Everything below the
+    // dev ref belongs to dev — labelling it `feat/x` would be actively misleading.
+    const l = layoutGraph([
+      c("a", ["b"], "refs/heads/feat/x"),
+      c("b", ["d"], "HEAD -> refs/heads/dev"),
+      c("d", ["e"]),
+      c("e", [], "refs/heads/ancient"),
+    ]);
+    expect(l.rows.map((r) => r.label?.name)).toEqual(["feat/x", "dev", "dev", "ancient"]);
+    expect(l.rows[1].label).toEqual({ name: "dev", from: "ref" });
+  });
+
+  it("labels each line separately, and prefers a branch over a tag", () => {
+    const l = layoutGraph([
+      c("m", ["main1", "side1"]),
+      c("main1", ["base"], "refs/heads/main"),
+      c("side1", ["base"], "tag: refs/tags/v1, refs/remotes/origin/side"),
+      c("base"),
+    ]);
+    expect(l.rows[1].label?.name).toBe("main");
+    // A tag names a moment, a remote branch names a line — so the remote wins.
+    expect(l.rows[2].label).toEqual({ name: "origin/side", from: "ref" });
+    // The merge above carries no ref and opened no line of its own, so it stays unnamed
+    // rather than borrowing a name from below.
+    expect(l.rows[0].label).toBeNull();
+  });
+
+  it("falls back to the merge subject for a branch that was deleted after merging", () => {
+    const l = layoutGraph([
+      c("m", ["main1", "side1"], "HEAD -> refs/heads/dev", "Merge pull request #30 from respeak-io/feat/x"),
+      c("main1", ["base"]),
+      c("side1", ["base"]), // no ref anywhere: the branch is gone
+      c("base"),
+    ]);
+    expect(l.rows[2].label).toEqual({ name: "respeak-io/feat/x", from: "merge" });
+    expect(lineTip(l.rows[2])).toContain("merged in as respeak-io/feat/x");
+    // …and it is attributed, because a subject is a message and not a ref.
+    expect(lineTip(l.rows[2])).toContain("merge's subject");
+  });
+
+  it("leaves a line unnamed rather than inventing one, and says so", () => {
+    const l = layoutGraph([c("a", ["b"]), c("b")]);
+    expect(l.rows.every((r) => r.label === null)).toBe(true);
+    expect(lineTip(l.rows[0])).toContain("No branch or tag above this commit");
+  });
+
+  it("does not let a tag name the stretch of history below it", () => {
+    const l = layoutGraph([
+      c("a", ["b"], "HEAD -> refs/heads/dev"),
+      c("b", ["d"], "tag: refs/tags/v1.0"),  // a release tag on dev's line
+      c("d"),
+    ]);
+    expect(l.rows.map((r) => r.label?.name)).toEqual(["dev", "dev", "dev"]);
+  });
+
+  it("names a merge's source from a ref BELOW it, never one above", () => {
+    // The trap: `feat/next` is cut from dev above the merge and shares dev's line, so a
+    // "first ref on the line" lookup would report the merge as having taken it in.
+    const l = layoutGraph([
+      c("tip", ["m"], "refs/heads/feat/next"),
+      c("m", ["main1", "side1"], "HEAD -> refs/heads/dev", "Merge pull request #7 from o/hotfix"),
+      c("main1", ["base"]),
+      c("side1", ["base"], "refs/remotes/origin/hotfix"),
+      c("base"),
+    ]);
+    expect(l.rows[1].merged).toEqual(["origin/hotfix"]);
+    expect(l.rows[1].merged).not.toContain("feat/next");
+  });
+
+  it("names what a merge took in — the one thing the drawing can't show", () => {
+    const l = layoutGraph([
+      c("m", ["main1", "side1"], "HEAD -> refs/heads/dev"),
+      c("main1", ["base"]),
+      c("side1", ["base"], "refs/heads/feature"),
+      c("base"),
+    ]);
+    expect(l.rows[0].merged).toEqual(["feature"]);
+    expect(lineTip(l.rows[0])).toBe("On the line leading up to dev · merges feature");
+    // A plain commit has one parent, so it never claims to merge anything.
+    expect(l.rows[1].merged).toEqual([]);
+    expect(lineTip(l.rows[1])).not.toContain("merges");
+  });
+
+  it("names a merged-in line from the merge subject when the branch left no ref", () => {
+    const l = layoutGraph([
+      c("m", ["main1", "side1"], "", "Merge branch 'hotfix/1' into dev"),
+      c("main1", ["base"]),
+      c("side1", ["base"]),
+      c("base"),
+    ]);
+    expect(l.rows[0].merged).toEqual(["hotfix/1"]);
+  });
+});
+
+describe("lineRef / mergeBranchName", () => {
+  it("ranks HEAD over branch over remote, and never names a line after a tag", () => {
+    expect(lineRef(parseRefs("tag: refs/tags/v1, refs/remotes/origin/x, refs/heads/x, HEAD -> refs/heads/dev"))).toBe("dev");
+    expect(lineRef(parseRefs("tag: refs/tags/v1, refs/remotes/origin/x, refs/heads/x"))).toBe("x");
+    expect(lineRef(parseRefs("tag: refs/tags/v1, refs/remotes/origin/x"))).toBe("origin/x");
+    // A tag marks a moment, and a line label propagates downward — "on v0.11.1" for a
+    // stretch of history would read as a lineage it never had.
+    expect(lineRef(parseRefs("tag: refs/tags/v1"))).toBeNull();
+    expect(lineRef([])).toBeNull();
+  });
+
+  it("reads git's and GitHub's merge wordings, and nothing else", () => {
+    expect(mergeBranchName("Merge branch 'feat/x' into dev")).toBe("feat/x");
+    expect(mergeBranchName("Merge branch 'feat/x'")).toBe("feat/x");
+    expect(mergeBranchName("Merge remote-tracking branch 'origin/main' into dev")).toBe("origin/main");
+    expect(mergeBranchName("Merge pull request #30 from respeak-io/dev")).toBe("respeak-io/dev");
+    // Prose names nothing. Guessing a lane name out of it would be worse than blank.
+    expect(mergeBranchName("Merge everything, finally")).toBeNull();
+    expect(mergeBranchName("fix: not a merge at all")).toBeNull();
+  });
+});
+
+describe("shortRel", () => {
+  it("shortens git's own wordings", () => {
+    expect(["3 seconds ago", "12 minutes ago", "17 hours ago", "2 days ago", "3 weeks ago", "5 months ago", "2 years ago"]
+      .map(shortRel)).toEqual(["3s", "12m", "17h", "2d", "3w", "5mo", "2y"]);
+    expect(shortRel("1 day ago")).toBe("1d"); // singular
+    expect(shortRel("1 year, 3 months ago")).toBe("1y"); // leading component wins
+  });
+
+  it("returns anything it doesn't recognise untouched", () => {
+    // %cr's wording belongs to git, and a date we can't parse must still be shown.
+    expect(shortRel("just now")).toBe("just now");
+    expect(shortRel("")).toBe("");
+    expect(shortRel("in the future somehow")).toBe("in the future somehow");
+  });
+});
+
+describe("geometry & colour", () => {
+  it("spaces lanes evenly and sizes the column to the widest row", () => {
+    expect(laneX(0)).toBeLessThan(laneX(1));
+    expect(laneX(2) - laneX(1)).toBe(laneX(1) - laneX(0));
+    expect(graphWidth(1)).toBeLessThan(graphWidth(3));
+    expect(graphWidth(0)).toBeGreaterThan(0); // an empty page still has a column
+  });
+
+  it("cycles colours instead of running out", () => {
+    expect(laneColor(0)).toBe(GRAPH_COLORS[0]);
+    expect(laneColor(GRAPH_COLORS.length)).toBe(GRAPH_COLORS[0]);
+    expect(laneColor(GRAPH_COLORS.length * 3 + 2)).toBe(GRAPH_COLORS[2]);
+  });
+});
+
+describe("refChips", () => {
+  const names = (d: string, max?: number) => refChips(d, max).map((c) => c.label);
+
+  it("collapses a local branch and its remote twin into one chip that says it is pushed", () => {
+    const [chip, ...rest] = refChips("HEAD -> refs/heads/main, refs/remotes/origin/main");
+    expect(chip).toMatchObject({ kind: "head", label: "main", also: ["origin"] });
+    expect(rest).toEqual([]);
+    expect(chipText(chip)).toBe("main (also on origin)");
+    // Several remotes fold into the same chip rather than multiplying it.
+    expect(refChips("refs/heads/x, refs/remotes/origin/x, refs/remotes/fork/x")[0].also).toEqual(["origin", "fork"]);
+  });
+
+  it("keeps a remote that has no local counterpart, prefix and all", () => {
+    // "not checked out here" is the entire difference between the two, so the prefix
+    // has to survive.
+    expect(names("refs/remotes/origin/feat/next")).toEqual(["origin/feat/next"]);
+    expect(names("refs/heads/feat/next, refs/remotes/origin/other")).toEqual(["feat/next", "origin/other"]);
+  });
+
+  it("drops origin/HEAD — a symref that always duplicates another chip", () => {
+    expect(names("HEAD -> refs/heads/main, refs/remotes/origin/main, refs/remotes/origin/HEAD, refs/remotes/origin/dev"))
+      .toEqual(["main", "origin/dev"]);
+  });
+
+  it("orders HEAD, then local, then remote, then tags — whatever order git listed", () => {
+    // Git's own order is not stable across repos (HEAD can come last), and the leftmost
+    // chip is the one that survives a narrow column.
+    expect(names("tag: refs/tags/v2, refs/remotes/origin/next, refs/heads/side, HEAD -> refs/heads/dev", 9))
+      .toEqual(["dev", "side", "origin/next", "v2"]);
+    // And the ordering is what decides who survives the cap: the tag folds, not HEAD.
+    expect(names("tag: refs/tags/v2, refs/remotes/origin/next, refs/heads/side, HEAD -> refs/heads/dev"))
+      .toEqual(["dev", "side", "origin/next", "+1"]);
+  });
+
+  it("folds the tail into a +N chip that names what it hides", () => {
+    const chips = refChips("refs/heads/a, refs/heads/b, refs/heads/c, refs/heads/d, tag: refs/tags/v1", 3);
+    expect(chips.map((c) => c.label)).toEqual(["a", "b", "c", "+2"]);
+    const more = chips[3];
+    expect(more.kind).toBe("more");
+    expect(chipText(more)).toBe("d, v1");
+    // Under the cap, nothing is folded.
+    expect(refChips("refs/heads/a, refs/heads/b", 3).some((c) => c.kind === "more")).toBe(false);
+  });
+
+  it("has nothing to show for an undecorated commit", () => {
+    expect(refChips("")).toEqual([]);
+  });
+});
+
+describe("rowSvg / refChipsHtml", () => {
+  it("draws one path per segment plus the node", () => {
+    const l = layoutGraph([c("m", ["main1", "side1"]), c("main1", ["base"]), c("side1", ["base"]), c("base")]);
+    const svg = rowSvg(l.rows[1]); // above:[0] below:[0] through:[1]
+    expect((svg.match(/<path/g) || []).length).toBe(3);
+    expect((svg.match(/<circle/g) || []).length).toBe(1);
+    // A vertical segment stays vertical; only a lane change curves.
+    expect(svg).toContain(`M${laneX(1)},0V26`);
+    expect(rowSvg(l.rows[0])).toContain("C"); // the merge's fork does curve
+  });
+
+  it("draws each row only as wide as its OWN lanes", () => {
+    // The point of the per-row span: in a page whose widest row uses 3 lanes, a 1-lane
+    // row must not be padded out to 3 — the chips beside it would sit past empty space.
+    const l = layoutGraph([
+      c("m", ["a1", "b1"]), c("a1", ["base"]), c("b1", ["base"]), c("base"), c("older"),
+    ]);
+    expect(l.lanes).toBe(2);
+    // `base` is 2 wide despite its node being in lane 0: the two lines converging into
+    // it arrive from lane 1, and a narrower SVG would clip that curve.
+    expect(l.rows.map((r) => r.span)).toEqual([2, 2, 2, 2, 1]);
+    expect(rowSvg(l.rows[4])).toContain(`width="${graphWidth(1)}"`);
+    expect(rowSvg(l.rows[0])).toContain(`width="${graphWidth(2)}"`);
+    // A lane merely passing through still has to fit, or its line gets clipped.
+    expect(l.rows[1].through.map((t) => t.lane)).toEqual([1]);
+    expect(l.rows[1].span).toBe(2);
+  });
+
+  it("marks the HEAD commit's node differently", () => {
+    const l = layoutGraph([c("a")]);
+    expect(rowSvg(l.rows[0], { head: true })).toContain("ghead");
+    expect(rowSvg(l.rows[0])).not.toContain("ghead");
+  });
+
+  it("escapes a ref name in text and in the title attribute", () => {
+    expect(refChipsHtml([])).toBe("");
+    // A branch name can contain almost anything, and it lands in innerHTML *and* in a
+    // quoted attribute — esc() neutralises the angle bracket, attr() also the quote.
+    const html = refChipsHtml(refChips('refs/heads/<script>, refs/heads/a"b'));
+    expect(html).toContain("&lt;script");
+    expect(html).not.toContain("<script");
+    expect(html).toContain("&quot;");
+    expect(html).not.toContain('title="a"b"');
+  });
+
+  it("marks a pushed branch with a glyph instead of a second chip", () => {
+    const html = refChipsHtml(refChips("refs/heads/main, refs/remotes/origin/main"));
+    expect(html).toContain("⇡");
+    expect(html).toContain('title="main (also on origin)"');
+    // A remote that isn't origin is named, since "pushed where" then matters.
+    expect(refChipsHtml(refChips("refs/heads/x, refs/remotes/fork/x"))).toContain("⇡fork");
+  });
+
+  it("keeps the marker out of the truncating part of the chip", () => {
+    // The name is what ellipsises; the ⇡ must not, or a long branch loses the one thing
+    // the collapse added.
+    const html = refChipsHtml(refChips("refs/heads/a-very-long-branch-name-indeed, refs/remotes/origin/a-very-long-branch-name-indeed"));
+    expect(html).toContain('<span class="gn">a-very-long-branch-name-indeed</span>');
+    expect(html.indexOf('class="gr"')).toBeGreaterThan(html.indexOf('class="gn"'));
+  });
+});


### PR DESCRIPTION
Right-click a project → **`Commit graph…`** for its lanes, merges, branch/tag labels and commits. Reachable from the context menu and nowhere else — history is a "go and look" surface, not a figure the cockpit should carry, and the row is dropped when the folder isn't a repo.

## The one invariant: never read a whole history

Nothing in either new module runs until that row is clicked, so app start and `renderAll()` are untouched. The panel then reads **one page** (`git log --skip=N -n LIMIT+1`) and asks for the next only when the reader scrolls near the end of what it has — a 300k-commit monorepo costs the same first paint as a week-old repo. `more` is the `+1` observed, never a count.

Two commands, both in `git.rs`:

| | |
| --- | --- |
| `git_graph(workdir, skip, limit, scope)` | one page of commits: sha, parents, subject, author, dates, `%D` decoration |
| `git_commit_message(workdir, sha)` | one commit's whole message, on demand |

The second is separate on purpose: the body was a `%b` field on *every* commit once, which forced a length cap so 60 of them wouldn't cross IPC as half a megabyte of JSON — and the cap then truncated the one message somebody had opened to read. It refuses anything that isn't a hex object name, since the sha goes to git as a revision argument where a leading dash would be read as an option.

## What's tested, and what isn't

`graph.ts` is pure and tested (**37 vitest cases**): lane assignment, lane naming, ref chips, geometry, the row SVG. `graphview.ts` owns the dialog, the IPC and the scroll and is untested by design, like the app's other DOM-owning modules. Rust side: 3 new tests covering paging, merge parents, awkward subjects (tabs survive the `\x1e`/NUL framing), scope, and the message command including its argument guard.

**Totals: 405 vitest, 85 cargo, clippy clean, no import cycles.**

## The parts that were wrong before they were right

Every rule below came out of running it against this repo's own history:

- **A row's lane label is the nearest ref *above* it, not the line's first.** A feature branch's tip is often simply the newest commit, sitting on top of `dev`'s line — "first ref on the line" then labelled half of dev's history with a branch cut from it.
- **A tag never names a line.** Labels propagate downward, so `v0.11.1` claimed a stretch of history as a lineage that never existed.
- **What a merge took in is read from a ref *below* it**, falling back to the merge subject — the last place a merged-and-deleted branch's name survives, and attributed as a subject rather than stated as a ref.
- **The subject is never the column that yields.** An `fr` track gives up space before any fixed one, so a rigid left block made the *message* vanish in a narrow window. The collapse ladder now shortens the date, then drops the sha, then the author.
- **`gc-` was already the ref-chip prefix**, so naming the overlay's header `.gc-head` gave every HEAD chip a header's `padding: 9px 13px` — a chip you could see was wrong but not say why. The overlay is `gco-*` now.

## Reviewing it

Open it on a repo with merges and several branches. The lanes must be unbroken row to row (a break means `.grow`'s height and `ROW_H` disagree), hovering a node must name the branch that lane leads up to, and scrolling to the bottom must append a page whose lanes continue across the seam. `RELEASE.md` gained click-through items for the lane wording, the chips, the collapse order, the Esc layering and the full message — none of which has automated cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)