### PR TITLE
The sidebar notices a branch switch or a new worktree as it happens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Mac has the same symlink — but it is one both legs will find at once.
 
 **Package manager: `pnpm`** for this repo (there's a `pnpm-lock.yaml`; both CI workflows use `pnpm install --frozen-lockfile`, and `packageManager` in `package.json` pins the version for corepack/CI). Use pnpm here, not npm. Windows code-signing / release-signing setup lives in `src-tauri/SIGNING.md`.
 
-Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **392 vitest + cargo (87 on macOS, 84 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
+Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **408 vitest + cargo (89 on macOS, 86 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
 
 **vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which nine those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
 
@@ -245,13 +245,13 @@ Four smaller P4 affordances, all in the frontend:
 
 | Module | Lines | What |
 | --- | --- | --- |
-| `lib.rs` | 450 | `run()`, `AppState`/`Session`, the tray mirror, the panic hook, `write_debug_file`/`log_frontend`, `confirm_quit`, and the `invoke_handler!` list |
+| `lib.rs` | 456 | `run()`, `AppState`/`Session`, the tray mirror, the panic hook, `write_debug_file`/`log_frontend`, `confirm_quit`, and the `invoke_handler!` list |
 | `tasks.rs` | 2,399 | runnable discovery — see Runnables above |
-| `git.rs` | 1,683 | worktrees, branches, the working-set diff, the toolbar's fetch/pull/push, commit info |
+| `git.rs` | 1,877 | worktrees, branches, the working-set diff, the toolbar's fetch/pull/push, commit info |
 | `usage.rs` | 1,286 | transcripts (incl. History's whole-machine scan) + the token ledger — everything read out of `~/.claude` |
 | `telemetry.rs` | 857 | `write_instrument_settings`, `run_telemetry_server`, `resolve_permission` |
 | `platform.rs` | 743 | OS leaves (top half, incl. `norm_path`/`physical_cwd`) + OS integrations (bottom half) |
-| `pty.rs` | 705 | the four launch engines, `stream_pty_session`, the PTY lifecycle |
+| `pty.rs` | 803 | the four launch engines, `stream_pty_session`, the PTY lifecycle |
 | `external.rs` | 339 | the `~/.claude/sessions` registry, `ProcTable`, terminal focus |
 | `icons.rs` | 184 | project favicon/logo probing |
 | `testutil.rs` | 50 | `git`, `scratch_dir`, `cfg(test)` only |
@@ -263,19 +263,19 @@ Four conventions hold across them:
 - **`platform.rs`'s first half imports nothing from the crate.** That is exactly what lets every other module depend on it; the second half (the OS integrations) may, since `set_caffeinate` takes `State<AppState>`. **Don't let the first half grow a crate dependency.**
 - **A cfg-gated helper with a single consumer module belongs to *that* module**, not to `platform.rs` — `apply_utf8_locale` and `interactive_shell` are `pty.rs`'s (`apply_utf8_locale` takes a `portable_pty::CommandBuilder`, and the leaf layer must not import `portable_pty`), `same_path` is `git.rs`'s.
 
-`AppState` holds the telemetry `port`, `sessions: HashMap<session_id, Session>` (each = PTY master + writer + child killer), `owned_pids` (see External sessions), the held-open `pending` permission requests, and `caffeinate`.
+`AppState` holds the telemetry `port`, `sessions: HashMap<session_id, Session>` (each = PTY master + writer + child killer), `owned_pids` (see External sessions), `io_samples` (the previous disk-I/O reading per pid, which is what turns the kernel's lifetime byte counters into the inspector's rate), the held-open `pending` permission requests, and `caffeinate`.
 
 - **PTY** via `portable-pty`. `spawn_claude` opens a PTY, spawns claude, and (via the shared `stream_pty_session` helper) starts two threads: a reader that base64-encodes output into `pty-output` events, and a reaper that removes the session and emits `pty-exit`. `write_pty` / `resize_pty` / `kill_session` operate by session_id. `spawn_shell` reuses the same path to run a plain login shell (no Claude, no instrumentation) in an embedded pane — the `❯ Terminal` button opens one when the launch engine is embedded (else it opens an external terminal via `open_terminal_here`). Shell panes carry `kind:"shell"` on the frontend `Sess` and skip telemetry/cost; `spawn_task` is the third entry point (see Runnables above).
 - **Telemetry server** (`run_telemetry_server`) forwards `/hook` and `/statusline` POSTs as one `telemetry` event each; `/permission` is the blocking path described above.
 - Commands are registered in the `invoke_handler![...]` list at the bottom of `run()` — add new `#[tauri::command]` fns there.
 
-## Frontend (`src/`, `index.html`, `src/styles.css`) — 36 modules
+## Frontend (`src/`, `index.html`, `src/styles.css`) — 37 modules
 
-**No framework, and no longer one file.** ~7,800 lines across 36 modules; `main.ts` is 668 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
+**No framework, and no longer one file.** ~8,100 lines across 37 modules; `main.ts` is 686 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (~70 lines — it is the seam map, and belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, and the nine `setInterval`s.
 
-**Tested logic modules** (ten — no DOM, no Tauri, no render imports; these are what the 392 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
+**Tested logic modules** (eleven — no DOM, no Tauri, no render imports; these are what the 408 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
 
 | Module | What |
 | --- | --- |
@@ -289,6 +289,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 | `grouping.ts` | what the sidebar shows and in what order; `urgencyRank`, `needsYou`, `nextAfterClose` |
 | `tasks.ts` | the frontend half of Runnables: `stopRuleBlocked`, `launchWithDeps`, `applyRunner`, `${input:…}` glue |
 | `history.ts` | History's rules: `histProject` (regrafting a row onto a project), `histBusy`, the scope/search predicates, day buckets |
+| `gitwatch.ts` | `gitMutates` — whether a shell command an agent ran is worth re-reading git for |
 
 **Shared**: `state.ts` (the session map, the stage pointer, every persisted preference) and `dom.ts` (`$`, `toast`, the shared scrim, `IS_MAC`/`MOD`/`chord`).
 
@@ -345,6 +346,48 @@ And the things that hold however the files are arranged:
 - **Persistence is all `localStorage`**, ~20 keys prefixed `cc-` (favorites, drag order, colours, icons, engine, font size, sort/grouping, frecency, caffeinate, the `cc-usage` daily cost rollup, the `cc-restore` roster, and the task keys `cc-task-{prefs,pins,hidden,onstop,runner,inputs}` + `cc-trusted`). `grep '"cc-'` for the current set.
 - **Debug console** (🐞 button, bottom-right): an in-app event log + live state via `dlog()`/`dbgSnapshot()`. It flags **unrouted telemetry** (the routing-drift class of bug above) and JS errors, and mirrors a snapshot to `$TMPDIR/cc-launcher/episko-debug.json` (written by the `write_debug_file` command) so an external tool or an LLM agent can read live app state while it runs.
 - **Two-tier logging — live snapshot vs. durable timeline.** The `episko-debug.json` snapshot is a *state-of-now* blob that is overwritten each flush and does **not** survive a crash (the frontend never flushes if the process dies). The durable tier is the backend rolling `episko.log` (+ `panic.log`) in the OS app-log dir (macOS `~/Library/Logs/io.respeak.episko/`), via `tauri-plugin-log` and a panic hook — the only on-disk trace of a panic that unwinds cleanly out of `main` (no crash dump / WER otherwise). Every `dlog()` line tees into it through the `log_frontend` command (tagged `[ui]`), so the UI and backend event streams land in **one time-ordered file**. A `episko.log` that stops without an `exit · clean shutdown` line is itself evidence of an abnormal termination. Use the snapshot for "what is it doing *now*", the rolling log for "why did it *die*".
+
+## Noticing that a checkout moved
+
+Nothing in Episko watches the filesystem — deliberately, for the reason the task
+discovery cache gives (no thread, no crate, no per-project lifecycle). So everything
+about "which branch is this on, and what checkouts exist" is either polled or pushed
+from the hook stream, and the split matters.
+
+**The hook stream is the trigger; git is the authority.** `PostToolUse` carries the
+Bash command verbatim, so a settled tool call is the earliest warning that a session
+moved HEAD or added a worktree. `phase.ts` hands it to the `onSessionTouched` seam
+(main.ts wires it, a test leaves it a no-op), which does two things: queues the
+session's workdir for a working-set re-read, and — if `gitMutates` matches — pokes
+`refreshGitViews` on a 250ms debounce. **`gitMutates` never decides what changed**, only
+whether to look, which is what makes it safe to keep loose: a false positive (`git
+checkout -- file.ts`) costs one re-read that renders nothing, and a false negative (an
+alias, a git call inside a script, an MCP git server) costs at most one poll interval.
+Don't tighten it into a shell parser; the poll below is the backstop, and it is the only
+thing that catches a branch switched in your own terminal.
+
+**Two commands, two costs, and they must not be confused.** `list_worktrees` runs a
+`status --porcelain` per checkout plus a `merge-base` per branch — right for the ⑃
+dialog, far too heavy to poll. `worktree_heads` answers "which checkouts exist and what
+is on each HEAD" from `.git/HEAD` and `.git/worktrees/*/{gitdir,HEAD}` with **no git
+process at all**, which is what lets the sidebar hold a roster (`worktreesByRepo`) and
+notice a worktree an agent created *before* anything runs in it. Its result doubles as
+the change stamp: compare, and only then do the expensive thing. Two traps live in it —
+git's bookkeeping name under `worktrees/` need not match the checkout's folder name (so
+the path comes from `gitdir`), and every path goes through `physical_cwd` for the same
+reason `repo_root_of` does, or one checkout renders as two.
+
+**The dirty poll is stale-driven, not blanket.** `refreshDirtyStates` used to re-read
+every open folder every 5s; it now reads only folders `markWorkdirStale` flagged, plus a
+15s sweep for what no hook can see (your editor, a build, an external session). The tool
+allowlist behind it is a list of *readers* — anything not on it marks the folder — so a
+tool added to Claude Code later defaults to wrong-but-cheap rather than to silently
+missing writes. `git_diffstat` itself is one `status --porcelain=v2 --branch` (which
+carries the upstream and ahead/behind that `upstream_state` cost two more processes),
+with the `--numstat` walk skipped entirely on a clean tree.
+
+Everything lands through `refreshGitViews` → `renderAll()`, so the sidebar, the header's
+branch chip and the open ⑃ dialog cannot disagree about what is checked out where.
 
 ## Four launch engines, one telemetry path
 
@@ -450,7 +493,7 @@ the `palette`/`palui` split, and what makes the rules testable.
 
 ## Notes on scope & doc drift
 
-macOS-first assumptions remain in the window/terminal layer: `osascript`, `open -a`, external-terminal engines, per-session CPU/RAM via `ps`, terminal-window focus. Windows has a working embedded-only port (PowerShell/`curl.exe` hook variants behind `#[cfg(windows)]`, cross-platform external-session listing); Linux is unported but the non-`ps` paths are written to be OS-agnostic.
+macOS-first assumptions remain in the window/terminal layer: `osascript`, `open -a`, external-terminal engines, terminal-window focus. Windows has a working embedded-only port (PowerShell/`curl.exe` hook variants behind `#[cfg(windows)]`, cross-platform external-session listing); Linux is unported but the non-`ps` paths are written to be OS-agnostic. Per-session resources are **no longer** one of the macOS-bound bits: `session_resources` reports disk I/O through `sysinfo` (one syscall, every OS) rather than shelling out to `ps`, so `ps_one` is now reached only from the macOS-only terminal-focus path.
 
 **`SPIKE.md` is a historical record and is not maintained.** It describes the Phase-0 spike — single-session, "observe-only" permissions, one file per side — and is kept because it is the record of where this started, not because it is true. It carries a banner saying so. Don't consult it for how the app works today, and don't edit it to match; `README.md` is current.
 

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -103,6 +103,99 @@ pub(crate) fn create_worktree(repo_dir: String, branch: String, base: Option<Str
     Err(String::from_utf8_lossy(&add.stderr).trim().to_string())
 }
 
+/// One checkout as seen by `worktree_heads` — the cheap, spawn-free half of
+/// `list_worktrees`. Deliberately carries only what can be answered from files.
+#[derive(serde::Serialize, Debug, PartialEq)]
+pub(crate) struct WorktreeHead {
+    /// The checkout directory, in the same physical spelling `repo_root_of` uses.
+    path: String,
+    /// Branch name, or "(detached)" when HEAD holds a raw sha.
+    branch: String,
+    is_main: bool,
+    /// The checkout dir is still on disk. A hand-deleted folder stays registered under
+    /// `.git/worktrees` until pruned, so this mirrors `Worktree::exists`.
+    exists: bool,
+}
+
+/// Read a `HEAD` file into a branch label without spawning git.
+/// `ref: refs/heads/foo` → "foo"; a bare sha → "(detached)".
+fn head_branch(head_file: &std::path::Path) -> Option<String> {
+    let text = std::fs::read_to_string(head_file).ok()?;
+    let t = text.trim();
+    if t.is_empty() {
+        return None;
+    }
+    Some(match t.strip_prefix("ref:") {
+        Some(r) => r.trim().strip_prefix("refs/heads/").unwrap_or(r.trim()).to_string(),
+        None => "(detached)".to_string(),
+    })
+}
+
+/// Every checkout of `dir`'s repo and the branch each has on HEAD — read straight off
+/// the filesystem, with **no `git` process at all**.
+///
+/// This is the cheap counterpart to `list_worktrees`, and it exists because the sidebar
+/// wants to notice a new worktree *continuously*, not when a dialog is opened.
+/// `list_worktrees` costs a `status --porcelain` per checkout plus a `merge-base` per
+/// branch — right for a picker, far too heavy to poll across every open project. The
+/// facts here come from three files per worktree:
+///
+/// ```text
+/// <root>/.git/HEAD                      → the main worktree's branch
+/// <root>/.git/worktrees/<n>/gitdir      → …/<checkout>/.git, whose parent is the checkout
+/// <root>/.git/worktrees/<n>/HEAD        → that checkout's branch
+/// ```
+///
+/// Two things this must not get wrong. `<n>` is git's bookkeeping name and does **not**
+/// have to match the checkout's folder name (`worktrees/board` can own `…/feat-board`),
+/// so the path comes from `gitdir` and never from the directory name. And every path is
+/// run through `physical_cwd`, for the reason spelled out on `repo_root_of`: git writes
+/// an already-resolved path into `gitdir`, so an unresolved one derived here would be a
+/// *second spelling of the same checkout*, and the sidebar groups by exact string
+/// equality — one worktree would render as two.
+///
+/// The result doubles as a change stamp: the caller compares it to its previous copy and
+/// only reaches for the expensive `list_worktrees` when it actually moved.
+#[tauri::command(async)]
+pub(crate) fn worktree_heads(dir: String) -> Vec<WorktreeHead> {
+    // repo_root_of already resolves both `.git` shapes (dir and `gitdir:` file) from a
+    // physical starting point, so asking it is what keeps this in step with every other
+    // root in the app — including when called from inside a linked worktree.
+    let Some(root) = repo_root_of(&dir) else {
+        return vec![];
+    };
+    let common = std::path::Path::new(&root).join(".git");
+    let mut out: Vec<WorktreeHead> = Vec::new();
+    if let Some(branch) = head_branch(&common.join("HEAD")) {
+        out.push(WorktreeHead {
+            path: root.clone(),
+            branch,
+            is_main: true,
+            exists: std::path::Path::new(&root).is_dir(),
+        });
+    }
+    let Ok(entries) = std::fs::read_dir(common.join("worktrees")) else {
+        return out; // a repo with no linked worktrees has no such dir
+    };
+    for e in entries.flatten() {
+        let bk = e.path();
+        // `gitdir` points at the checkout's `.git` file; its parent is the checkout.
+        let Ok(gd) = std::fs::read_to_string(bk.join("gitdir")) else { continue };
+        let Some(checkout) = std::path::Path::new(gd.trim()).parent() else { continue };
+        let Some(branch) = head_branch(&bk.join("HEAD")) else { continue };
+        let exists = checkout.is_dir();
+        out.push(WorktreeHead {
+            path: norm_path(&physical_cwd(&checkout.to_string_lossy())),
+            branch,
+            is_main: false,
+            exists,
+        });
+    }
+    // Stable order so the caller's change comparison isn't fooled by readdir order.
+    out.sort_by(|a, b| (!a.is_main, &a.path).cmp(&(!b.is_main, &b.path)));
+    out
+}
+
 #[derive(serde::Serialize, Debug)]
 pub(crate) struct Worktree {
     path: String,
@@ -863,32 +956,66 @@ pub(crate) fn git_diffstat(workdir: String) -> Option<DiffStat> {
             .args(args)
             .output()
     };
-    let ns = git(&["--no-optional-locks", "diff", "--numstat", "HEAD"]).ok()?;
-    if !ns.status.success() {
-        return None; // not a repo, or an unborn HEAD (no commits)
+    // ONE spawn for everything except the line counts. `--porcelain=v2 --branch` is
+    // git's machine format: it reports the dirty entries *and* the upstream name and
+    // ahead/behind in a single walk, which is what `upstream_state`'s two extra
+    // processes used to cost. This is polled per folder on a timer (see
+    // `refreshDirtyStates`), so the spawn count here is the difference between
+    // "background" and "a git every few hundred milliseconds".
+    let st = git(&["--no-optional-locks", "status", "--porcelain=v2", "--branch"]).ok()?;
+    if !st.status.success() {
+        return None; // not a repo
     }
-    let (mut added, mut removed, mut files) = (0u32, 0u32, 0u32);
-    for line in String::from_utf8_lossy(&ns.stdout).lines() {
-        let mut it = line.split('\t');
-        let a = it.next().unwrap_or("");
-        let d = it.next().unwrap_or("");
-        files += 1;
-        added += a.parse::<u32>().unwrap_or(0); // "-" (binary) parses to 0
-        removed += d.parse::<u32>().unwrap_or(0);
-    }
+    let text = String::from_utf8_lossy(&st.stdout);
     let (mut untracked, mut dirty) = (0u32, 0u32);
-    if let Ok(st) = git(&["--no-optional-locks", "status", "--porcelain"]) {
-        for line in String::from_utf8_lossy(&st.stdout).lines() {
-            if line.is_empty() {
-                continue;
-            }
-            dirty += 1;
-            if line.starts_with("??") {
+    let (mut upstream, mut ahead, mut behind) = (None, 0u32, 0u32);
+    let mut unborn = false;
+    for line in text.lines() {
+        match line.as_bytes().first() {
+            // Tracked entries: `1` changed, `2` renamed/copied, `u` unmerged.
+            Some(b'1') | Some(b'2') | Some(b'u') => dirty += 1,
+            Some(b'?') => {
+                dirty += 1;
                 untracked += 1;
             }
+            Some(b'#') => {
+                if let Some(v) = line.strip_prefix("# branch.upstream ") {
+                    upstream = Some(v.trim().to_string());
+                } else if let Some(v) = line.strip_prefix("# branch.ab ") {
+                    // "+<ahead> -<behind>", present only when an upstream is set.
+                    let mut it = v.split_whitespace();
+                    ahead = it.next().and_then(|s| s.trim_start_matches('+').parse().ok()).unwrap_or(0);
+                    behind = it.next().and_then(|s| s.trim_start_matches('-').parse().ok()).unwrap_or(0);
+                } else if line.starts_with("# branch.oid (initial)") {
+                    unborn = true;
+                }
+            }
+            _ => {}
         }
     }
-    let (upstream, ahead, behind) = upstream_state(&workdir);
+    // An unborn HEAD has nothing to diff against; None, as before, so the UI shows no
+    // working-set card rather than a card claiming zero changes in a repo full of them.
+    if unborn {
+        return None;
+    }
+    // The expensive half — a second walk, purely for +/- line counts — is skipped
+    // entirely when the tree is clean. That is the steady state for most open folders,
+    // so in practice this halves the polling cost rather than shaving it.
+    let (mut added, mut removed, mut files) = (0u32, 0u32, 0u32);
+    if dirty > 0 {
+        let ns = git(&["--no-optional-locks", "diff", "--numstat", "HEAD"]).ok()?;
+        if !ns.status.success() {
+            return None;
+        }
+        for line in String::from_utf8_lossy(&ns.stdout).lines() {
+            let mut it = line.split('\t');
+            let a = it.next().unwrap_or("");
+            let d = it.next().unwrap_or("");
+            files += 1;
+            added += a.parse::<u32>().unwrap_or(0); // "-" (binary) parses to 0
+            removed += d.parse::<u32>().unwrap_or(0);
+        }
+    }
     Some(DiffStat { added, removed, files, untracked, dirty, upstream, ahead, behind })
 }
 
@@ -1249,6 +1376,57 @@ mod tests {
         git(dir, &["-c", "user.email=t@example.com", "-c", "user.name=T", "-c", "commit.gpgsign=false", "commit", "-q", "--allow-empty", "-m", msg]);
     }
 
+    /// `worktree_heads` is the sidebar's polling path, so it has to agree with
+    /// `list_worktrees` while spawning no git at all. Four things are load-bearing: it
+    /// must answer identically from a *linked* checkout (whose `.git` is a file, a
+    /// different branch of `repo_root_of`), it must take the path from `gitdir` rather
+    /// than the bookkeeping folder name, it must track a branch switch — that is the
+    /// whole reason it exists — and it must label a detached HEAD rather than drop the
+    /// row, or a rebasing worktree would vanish from the sidebar mid-operation.
+    #[test]
+    fn worktree_heads_reads_every_checkout_without_spawning_git() {
+        let dir = scratch_dir();
+        git(&dir, &["init", "-q", "-b", "main"]);
+        commit(&dir, "init");
+        let repo = dir.to_str().unwrap().to_string();
+        let made = create_worktree(repo.clone(), "feat/thing".into(), None).expect("worktree created");
+
+        let heads = worktree_heads(repo.clone());
+        assert_eq!(heads.len(), 2, "main + the linked checkout: {heads:?}");
+        let main = heads.iter().find(|w| w.is_main).expect("a main entry");
+        assert_eq!(main.branch, "main");
+        assert_eq!(Some(main.path.as_str()), repo_root_of(&repo).as_deref(),
+            "main's path is the checkout root, in the same spelling every other root uses");
+        let linked = heads.iter().find(|w| !w.is_main).expect("a linked entry");
+        assert_eq!(linked.branch, "feat/thing", "a slashed branch keeps its slash");
+        // The linked entry is the CHECKOUT, not the repo root `repo_root_of` would map
+        // it back to — and its folder is `feat-thing` while git's bookkeeping name is
+        // whatever it chose, so this also pins that the path came out of `gitdir`.
+        assert_eq!(linked.path, norm_path(&physical_cwd(&made)));
+        assert!(linked.path.ends_with("feat-thing"), "the checkout dir, not the repo root: {}", linked.path);
+        assert!(linked.exists);
+
+        // Asked from *inside* the linked worktree the answer must be identical. That
+        // dir's `.git` is a file, so this is a different resolution path reaching the
+        // same repo — the asymmetry that produced two spellings of one root before.
+        assert_eq!(worktree_heads(made.clone()), heads, "same repo, same answer from any checkout");
+
+        // The point of the whole thing: a branch switch is visible with no git spawn.
+        git(Path::new(&made), &["checkout", "-q", "-b", "second"]);
+        assert_eq!(worktree_heads(repo.clone()).iter().find(|w| !w.is_main).unwrap().branch, "second");
+
+        git(Path::new(&made), &["checkout", "-q", "--detach"]);
+        assert_eq!(worktree_heads(repo.clone()).iter().find(|w| !w.is_main).unwrap().branch, "(detached)");
+
+        // A directory that is not a repo answers empty rather than erroring.
+        let plain = scratch_dir();
+        assert!(worktree_heads(plain.to_str().unwrap().to_string()).is_empty());
+
+        let _ = std::fs::remove_dir_all(wt_root(&dir));
+        let _ = std::fs::remove_dir_all(&plain);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// The inspector's working-set strip ("+2 −1 · 1 file · 1 new") and the ahead/
     /// behind pair beside it. Two things it must not do: count an untracked file's
     /// lines as insertions (they're a separate, differently-worded number), and
@@ -1292,6 +1470,22 @@ mod tests {
         // Detached HEAD tracks nothing — it must not inherit the branch it left.
         git(&dir, &["checkout", "-q", "--detach"]);
         assert_eq!(upstream_state(&path), (None, 0, 0));
+        // …and the same through `git_diffstat`, which reads the gap out of porcelain=v2
+        // rather than asking separately: detached prints no `# branch.upstream` and no
+        // `# branch.ab`, so this is the parser's absent-field path, not its zero path.
+        let d = git_diffstat(path.clone()).expect("a detached checkout still has a working set");
+        assert_eq!(d.upstream, None);
+        assert_eq!((d.ahead, d.behind), (0, 0));
+        assert_eq!((d.added, d.removed, d.untracked), (2, 1, 1), "detaching changed no files");
+
+        // A clean tree takes the path that skips `--numstat` entirely, so it needs its
+        // own assertion — every count zero, and still Some rather than None.
+        git(&dir, &["checkout", "-q", "main"]);
+        git(&dir, &["checkout", "-q", "--", "a.txt"]);
+        std::fs::remove_file(dir.join("new.txt")).unwrap();
+        let clean = git_diffstat(path.clone()).expect("clean is still a diffstat");
+        assert_eq!((clean.added, clean.removed, clean.files, clean.untracked, clean.dirty), (0, 0, 0, 0, 0));
+        assert_eq!(clean.upstream.as_deref(), Some("origin/main"), "clean does not lose the upstream");
 
         let _ = std::fs::remove_dir_all(&dir);
         let _ = std::fs::remove_dir_all(&remote);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -53,6 +53,10 @@ pub(crate) struct AppState {
     /// as "external" — robust to the session id changing under /resume or /clear
     /// (which rewrites `~/.claude/sessions/<pid>.json` with the new id).
     owned_pids: Mutex<HashSet<u32>>,
+    /// Last disk-I/O reading per owned pid: (total_read, total_written, when).
+    /// `session_resources` differences against this to turn the kernel's lifetime byte
+    /// counters into a rate — see there for why sysinfo's own deltas aren't used.
+    io_samples: Mutex<HashMap<u32, (u64, u64, std::time::Instant)>>,
     /// Held-open PermissionRequest HTTP requests, keyed by an id we assign.
     /// Answered later by the `resolve_permission` command.
     pending: Mutex<HashMap<String, tiny_http::Request>>,
@@ -239,6 +243,7 @@ pub fn run() {
                 port,
                 sessions: Mutex::new(HashMap::new()),
                 owned_pids: Mutex::new(HashSet::new()),
+                io_samples: Mutex::new(HashMap::new()),
                 pending: Mutex::new(HashMap::new()),
                 next_perm: std::sync::atomic::AtomicU64::new(1),
                 caffeinate: Mutex::new(None),
@@ -398,6 +403,7 @@ pub fn run() {
             platform::set_caffeinate,
             telemetry::resolve_permission,
             git::list_worktrees,
+            git::worktree_heads,
             git::remove_worktree,
             git::git_branch_list,
             git::delete_branch,

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -198,15 +198,22 @@ pub(crate) fn sh_quote(s: &str) -> String {
 }
 
 /// One `ps -o <fields>=` line for a single pid (trimmed), or None if the process
-/// is gone / no output. Windows has no `ps`; the remaining `ps` consumers
-/// (per-session CPU/RAM, terminal-window focus) are macOS-only for now, so this
-/// is None there. External-session listing does NOT go through here — it uses
-/// the cross-platform `ProcTable` (in `lib.rs`, and `external.rs` once split).
-#[cfg(windows)]
-pub(crate) fn ps_one(_pid: u32, _fields: &str) -> Option<String> {
-    None
-}
-
+/// is gone / no output.
+///
+/// **Not compiled on Windows at all**, and that is now load-bearing rather than tidy.
+/// There used to be a `cfg(windows)` stub returning None, because `session_resources`
+/// called this on every platform for per-session CPU/RAM; that reader now measures disk
+/// I/O through `sysinfo` instead, which leaves `focus_external_session` — itself
+/// macOS-only — as the sole caller. A stub with no callers is `dead_code`, which is a
+/// **CI failure** under `-D warnings`, and one only the Windows leg can see.
+///
+/// The general shape of that trap: removing the last cross-platform caller of a
+/// cfg-gated helper breaks the *other* platform's build, invisibly from this one. The
+/// cfg flip in CLAUDE.md is what catches it; "I added no cfg arms" is not a reason to
+/// skip it, because deleting a call is enough.
+///
+/// External-session *listing* does NOT go through here — it uses the cross-platform
+/// `ProcTable` in `external.rs`.
 #[cfg(not(windows))]
 pub(crate) fn ps_one(pid: u32, fields: &str) -> Option<String> {
     let out = sys_command("ps")

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -35,7 +35,7 @@ use tauri::{AppHandle, Emitter, Manager, State};
 
 #[cfg(not(windows))]
 use crate::platform::sh_quote;
-use crate::platform::{augmented_path, ps_one, resolve_claude, sys_command};
+use crate::platform::{augmented_path, resolve_claude, sys_command};
 use crate::tasks;
 use crate::telemetry::write_instrument_settings;
 use crate::{AppState, Session};
@@ -646,31 +646,129 @@ pub(crate) fn kill_session(state: State<AppState>, session_id: String) -> Result
 
 #[derive(serde::Serialize)]
 pub(crate) struct Resources {
-    /// %CPU as reported by `ps` (a decaying lifetime average on macOS, so it reads
-    /// as a rough gauge, not an instantaneous sample).
-    cpu: f32,
-    /// Resident set size in MiB.
-    mem_mb: f32,
+    /// Bytes/second read from disk, averaged over the gap since the previous sample.
+    read_bps: f64,
+    /// Bytes/second written to disk, same window.
+    write_bps: f64,
+    /// Lifetime totals for this process, in MiB — the "how much has this session
+    /// actually churned" number a rate alone can't tell you.
+    read_mb: f64,
+    written_mb: f64,
+    /// False on the first sample of a process, when there is no previous reading to
+    /// difference against and the rates are therefore 0 rather than measured. Lets the
+    /// UI show "—" instead of a confident, wrong "0 B/s".
+    primed: bool,
 }
 
-/// Per-session CPU/RAM for the embedded-PTY `claude` process, looked up by the
+/// Per-session **disk I/O** for the embedded-PTY `claude` process, looked up by the
 /// session id's stored pid. Measures the `claude` process itself (not its whole
-/// subtree) — enough for the inspector's "what's this costing my machine" readout.
-/// None for external/shell sessions (no owned pid) or a process that has exited.
+/// subtree). None for external/shell sessions (no owned pid) or a process that has
+/// exited.
+///
+/// I/O rather than CPU/RAM because that is the resource a Claude session actually
+/// spends: it reads your tree and writes files, and a runaway agent shows up as
+/// sustained throughput long before it shows up as CPU. Read via `sysinfo` (macOS:
+/// `proc_pid_rusage` → `ri_diskio_*`) rather than a `ps` child, because `ps` cannot
+/// report I/O at all — and refreshing exactly one pid costs a single syscall, less than
+/// the process spawn it replaces.
+///
+/// Rates are computed here from the **lifetime totals** and our own timestamp, not from
+/// sysinfo's per-refresh deltas: those are relative to the last refresh of that
+/// `System`, and we build a fresh one per call. Differencing totals ourselves makes the
+/// window explicit and survives a missed or irregular poll.
 #[tauri::command(async)]
 pub(crate) fn session_resources(state: State<AppState>, session_id: String) -> Option<Resources> {
+    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
     let pid = state.sessions.lock().unwrap().get(&session_id)?.pid?;
-    let line = ps_one(pid, "%cpu=,rss=")?;
-    let mut it = line.split_whitespace();
-    let cpu: f32 = it.next()?.parse().ok()?;
-    let rss_kb: f32 = it.next()?.parse().ok()?;
-    Some(Resources { cpu, mem_mb: rss_kb / 1024.0 })
+    let spid = Pid::from_u32(pid);
+    let mut sys = System::new();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[spid]),
+        true,
+        ProcessRefreshKind::nothing().with_disk_usage(),
+    );
+    let usage = sys.process(spid)?.disk_usage();
+    let (read, written) = (usage.total_read_bytes, usage.total_written_bytes);
+
+    let now = std::time::Instant::now();
+    let mut samples = state.io_samples.lock().unwrap();
+    // Drop readings for processes we no longer own, so a long-lived app doesn't
+    // accumulate an entry per session it has ever run.
+    {
+        let owned = state.owned_pids.lock().unwrap();
+        samples.retain(|p, _| owned.contains(p));
+    }
+    let prev = samples.insert(pid, (read, written, now));
+
+    let (read_bps, write_bps, primed) = match prev {
+        // saturating_sub: the counters are monotonic, but a pid reused after an exit we
+        // missed would otherwise underflow into a nonsense spike.
+        Some((pr, pw, pt)) => {
+            let secs = now.duration_since(pt).as_secs_f64();
+            if secs > 0.0 {
+                (
+                    read.saturating_sub(pr) as f64 / secs,
+                    written.saturating_sub(pw) as f64 / secs,
+                    true,
+                )
+            } else {
+                (0.0, 0.0, false)
+            }
+        }
+        None => (0.0, 0.0, false),
+    };
+    const MIB: f64 = 1024.0 * 1024.0;
+    Some(Resources {
+        read_bps,
+        write_bps,
+        read_mb: read as f64 / MIB,
+        written_mb: written as f64 / MIB,
+        primed,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// The inspector's I/O readout is only worth showing if the platform actually
+    /// accounts for it. Per-process disk counters are easy to wire up and get back a
+    /// permanent zero — `proc_pid_rusage` on macOS, `/proc/<pid>/io` on Linux, the IO
+    /// counters on Windows all have their own preconditions — and a silently-zero
+    /// counter renders as a confident, permanently-idle gauge rather than as a bug.
+    /// This asserts the counter moves; the rate arithmetic on top is plain division.
+    #[test]
+    fn process_disk_usage_actually_counts_bytes() {
+        use crate::testutil::scratch_dir;
+        use std::io::Write;
+        use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+        let me = Pid::from_u32(std::process::id());
+        let sample = || {
+            let mut sys = System::new();
+            sys.refresh_processes_specifics(
+                ProcessesToUpdate::Some(&[me]),
+                true,
+                ProcessRefreshKind::nothing().with_disk_usage(),
+            );
+            sys.process(me).map(|p| p.disk_usage().total_written_bytes)
+        };
+        let before = sample().expect("our own process is visible to sysinfo");
+
+        // fsync, so the bytes are charged to real disk I/O rather than sitting in the
+        // page cache where the counter would never see them.
+        let dir = scratch_dir();
+        let mut f = std::fs::File::create(dir.join("blob")).unwrap();
+        f.write_all(&vec![7u8; 8 * 1024 * 1024]).unwrap();
+        f.sync_all().unwrap();
+        drop(f);
+
+        let after = sample().expect("still visible");
+        assert!(
+            after > before,
+            "written-bytes counter must move after an 8 MiB fsync'd write (before={before}, after={after})"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     /// `spawn_task` hands `Exec::Shell` to a *login* shell so a task inherits the
     /// PATH and version-manager shims the user's own terminal has. That argument

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -342,6 +342,7 @@ mod tests {
             port,
             sessions: Mutex::new(HashMap::new()),
             owned_pids: Mutex::new(HashSet::new()),
+            io_samples: Mutex::new(HashMap::new()),
             pending: Mutex::new(HashMap::new()),
             next_perm: std::sync::atomic::AtomicU64::new(1),
             caffeinate: Mutex::new(None),

--- a/src/format.ts
+++ b/src/format.ts
@@ -65,6 +65,18 @@ export function fmtDwell(ms: number): string {
   return h > 0 ? `${h}h ${m}m` : `${m}:${String(ss).padStart(2, "0")}`;
 }
 export function fmtLatency(ms: number): string { return ms >= 1000 ? (ms / 1000).toFixed(1) + "s" : Math.round(ms) + "ms"; }
+/// A disk-I/O rate, in the unit a human reads it in. Whole bytes and whole KB — a
+/// fractional B/s is noise — but MB/s keeps one decimal, because that is the range
+/// where the difference between 1.2 and 4.8 is the thing you are looking at.
+export function fmtRate(bps: number): string {
+  if (bps < 1024) return `${Math.round(bps)} B/s`;
+  if (bps < 1024 * 1024) return `${(bps / 1024).toFixed(0)} KB/s`;
+  return `${(bps / (1024 * 1024)).toFixed(1)} MB/s`;
+}
+/// A size already in MiB, promoted to GB once it stops being readable as MB.
+export function fmtMb(mb: number): string {
+  return mb >= 1024 ? `${(mb / 1024).toFixed(1)} GB` : `${mb.toFixed(0)} MB`;
+}
 export function fmtShort(ms: number): string {
   const s = Math.round(ms / 1000);
   return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${s % 60}s`;

--- a/src/gitwatch.ts
+++ b/src/gitwatch.ts
@@ -1,0 +1,33 @@
+// Deciding, from a shell command an agent just ran, whether Episko should go and
+// re-read git state. Pure logic, in its own module so it can be tested — the DOM and
+// PTY halves of main.ts can't be.
+//
+// The contract that makes this safe to keep loose: **this is a trigger, not an
+// authority**. It only decides *when to look*; `git_head` and `worktree_heads` decide
+// what actually changed, and render nothing when the answer is "nothing". So the two
+// error directions cost very different amounts:
+//
+//   false positive — `git checkout -- src/foo.ts` restores a file and moves no branch.
+//     We do one cheap re-read that finds nothing and repaints nothing.
+//   false negative — `git co` (a user alias), `gco` from oh-my-zsh, a git call buried
+//     inside `./scripts/new-wt.sh`, or an MCP git server that never touches Bash.
+//     The 4s poll still catches it; we lose the instant update, not the update.
+//
+// Which is why the list below leans inclusive and doesn't try to be a shell parser.
+
+/// Verbs that can move HEAD or change the set of checkouts.
+const VERBS = "checkout|switch|worktree|branch|merge|rebase|reset|pull|stash";
+
+// Matched anywhere in the string, because `cd sub && git switch x` is entirely normal.
+// The bounded gap between `git` and the verb lets global flags through
+// (`git -C /some/long/path checkout`) without letting the match run away into an
+// unrelated later command.
+const GIT_MUTATES = new RegExp(
+  `\\bgit\\b[\\s\\S]{0,80}?\\b(${VERBS})\\b` +
+  `|\\bgh\\b[\\s\\S]{0,40}?\\bpr\\s+checkout\\b`,
+);
+
+/// True when `cmd` might have moved HEAD or changed the set of worktrees.
+export function gitMutates(cmd: unknown): boolean {
+  return typeof cmd === "string" && GIT_MUTATES.test(cmd);
+}

--- a/src/grouping.ts
+++ b/src/grouping.ts
@@ -16,6 +16,7 @@ import { basename } from "./format";
 import type { ExtSession, Restorable, Sess } from "./types";
 import {
   accentFor, dormants, externals, FAVORITES, projOrder, sessions, sortMode, wtGroup,
+  worktreesByRepo,
 } from "./state";
 import { taskPrefs } from "./tasks";
 
@@ -29,7 +30,13 @@ export interface ProjGroup { name: string; path: string; accent: string; session
 // attention sort still decides which worktree floats up. The repo-root checkout
 // (worktree === null) is the "main" cluster; its label is the live branch.
 export interface WtCluster { key: string; branch: string; isMain: boolean; sessions: Sess[]; externals: ExtSession[] }
-export function clusterByWorktree(p: ProjGroup): WtCluster[] {
+// `withEmpty` folds in the roster's session-less checkouts, so a worktree an agent just
+// created is visible before anything runs in it. Off by default because only the
+// sidebar body wants them: `splitByWorktree` must not promote an empty checkout to a
+// top-level project group, which would be a lot of chrome for a folder with nothing in
+// it. Roster clusters land after the session-bearing ones (`order` is append-only),
+// which keeps "running now" above "available".
+export function clusterByWorktree(p: ProjGroup, withEmpty = false): WtCluster[] {
   const by = new Map<string, WtCluster>();
   const order: WtCluster[] = [];
   const bucket = (key: string, branch: string): WtCluster => {
@@ -40,6 +47,23 @@ export function clusterByWorktree(p: ProjGroup): WtCluster[] {
   };
   for (const s of p.sessions) bucket(s.workdir || p.path, s.branch || s.worktree || "").sessions.push(s);
   for (const e of p.externals) bucket(e.cwd || p.path, e.branch || "").externals.push(e);
+  if (withEmpty) {
+    const roster = worktreesByRepo.get(p.path) ?? [];
+    // Only fold the roster in when this group really is the repo — i.e. the repo's main
+    // checkout IS p.path. A project pinned *at* a linked worktree resolves to the same
+    // repo, and without this guard that group would suddenly sprout a row for the main
+    // checkout and every sibling worktree, silently redefining what the group means.
+    if (roster.some((w) => w.is_main && w.path === p.path)) {
+      for (const w of roster) {
+        // A registered-but-deleted checkout is git bookkeeping, not a place to work —
+        // the ⑃ dialog is where you prune those, so the sidebar stays quiet about them.
+        if (!w.exists) continue;
+        const c = bucket(w.path, w.branch);
+        // The roster read HEAD directly, so it wins over a session's cached label.
+        c.branch = w.branch || c.branch;
+      }
+    }
+  }
   // Label clusters that never carried a branch: the repo-root checkout is "main",
   // any other bare dir falls back to its folder name.
   for (const c of order) if (!c.branch) c.branch = c.isMain ? "main" : basename(c.key);

--- a/src/inspectorview.ts
+++ b/src/inspectorview.ts
@@ -12,7 +12,7 @@
 // git operation in flight is only ever read to grey them out. main.ts's runGit
 // sets it through setGitBusy — the state.ts convention, a live binding to read.
 
-import { esc, fmtDur, fmtDwell, fmtLatency, sparkline } from "./format";
+import { esc, fmtDur, fmtDwell, fmtLatency, fmtMb, fmtRate, sparkline } from "./format";
 import type { DiffHunk } from "./diff";
 import { apiErrText, isAgent, statusKey, type DiffStat, type Risk, type Sess } from "./types";
 import { sessions } from "./state";
@@ -188,10 +188,28 @@ export function timelineHtml(s: Sess): string {
   }).join("");
   return `<div><div class="lab" style="margin-bottom:6px">Activity · by tool</div><div class="tl2">${rows}</div></div>`;
 }
+// Disk I/O for the session's `claude` process. Replaced cpu/mem, which measured the one
+// thing a Claude session is never short of: this is an I/O-bound workload — it reads
+// your tree and writes files — and a runaway agent shows up as sustained throughput
+// long before it shows up as CPU.
+//
+// The bar is log-scaled against a 32 MB/s reference rather than linear: real rates span
+// idle-KB/s to burst-MB/s, and a linear bar would sit at zero for everything short of a
+// pathological write storm, which is precisely the case it needs to show.
+const IO_REF_BPS = 32 * 1024 * 1024;
+function ioPct(bps: number): number {
+  if (bps <= 0) return 0;
+  return Math.max(2, Math.min(100, (Math.log10(bps / 1024 + 1) / Math.log10(IO_REF_BPS / 1024 + 1)) * 100));
+}
 export function resHtml(s: Sess): string {
   const r = s.res!;
-  const cpu = Math.min(100, r.cpu), memPct = Math.min(100, (r.memMb / 2048) * 100);
-  return `<div class="res">
-    <div class="rr"><span class="rk">cpu</span><span class="rbar ${mc(cpu)}"><i style="width:${cpu}%"></i></span><span class="rv">${r.cpu.toFixed(0)}%</span></div>
-    <div class="rr"><span class="rk">mem</span><span class="rbar ${mc(memPct)}"><i style="width:${memPct}%"></i></span><span class="rv">${r.memMb.toFixed(0)} MB</span></div></div>`;
+  // Before the second sample there is no window to average over, so the rate is unknown
+  // rather than zero — say so instead of showing a confident "0 B/s".
+  const rd = r.primed ? fmtRate(r.readBps) : "—";
+  const wr = r.primed ? fmtRate(r.writeBps) : "—";
+  const rp = r.primed ? ioPct(r.readBps) : 0, wp = r.primed ? ioPct(r.writeBps) : 0;
+  return `<div class="res" title="Disk I/O for this session's claude process · ${fmtMb(r.readMb)} read, ${fmtMb(r.writtenMb)} written since it started">
+    <div class="rr"><span class="rk">read</span><span class="rbar ${mc(rp)}"><i style="width:${rp}%"></i></span><span class="rv">${rd}</span></div>
+    <div class="rr"><span class="rk">write</span><span class="rbar ${mc(wp)}"><i style="width:${wp}%"></i></span><span class="rv">${wr}</span></div>
+    <div class="rr rtot"><span class="rk">total</span><span class="rvtot">${fmtMb(r.readMb)} read · ${fmtMb(r.writtenMb)} written</span></div></div>`;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ import {
 } from "./actions";
 import {
   activeCwd, activeProjectCtx, closeSession, handToTerminal, launch, launchShell,
-  launchTask, openPlainTerminal, refreshBranches, refreshSessionStats, renderHeader,
+  launchTask, noteGitCommand, openPlainTerminal, refreshGitViews, refreshSessionStats, renderHeader,
   requestLaunch, runGit, scheduleDismiss, setActive, setPanesRenderAll,
   syncStageButtons,
 } from "./panes";
@@ -68,12 +68,13 @@ import {
 import { dwellText } from "./inspectorview";
 import { closeHistory, histOpen, initHistoryEvents, openHistory } from "./historyui";
 import {
-  applyHook, applyStatusline, permCmd, riskLevel, setOnTurnEnd, setPhase,
+  applyHook, applyStatusline, permCmd, riskLevel, setOnSessionTouched, setOnTurnEnd,
+  setPhase,
 } from "./phase";
 import {
   activeId, ALL_ENGINES, availEngines, dormants, externals, extMirrorId, FAVORITES,
-  mirror, pastMirrorId, sessions, setAvailEngines, setTermEngine, setTermFontSize,
-  sortMode, termEngine,
+  markWorkdirStale, mirror, pastMirrorId, sessions, setAvailEngines, setTermEngine,
+  setTermFontSize, sortMode, termEngine,
 } from "./state";
 import { orderedSessions } from "./grouping";
 import {
@@ -144,6 +145,11 @@ homeDir().then((h) => { setHome(h.replace(/[/\\]+$/, "")); }).catch(() => {});
 // All default to a no-op, so the modules stand alone in a test.
 setRlLogger(dlog);
 setOnTurnEnd((s) => { void maybeRunOnStop(s); });
+// A settled tool call (or a finished turn) is the app's only warning that a session
+// changed its checkout — nothing watches the filesystem. Two consequences, both cheap:
+// the folder is queued for a working-set re-read, and a git command that could have
+// moved HEAD or added a worktree pokes the git views straight away.
+setOnSessionTouched((s, tool, cmd) => { markWorkdirStale(s, tool); noteGitCommand(cmd); });
 setTaskLauncher(launchTask);
 setTaskLogger(dlog);
 setTaskToast(toast);
@@ -446,7 +452,7 @@ document.addEventListener("click", (e) => {
   if (dot) { const owner = dot.closest<HTMLElement>("[data-key]"); if (owner?.dataset.key) { openColorPopover(owner.dataset.key, e.clientX, e.clientY + 6); return; } }
   // data-forget and data-resume sit INSIDE a data-past row, so they must be matched
   // (and dispatched) ahead of it or the row's own click would swallow them.
-  const el = t.closest<HTMLElement>("[data-perm],[data-git],[data-diff],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-sel],[data-launch],[data-pal],[data-rail],[data-toast]");
+  const el = t.closest<HTMLElement>("[data-perm],[data-git],[data-diff],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-sel],[data-launch],[data-wtlaunch],[data-pal],[data-rail],[data-toast]");
   if (!el) return;
   if (el.dataset.perm) resolvePermission(el.dataset.permid || "", el.dataset.perm);
   else if (el.dataset.git) runGit(el.dataset.gitsid || "", el.dataset.git);
@@ -461,6 +467,14 @@ document.addEventListener("click", (e) => {
   else if (el.dataset.past) openDormant(el.dataset.past);
   else if (el.dataset.sel) { setActive(el.dataset.sel); closeAttnPop(); }
   else if (el.dataset.launch) requestLaunch(el.dataset.proj || basename(el.dataset.launch), el.dataset.launch);
+  // A session-less worktree row. Unlike data-launch this keeps colorKey pinned to the
+  // repo root, so the new session joins the project it belongs to rather than becoming
+  // a project of its own — the same contract the ⑃ dialog's worktree rows use.
+  else if (el.dataset.wtlaunch) {
+    const branch = el.dataset.wtbranch || "";
+    launch(el.dataset.proj || basename(el.dataset.wtlaunch), el.dataset.wtlaunch,
+      { colorKey: el.dataset.key || el.dataset.wtlaunch, worktree: branch, branch });
+  }
   else if (el.dataset.pal) openPalette();
   else if (el.dataset.rail) toggleRail();
   else if (el.dataset.toast) toast(el.dataset.toast);
@@ -649,14 +663,18 @@ void loadDormants();
 window.addEventListener("beforeunload", flushRoster);
 
 // keep the sidebar's "uncommitted changes" dot (and the external diff card) honest
-// for every project at once — s.git alone only covers the active session.
-refreshDirtyStates();
+// for every project at once — s.git alone only covers the active session. The tick
+// stays at 5s, but the work behind it is now driven by which folders an agent actually
+// touched (see setOnSessionTouched below); the sweep inside is the backstop.
+refreshDirtyStates(true);
 setInterval(refreshDirtyStates, 5000);
 
-// keep each session's branch label honest — re-read the real HEAD so switching
-// branches inside a session (or a worktree) is reflected instead of the stale
-// creation-time name.
-setInterval(refreshBranches, 4000);
+// Keep every git-derived label honest: each session's real HEAD, plus the set of
+// checkouts each repo has. The hook stream pokes the same function the moment an agent
+// runs a git command, so this interval is the backstop that catches changes made
+// outside Claude — your own terminal, an editor, an MCP tool.
+setInterval(refreshGitViews, 4000);
+void refreshGitViews(); // seed the roster so the first paint isn't a checkout short
 
 setSort(sortMode, false); // paint the sort button's glyph/title for the persisted mode
 initProjectDnD();

--- a/src/mirror.ts
+++ b/src/mirror.ts
@@ -23,8 +23,9 @@ import { dormantBusy, extWorking } from "./sidebarview";
 import { orderedSessions } from "./grouping";
 import { isAgent, type DiffStat, type ExtSession, type Restorable, type Sess } from "./types";
 import {
-  accentFor, dirtyByFolder, dormants, externals, extMirrorId, extMirrorPid, isDirty,
-  mirror, pastMirrorId, sessions, setActiveId, setDormants, setExternals, setMirror,
+  accentFor, dirtyByFolder, dirtyStale, dormants, externals, extMirrorId, extMirrorPid,
+  isDirty, mirror, pastMirrorId, sessions, setActiveId, setDormants, setExternals,
+  setMirror,
 } from "./state";
 
 // Three callees this module does not own: putting an Episko pane on the stage when a
@@ -103,18 +104,36 @@ export async function refreshExternals() {
     renderSidebar(); renderMini();
   } catch { /* backend not ready yet */ }
 }
-// Poll uncommitted git state for every folder in play (session workdirs + external
-// cwds), so the sidebar dot and the external diff card are accurate for all projects
-// at once — not just whichever session is active. git_diffstat is the same cheap
-// call the inspector already makes; here it fans out across the distinct folders.
-export async function refreshDirtyStates() {
+// The backstop sweep. Agent-driven edits arrive via `markWorkdirStale` and are picked
+// up on the very next tick; this interval exists only for the changes no hook can see —
+// you editing in your own editor, a build writing artefacts, an external session.
+const DIRTY_SWEEP_MS = 15_000;
+let dirtySweptAt = 0;
+// Uncommitted git state for every folder in play (session workdirs + external cwds), so
+// the sidebar dot and the external diff card are accurate for all projects at once —
+// not just whichever session is active.
+//
+// This used to re-read every folder every 5s, which on an idle fleet was pure waste: a
+// `git status` walk per open worktree, forever, to learn nothing. Now the hook stream
+// says which folders actually moved (a Write/Edit/Bash names its session, and the
+// session names its workdir), and everything else rides the slower sweep. An idle fleet
+// costs nothing; a busy one is *more* responsive than before, because a folder is
+// re-read on the tick after the edit rather than up to 5s later.
+export async function refreshDirtyStates(force = false) {
   const folders = new Set<string>();
   for (const s of sessions.values()) if (isAgent(s) && s.workdir) folders.add(s.workdir);
   for (const e of externals) if (e.cwd) folders.add(e.cwd);
   for (const f of [...dirtyByFolder.keys()]) if (!folders.has(f)) dirtyByFolder.delete(f); // prune gone folders
+  const sweep = force || Date.now() - dirtySweptAt >= DIRTY_SWEEP_MS;
+  if (sweep) dirtySweptAt = Date.now();
+  // A folder never read is always read now — otherwise a newly launched session would
+  // show no dot until the first sweep happened to come round.
+  const targets = [...folders].filter((f) => sweep || dirtyStale.has(f) || !dirtyByFolder.has(f));
+  dirtyStale.clear();
+  if (!targets.length) return;
   const sig = (g?: DiffStat | null) => (g ? `${g.files}/${g.untracked}/${g.added}/${g.removed}` : "-");
   let changed = false;
-  await Promise.all([...folders].map(async (f) => {
+  await Promise.all(targets.map(async (f) => {
     const g = await invoke<DiffStat | null>("git_diffstat", { workdir: f }).catch(() => null);
     if (sig(dirtyByFolder.get(f)) !== sig(g)) changed = true;
     dirtyByFolder.set(f, g ?? null);
@@ -134,7 +153,10 @@ export function openExternal(sid: string) {
   document.documentElement.style.setProperty("--accent", accentFor(e.cwd));
   renderExtHeader(e); renderExtInspector(e); renderSidebar(); renderMini(); renderFoot();
   $("extBody").innerHTML = `<div class="ext-empty">Loading transcript…</div>`;
-  void refreshDirtyStates(); // fill the working-set card promptly, not on the next poll tick
+  // Fill the working-set card promptly, not on the next poll tick. Forced, because
+  // this folder is very likely already cached and would otherwise be skipped — the
+  // point is a fresh read for the card the user just opened.
+  void refreshDirtyStates(true);
   loadTranscript(e, true);
   clearInterval(extTranscriptTimer);
   extTranscriptTimer = window.setInterval(() => {

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -24,21 +24,25 @@ import { $, toast } from "./dom";
 import { dlog } from "./debug";
 import { basename, esc, tilde } from "./format";
 import {
-  isAgent, type DiffStat, type GitActionResult, type Runnable, type Sess,
+  isAgent, type DiffStat, type GitActionResult, type Res, type Runnable, type Sess,
+  type WtHead,
 } from "./types";
+import { gitMutates } from "./gitwatch";
+import { fmtMb, fmtRate } from "./format";
 import { claudeInput, cleanTitle, fitSession, loadWebgl, macShellKeys, MONO, winClaudePaste } from "./terminal";
 import { gitBusy, setGitBusy } from "./inspectorview";
 import { renderInspector } from "./inspector";
 import { renderMini, renderSidebar } from "./sidebar";
 import { renderFoot } from "./footer";
 import { closeExternalView, flushRoster, queueRosterSave } from "./mirror";
-import { openWt } from "./worktree";
+import { openWt, refreshWtDialog } from "./worktree";
 import { nextAfterClose } from "./grouping";
 import { probeIcon } from "./icons";
 import { execCmd, exitWaiters, taskPrefs, type TaskLaunchOpts } from "./tasks";
 import {
   accentFor, activeId, dirtyByFolder, dormants, engineDef, externals, extMirrorId,
   pastMirrorId, sessions, setActiveId, setDormants, termEngine, termFontSize,
+  worktreesByRepo, wtSig,
 } from "./state";
 
 // The one thing a pane's lifecycle cannot own: `renderAll()` repaints every surface
@@ -286,22 +290,26 @@ export function setActive(id: string) {
 }
 
 // Poll the inspector's on-demand stats for the active session: the uncommitted
-// working-set diff (git_diffstat) and the claude process's CPU/RAM
+// working-set diff (git_diffstat) and the claude process's disk I/O
 // (session_resources). Both are cheap and only fetched for the visible session.
 export async function refreshSessionStats(s: Sess) {
   if (!isAgent(s) || s.external) return;
   const [git, res] = await Promise.all([
     invoke<DiffStat | null>("git_diffstat", { workdir: s.workdir }).catch(() => null),
-    invoke<{ cpu: number; mem_mb: number } | null>("session_resources", { sessionId: s.id }).catch(() => null),
+    invoke<{ read_bps: number; write_bps: number; read_mb: number; written_mb: number; primed: boolean } | null>(
+      "session_resources", { sessionId: s.id }).catch(() => null),
   ]);
-  // Only re-render when the *displayed* values change — CPU/RAM jitter every poll,
-  // so comparing rounded values avoids a needless inspector rebuild (which would
+  // Only re-render when the *displayed* values change — I/O rates jitter every poll, so
+  // comparing the rendered strings avoids a needless inspector rebuild (which would
   // restart the heartbeat animation) every 4s while a session sits idle.
-  const sig = (g: DiffStat | null, r: { cpu: number; memMb: number } | null) =>
-    (g ? `${g.added}/${g.removed}/${g.files}/${g.untracked}/${g.ahead}/${g.behind}/${g.upstream}` : "-") + "|" + (r ? `${Math.round(r.cpu)}/${Math.round(r.memMb)}` : "-");
+  const sig = (g: DiffStat | null, r: Res | null) =>
+    (g ? `${g.added}/${g.removed}/${g.files}/${g.untracked}/${g.ahead}/${g.behind}/${g.upstream}` : "-") + "|"
+    + (r ? `${fmtRate(r.readBps)}/${fmtRate(r.writeBps)}/${fmtMb(r.readMb)}/${fmtMb(r.writtenMb)}/${r.primed}` : "-");
   const before = sig(s.git, s.res);
   s.git = git ?? null;
-  s.res = res ? { cpu: res.cpu, memMb: res.mem_mb } : null;
+  s.res = res
+    ? { readBps: res.read_bps, writeBps: res.write_bps, readMb: res.read_mb, writtenMb: res.written_mb, primed: res.primed }
+    : null;
   if (sig(s.git, s.res) !== before && activeId === s.id && !extMirrorId()) renderInspector(s);
 }
 
@@ -318,13 +326,73 @@ async function refreshBranch(s: Sess): Promise<boolean> {
   s.branch = label;
   return true;
 }
-export async function refreshBranches() {
+async function refreshBranches(): Promise<boolean> {
   const changed = await Promise.all([...sessions.values()].map(refreshBranch));
-  if (changed.some(Boolean)) {
-    renderSidebar();
-    const a = activeId ? sessions.get(activeId) ?? null : null;
-    if (a) renderHeader(a);
-  }
+  return changed.some(Boolean);
+}
+
+// Re-read the set of checkouts for every repo that currently has something running in
+// it. Returns true if any repo's roster moved. Repos with nothing live are pruned: the
+// sidebar is a view of what is in play, and listing the worktrees of a project you
+// aren't working in would be noise rather than information.
+async function refreshWorktrees(): Promise<boolean> {
+  const roots = new Set<string>();
+  for (const s of sessions.values()) if (isAgent(s) && s.colorKey) roots.add(s.colorKey);
+  for (const e of externals) if (e.repo_root) roots.add(e.repo_root);
+  for (const k of [...worktreesByRepo.keys()]) if (!roots.has(k)) worktreesByRepo.delete(k);
+  let changed = false;
+  await Promise.all([...roots].map(async (root) => {
+    const list = await invoke<WtHead[]>("worktree_heads", { dir: root }).catch(() => null);
+    if (!list) return;                                  // not a repo, or it vanished
+    const prev = worktreesByRepo.get(root);
+    if (prev && wtSig(prev) === wtSig(list)) return;    // the common case: nothing moved
+    // Announce only against a roster we already had. The first read of a repo is
+    // entirely "new", and toasting every checkout at launch would be pure noise.
+    if (prev) announceWtDelta(root, prev, list);
+    worktreesByRepo.set(root, list);
+    changed = true;
+  }));
+  return changed;
+}
+
+// Tell the user when a checkout appears or disappears underneath them — the event a
+// terminal would have shown in its scrollback and the sidebar used to swallow.
+function announceWtDelta(root: string, prev: WtHead[], next: WtHead[]) {
+  const was = new Set(prev.filter((w) => w.exists).map((w) => w.path));
+  const now = new Set(next.filter((w) => w.exists).map((w) => w.path));
+  const added = next.filter((w) => w.exists && !was.has(w.path));
+  const gone = prev.filter((w) => w.exists && !now.has(w.path));
+  // One toast, not one per checkout: `git worktree add` in a loop would otherwise fire
+  // a burst where only the last is readable (toast shows a single message at a time),
+  // and an add paired with a removal would hide the add entirely.
+  const parts: string[] = [];
+  if (added.length === 1) parts.push(`⑃ ${added[0].branch} added`);
+  else if (added.length > 1) parts.push(`⑃ ${added.length} worktrees added`);
+  if (gone.length === 1) parts.push(`⑃ ${gone[0].branch} removed`);
+  else if (gone.length > 1) parts.push(`⑃ ${gone.length} worktrees removed`);
+  if (parts.length) toast(`${parts.join(" · ")} — ${basename(root)}`);
+}
+
+// The single place every git-derived label is re-read and repainted. Both the poll and
+// the hook-driven poke land here, so the sidebar, the header's branch chip and the ⑃
+// dialog can never disagree about what is checked out where.
+export async function refreshGitViews() {
+  const [branchMoved, wtMoved] = await Promise.all([refreshBranches(), refreshWorktrees()]);
+  if (!branchMoved && !wtMoved) return;
+  renderAll();                     // sidebar, header, mini-rail, inspector, tray
+  if (wtMoved) void refreshWtDialog();   // …and the ⑃ dialog, if it happens to be open
+}
+
+// A Bash call an agent just made is the earliest warning that HEAD moved or a checkout
+// appeared. `gitMutates` decides only whether it is worth looking; the re-read decides
+// what actually changed. Coalesced, because `git worktree add` immediately followed by
+// a checkout inside it is two hooks describing one change.
+const GIT_POKE_MS = 250;
+let gitPokeT: number | undefined;
+export function noteGitCommand(cmd: unknown) {
+  if (!gitMutates(cmd)) return;
+  clearTimeout(gitPokeT);
+  gitPokeT = window.setTimeout(() => { void refreshGitViews(); }, GIT_POKE_MS);
 }
 
 // A green run shouldn't linger — tasks are far more numerous and shorter-lived

--- a/src/phase.ts
+++ b/src/phase.ts
@@ -23,6 +23,17 @@ import { mergeRl, onRlUpdate, rl } from "./rl";
 let onTurnEnd: (s: Sess) => void = () => {};
 export function setOnTurnEnd(fn: (s: Sess) => void) { onTurnEnd = fn; }
 
+// A tool call settled, or a turn ended: this session may have moved HEAD, added a
+// worktree, or dirtied its working tree — and this is the app's *only* warning that it
+// did. Nothing watches the filesystem, so without a nudge from here the sidebar waits
+// for the next poll to notice a branch switch and never notices a new checkout at all.
+//
+// A seam rather than a direct call for the same reason as `onTurnEnd`: acting on it
+// means git commands, the roster and a repaint, none of which belong in the phase state
+// machine. main.ts wires it; in a test a settled tool is just a settled tool.
+let onSessionTouched: (s: Sess, tool: string, cmd: unknown) => void = () => {};
+export function setOnSessionTouched(fn: typeof onSessionTouched) { onSessionTouched = fn; }
+
 // Set the phase and, when it actually changes, stamp phaseSince — the anchor for
 // the inspector's dwell timer ("0:42 in state") and the "your turn" wait clock.
 export function setPhase(s: Sess, p: Phase) { if (s.phase !== p) { s.phase = p; s.phaseSince = Date.now(); } }
@@ -145,11 +156,22 @@ export function applyHook(s: Sess, data: any) {
       if (!bg()) { setPhase(s, "working"); clearPending(s); newTurn(s); s.curTool = tool; s.curArg = arg; }
       break;
     }
-    case "PostToolUse": closeActivity(s, data.tool_name); if (!bg()) setPhase(s, "working"); break;
-    case "PostToolUseFailure": closeActivity(s, data.tool_name); if (!bg()) setPhase(s, "error"); break;
+    // Failure counts as "touched" too: a compound shell command whose tail failed may
+    // still have run the git half, and a failed Edit may have written before it failed.
+    case "PostToolUse":
+    case "PostToolUseFailure": {
+      const tool = data.tool_name || "";
+      closeActivity(s, data.tool_name);
+      onSessionTouched(s, tool, data.tool_input?.command);
+      if (!bg()) setPhase(s, ev === "PostToolUse" ? "working" : "error");
+      break;
+    }
     // The turn is over — which is exactly when a project's run-on-stop rule, if it
     // has one, gets to check the agent's work.
     case "Stop": endTurn(s); clearPending(s); s.curTool = ""; s.curArg = "";
+      // Reconcile the working set even if the last tool looked read-only, so the state
+      // you come back to read is the state after the whole turn.
+      onSessionTouched(s, "Stop", undefined);
       // Only a turn that really ended gets its work checked: an unattended run
       // against a turn the API cut short would be verifying half-written files.
       if (!s.apiErr) onTurnEnd(s);

--- a/src/sidebarview.ts
+++ b/src/sidebarview.ts
@@ -11,7 +11,7 @@
 // over ProjGroups and WtClusters already split and sorted, and this only paints
 // them.
 
-import { basename, esc, fmtShort, relTime } from "./format";
+import { basename, esc, fmtShort, relTime, tilde } from "./format";
 import { apiErrText, statusKey, type ExtSession, type Restorable, type Sess } from "./types";
 import {
   accentFor, activeId, externals, extMirrorId, pastMirrorId, sessions, wtGroup,
@@ -61,24 +61,44 @@ function sessionRow(s: Sess, chip?: WtCluster): string {
 export function groupBody(p: ProjGroup): string {
   const flat = () => p.sessions.map((s) => sessionRow(s)).join("") + p.externals.map((e) => extRow(e)).join("");
   if (wtGroup === "subheader") {
-    const cl = clusterByWorktree(p);
+    const cl = clusterByWorktree(p, true);
     if (cl.length >= 2) return cl.map((c) => {
       const col = branchHue(c), n = c.sessions.length + c.externals.length;
-      const body = c.sessions.map((s) => sessionRow(s)).join("") + c.externals.map((e) => extRow(e)).join("");
+      const body = n
+        ? c.sessions.map((s) => sessionRow(s)).join("") + c.externals.map((e) => extRow(e)).join("")
+        : wtEmptyRow(p, c);
       return `<div class="wthead"><span class="wtglyph" style="color:${col}">⑃</span>`
         + `<span class="wtname" style="color:${col}" title="${esc(c.branch)}">${esc(c.branch)}</span>`
-        + `<span class="wtcount">${n}</span></div>`
+        + `<span class="wtcount">${n || ""}</span></div>`
         + `<div class="wtsessions" style="--wtc:${col}">${body}</div>`;
     }).join("");
   } else if (wtGroup === "chip") {
-    const cl = clusterByWorktree(p);
+    const cl = clusterByWorktree(p, true);
     if (cl.length >= 2) {
       const byKey = new Map(cl.map((c) => [c.key, c]));
       return p.sessions.map((s) => sessionRow(s, byKey.get(s.workdir || p.path))).join("")
-        + p.externals.map((e) => extRow(e, byKey.get(e.cwd || p.path))).join("");
+        + p.externals.map((e) => extRow(e, byKey.get(e.cwd || p.path))).join("")
+        + cl.filter((c) => !c.sessions.length && !c.externals.length).map((c) => wtEmptyRow(p, c, c)).join("");
     }
   }
   return flat();
+}
+// A checkout that exists on disk with nothing running in it. Rendered rather than
+// dropped for the same reason a blocked task is: a missing row reads as "Episko didn't
+// notice my worktree", which is exactly the gap this path was built to close.
+//
+// Clicking it launches into that checkout while keeping the repo's identity — colorKey
+// stays the repo root, so the new session joins this project group instead of
+// splintering into one of its own. That is why it is `data-wtlaunch` and not the plain
+// `data-launch` a project header uses.
+function wtEmptyRow(p: ProjGroup, c: WtCluster, chip?: WtCluster): string {
+  const chipHtml = chip
+    ? `<span class="chip" style="--wtc:${branchHue(chip)}"><span class="fork">⑃</span><span class="lbl">${esc(chip.branch)}</span></span>`
+    : "";
+  // `o3` widens the grid for the chip and arms its hover-expand, exactly as sessionRow does.
+  return `<div class="srow wtempty${chip ? " o3" : ""}" data-wtlaunch="${esc(c.key)}" data-key="${esc(p.path)}" data-proj="${esc(p.name)}" data-wtbranch="${esc(c.branch)}" title="No session here yet — start one in ${esc(tilde(c.key))}">
+    <span class="sglyph g-idle">＋</span>
+    <span class="sbranch">no session</span>${chipHtml}</div>`;
 }
 // Dormant rows always sit below the live ones, outside any worktree cluster.
 export function dormantRows(p: ProjGroup): string {

--- a/src/state.ts
+++ b/src/state.ts
@@ -21,7 +21,7 @@
 // scope*, so `import { store } from "./localstorage"` must sit on the line above
 // this module's import (see test/localstorage.ts).
 import { basename, hslToHex } from "./format";
-import type { DiffStat, Engine, ExtSession, Restorable, Sess } from "./types";
+import type { DiffStat, Engine, ExtSession, Restorable, Sess, WtHead } from "./types";
 
 export interface Favorite { name: string; path: string }
 const DEFAULT_FAVORITES: Favorite[] = [];
@@ -141,3 +141,28 @@ export function setTermEngine(e: Engine) { termEngine = e; }
 export const dirtyByFolder = new Map<string, DiffStat | null>();
 export const isDirty = (g?: DiffStat | null): boolean => !!g && (g.files > 0 || g.untracked > 0);
 export const folderDirty = (f: string): boolean => isDirty(dirtyByFolder.get(f));
+// Folders whose working tree an agent has just touched, so the dirty poll knows which
+// are worth re-reading instead of sweeping every open checkout on a timer. Drained by
+// `refreshDirtyStates`; filled by `markWorkdirStale` off the hook stream.
+export const dirtyStale = new Set<string>();
+// Tools that cannot change a working tree. An allowlist of *readers* rather than a
+// list of writers, deliberately: a tool added to Claude Code later should default to
+// "re-read the folder" and be wrong-but-cheap, not silently miss its writes.
+const READONLY_TOOLS = new Set(["Read", "Glob", "Grep", "WebFetch", "WebSearch", "TodoWrite", "ExitPlanMode", "BashOutput", "AskUserQuestion"]);
+export function markWorkdirStale(s: Sess, tool: string) {
+  if (!s.workdir || READONLY_TOOLS.has(tool)) return;
+  dirtyStale.add(s.workdir);
+}
+
+// The worktree roster: every checkout of a repo, whether or not a session lives in
+// one. Keyed by the repo root the sidebar already groups by (`Sess.colorKey`), and
+// filled by `refreshWorktrees` from the spawn-free `worktree_heads` command.
+//
+// Without this the sidebar can only show worktrees it has a session in, because
+// clusters are derived from sessions — so an agent running `git worktree add` produced
+// no visible change at all until you launched something into the new checkout.
+export const worktreesByRepo = new Map<string, WtHead[]>();
+// Cheap change stamp, compared per repo so a poll that finds nothing new costs a few
+// file reads and zero renders. That is what lets the roster ride the same tick as the
+// branch poll without adding a cost anyone can feel.
+export const wtSig = (l: WtHead[]) => l.map((w) => `${w.path} ${w.branch} ${w.exists ? 1 : 0}`).join("");

--- a/src/styles.css
+++ b/src/styles.css
@@ -236,6 +236,10 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .wtname { min-width: 0; font-size: 11px; font-weight: 600; letter-spacing: -.01em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .wtcount { flex: none; margin-left: auto; font: 600 9px var(--font-mono); color: var(--muted-2); }
 .wtsessions { padding-left: 8px; margin-left: 6px; border-left: 1px solid color-mix(in srgb, var(--wtc, var(--hair)) 45%, transparent); display: flex; flex-direction: column; gap: 1px; }
+/* a checkout with nothing running in it: present, but clearly not a session */
+.srow.wtempty .sbranch { font-style: italic; color: var(--muted-2); }
+.srow.wtempty .sglyph { color: var(--muted-2); }
+.srow.wtempty:hover .sbranch, .srow.wtempty:hover .sglyph { color: var(--accent-ink); }
 /* toplevel mode: the branch suffix on a per-worktree group header */
 .pwt { margin-left: 5px; color: var(--muted-2); font-weight: 550; }
 /* chip mode: a colour-coded ⑃ that expands to the branch name on row hover */
@@ -475,7 +479,10 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .res .rbar { flex: 1; height: 4px; border-radius: 2px; background: var(--hair-strong); overflow: hidden; }
 .res .rbar > i { display: block; height: 100%; border-radius: 2px; background: var(--st-done); }
 .res .rbar.warn > i { background: var(--st-working); } .res .rbar.hot > i { background: var(--st-error); }
-.res .rv { font: 11px var(--font-mono); width: 54px; text-align: right; color: var(--muted); font-variant-numeric: tabular-nums; flex: none; }
+.res .rv { font: 11px var(--font-mono); width: 62px; text-align: right; color: var(--muted); font-variant-numeric: tabular-nums; flex: none; }
+/* lifetime totals: context for the rates above, so it reads as a footnote not a third gauge */
+.res .rtot { margin-top: 1px; }
+.res .rvtot { font: 10px var(--font-mono); color: var(--muted-2); font-variant-numeric: tabular-nums; }
 
 /* --- risk badge on the pending-permission block --- */
 .attn-h { justify-content: flex-start; }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,14 @@ export interface DiffStat {
   added: number; removed: number; files: number; untracked: number; dirty: number;
   upstream: string | null; ahead: number; behind: number;
 }
+// One checkout of a repo as `worktree_heads` reports it — path, the branch on its
+// HEAD, and whether the directory is still on disk. Read from files rather than from
+// `git worktree list`, so it is cheap enough to poll; see the Rust side for why.
+export interface WtHead { path: string; branch: string; is_main: boolean; exists: boolean }
+// Disk I/O for one session's `claude` process: rates over the gap since the previous
+// sample, plus lifetime totals. `primed` is false on the first reading, when there is
+// nothing to difference against and the rates are 0 by default rather than measured.
+export interface Res { readBps: number; writeBps: number; readMb: number; writtenMb: number; primed: boolean }
 // Result of a fetch/pull/push. `suggest` is set when the action was refused (or
 // git failed) and there's a command worth handing to a real terminal.
 export interface GitActionResult { ok: boolean; summary: string; output: string; suggest: string | null }
@@ -103,7 +111,7 @@ export interface Sess {
   apiErr: ApiErr | null;
   model: string; ctxPct: number | null; ctxTokens: number | null; cost: number | null; durMs: number | null;
   curTool: string; curArg: string; todos: Todo[];
-  ctxHist: number[]; costHist: number[]; git: DiffStat | null; res: { cpu: number; memMb: number } | null;
+  ctxHist: number[]; costHist: number[]; git: DiffStat | null; res: Res | null;
   lastEvent: string; activity: Act[];
   kind: SessKind; external: boolean; term?: Terminal; fit?: FitAddon; pane: HTMLElement;
   // task panes only

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -171,6 +171,15 @@ async function wtLoad(quiet = false) {
   void wtMaybeFetch();
 }
 
+// Re-list because the repo changed underneath the open dialog — a worktree created or
+// removed by an agent while you were looking at the picker. A no-op when the dialog is
+// closed, so the caller (the git-invalidation path in panes.ts) doesn't have to know
+// whether it is. Local read only: this is not a reason to hit the network.
+export async function refreshWtDialog() {
+  if (!wtCtx) return;
+  await wtReadLocal(true);
+}
+
 // Fetch is throttled and best-effort: it runs in the background, never blocks the list,
 // and stays silent on failure (offline, no remote, auth) — a stale number is a better
 // outcome than a toast every time you alt-tab with no network.

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import {
-  basename, esc, fmtClock, fmtDur, fmtDwell, fmtLatency, fmtShort, fmtSpan, fmtUntil,
-  hslToHex, relTime, setHome, sparkline, tilde, uDelta, uTok, uUsd, uUsd2,
+  basename, esc, fmtClock, fmtDur, fmtDwell, fmtLatency, fmtMb, fmtRate, fmtShort,
+  fmtSpan, fmtUntil, hslToHex, relTime, setHome, sparkline, tilde, uDelta, uTok, uUsd,
+  uUsd2,
 } from "../src/format";
 
 // A fixed epoch for everything that reads the clock, so "2h 10m from now" is a
@@ -98,6 +99,24 @@ describe("fmtLatency — the Pre→Post tool gap", () => {
     expect(fmtLatency(999.6)).toBe("1000ms"); // rounds within the ms branch
     expect(fmtLatency(1_000)).toBe("1.0s");
     expect(fmtLatency(1_499)).toBe("1.5s");
+  });
+});
+
+describe("fmtRate / fmtMb — the inspector's disk-I/O readout", () => {
+  it("picks the unit the number is readable in, and keeps a decimal only for MB/s", () => {
+    expect(fmtRate(0)).toBe("0 B/s");
+    expect(fmtRate(512)).toBe("512 B/s");
+    expect(fmtRate(1023)).toBe("1023 B/s");
+    expect(fmtRate(1024)).toBe("1 KB/s");        // whole KB — a fractional one is noise
+    expect(fmtRate(1024 * 1023)).toBe("1023 KB/s");
+    expect(fmtRate(1024 * 1024)).toBe("1.0 MB/s"); // …but MB/s keeps one, 1.2 vs 4.8 matters
+    expect(fmtRate(1024 * 1024 * 32.45)).toBe("32.5 MB/s");
+  });
+  it("promotes a total to GB only once it stops reading as MB", () => {
+    expect(fmtMb(0)).toBe("0 MB");
+    expect(fmtMb(1023.4)).toBe("1023 MB");
+    expect(fmtMb(1024)).toBe("1.0 GB");
+    expect(fmtMb(3891.2)).toBe("3.8 GB");
   });
 });
 

--- a/test/gitwatch.test.ts
+++ b/test/gitwatch.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { gitMutates } from "../src/gitwatch";
+
+describe("gitMutates", () => {
+  it("catches every ordinary way an agent moves HEAD", () => {
+    // `checkout` and `switch` are the same case, whatever the user's habit.
+    expect(gitMutates("git checkout main")).toBe(true);
+    expect(gitMutates("git checkout -b feat/thing")).toBe(true);
+    expect(gitMutates("git switch dev")).toBe(true);
+    expect(gitMutates("git switch -c feat/thing")).toBe(true);
+    expect(gitMutates("git rebase origin/main")).toBe(true);
+    expect(gitMutates("git pull --rebase")).toBe(true);
+    expect(gitMutates("git reset --hard HEAD~1")).toBe(true);
+    expect(gitMutates("gh pr checkout 126")).toBe(true);
+  });
+
+  it("catches worktree creation and removal — the case nothing else can see", () => {
+    expect(gitMutates("git worktree add ../feature-x -b feature-x")).toBe(true);
+    expect(gitMutates("git worktree remove ../feature-x")).toBe(true);
+    expect(gitMutates("git worktree prune")).toBe(true);
+  });
+
+  it("sees through the shapes a real command actually arrives in", () => {
+    // Compound commands are the norm, so this can't be a prefix match.
+    expect(gitMutates("cd sub && git switch dev")).toBe(true);
+    expect(gitMutates("git worktree add ../x && cd ../x && pnpm install")).toBe(true);
+    // Global flags sit between `git` and the verb.
+    expect(gitMutates("git -C /Users/t/dev/some/deep/path checkout main")).toBe(true);
+    expect(gitMutates("git --no-pager branch -a")).toBe(true);
+    // Multi-line heredoc-ish blobs still match.
+    expect(gitMutates("set -e\ngit fetch origin\ngit checkout main\n")).toBe(true);
+  });
+
+  it("ignores commands that touch no git state", () => {
+    expect(gitMutates("ls -la")).toBe(false);
+    expect(gitMutates("pnpm test")).toBe(false);
+    expect(gitMutates("git status --porcelain")).toBe(false);
+    expect(gitMutates("git log --oneline -5")).toBe(false);
+    expect(gitMutates("git diff HEAD")).toBe(false);
+    expect(gitMutates("cargo build")).toBe(false);
+  });
+
+  it("is not fooled by non-strings", () => {
+    expect(gitMutates(undefined)).toBe(false);
+    expect(gitMutates(null)).toBe(false);
+    expect(gitMutates(42)).toBe(false);
+    expect(gitMutates({ command: "git checkout main" })).toBe(false);
+  });
+
+  it("accepts the false positives it is designed to tolerate", () => {
+    // `checkout -- <path>` restores a file and moves nothing. Matching it is fine and
+    // deliberate: the re-read finds no change and renders nothing. This test exists so
+    // that if someone later tightens the regex to exclude it, they do so knowingly —
+    // the risk of a clever exclusion is missing a real `checkout` that looks like it.
+    expect(gitMutates("git checkout -- src/main.ts")).toBe(true);
+    // A word merely containing a verb must not trigger on its own, though.
+    expect(gitMutates("./scripts/branchless-deploy.sh")).toBe(false);
+    expect(gitMutates("echo 'nothing to see'")).toBe(false);
+  });
+
+  it("does not let the match run away into an unrelated later command", () => {
+    // `git` early, a verb far later in a long unrelated pipeline: the bounded gap is
+    // what stops this reading as a branch change.
+    const far = "git status && " + "echo padding ".repeat(20) + "&& npm run reset";
+    expect(gitMutates(far)).toBe(false);
+  });
+});

--- a/test/grouping.test.ts
+++ b/test/grouping.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import type { ExtSession, Restorable, Sess } from "../src/types";
+import type { ExtSession, Restorable, Sess, WtHead } from "../src/types";
 import { store } from "./localstorage"; // must precede the subject imports
 import {
   accentFor, colorOverrides, sessions, setDormants, setExternals, setFavorites,
-  setProjOrder, setSortMode, setWtGroup,
+  setProjOrder, setSortMode, setWtGroup, worktreesByRepo,
 } from "../src/state";
 import {
   allProjects, clusterByWorktree, needsYou, needsYouSessions, nextAfterClose,
@@ -46,6 +46,7 @@ beforeEach(() => {
   sessions.clear();
   setExternals([]); setDormants([]); setFavorites([]); setProjOrder([]);
   setSortMode("manual"); setWtGroup("off");
+  worktreesByRepo.clear();
   for (const k of Object.keys(colorOverrides)) delete colorOverrides[k];
   taskPrefs.attention = true; // needsYou reads it; restore the shipped default
   store.clear();
@@ -113,6 +114,64 @@ describe("clusterByWorktree — one cluster per checkout dir", () => {
   it("takes a cluster's branch from an external when no session carries one", () => {
     const p = grp({ externals: [ext({ cwd: "/w/wt", branch: "feature" })] });
     expect(clusterByWorktree(p)[0].branch).toBe("feature");
+  });
+});
+
+// The roster half: checkouts that exist on disk with nothing running in them. Off
+// unless asked for, because only the sidebar body wants them — see the note on the
+// parameter for why splitByWorktree must not get them.
+describe("clusterByWorktree — session-less checkouts from the worktree roster", () => {
+  const roster = (l: WtHead[]) => { worktreesByRepo.set("/w/epi", l); };
+  const main = (o: Partial<WtHead> = {}): WtHead =>
+    ({ path: "/w/epi", branch: "main", is_main: true, exists: true, ...o });
+  const linked = (o: Partial<WtHead> = {}): WtHead =>
+    ({ path: "/w/wt-x", branch: "feat/x", is_main: false, exists: true, ...o });
+
+  it("ignores the roster entirely unless withEmpty is asked for", () => {
+    roster([main(), linked()]);
+    const p = grp({ sessions: [sess({ id: "a", workdir: "/w/epi" })] });
+    expect(clusterByWorktree(p).map((c) => c.key)).toEqual(["/w/epi"]);
+  });
+  it("adds a checkout with no session, after the ones that have sessions", () => {
+    roster([main(), linked()]);
+    const p = grp({ sessions: [sess({ id: "a", workdir: "/w/epi" })] });
+    const cl = clusterByWorktree(p, true);
+    expect(cl.map((c) => c.key)).toEqual(["/w/epi", "/w/wt-x"]);
+    expect(cl[1]).toMatchObject({ branch: "feat/x", isMain: false });
+    expect(cl[1].sessions).toEqual([]);
+    expect(cl[1].externals).toEqual([]);
+  });
+  it("does not duplicate a checkout that already has a session", () => {
+    roster([main(), linked()]);
+    const p = grp({ sessions: [
+      sess({ id: "a", workdir: "/w/epi" }),
+      sess({ id: "b", workdir: "/w/wt-x", branch: "feat/x" }),
+    ] });
+    const cl = clusterByWorktree(p, true);
+    expect(cl.map((c) => c.key)).toEqual(["/w/epi", "/w/wt-x"]);
+    expect(ids(cl[1].sessions)).toEqual(["b"]);
+  });
+  it("prefers the roster's branch over a session's cached one — it read HEAD directly", () => {
+    roster([main(), linked({ branch: "renamed" })]);
+    const p = grp({ sessions: [sess({ id: "b", workdir: "/w/wt-x", branch: "stale" })] });
+    expect(clusterByWorktree(p, true).find((c) => c.key === "/w/wt-x")!.branch).toBe("renamed");
+  });
+  it("skips a registered checkout whose folder is gone — that is git bookkeeping", () => {
+    roster([main(), linked({ exists: false })]);
+    const p = grp({ sessions: [sess({ id: "a", workdir: "/w/epi" })] });
+    expect(clusterByWorktree(p, true).map((c) => c.key)).toEqual(["/w/epi"]);
+  });
+  // The guard: a project pinned AT a linked worktree resolves to the same repo, and
+  // folding the roster in there would sprout a row for the main checkout and every
+  // sibling — silently redefining what that group means.
+  it("leaves a group alone when it is not the repo's main checkout", () => {
+    worktreesByRepo.set("/w/wt-x", [main(), linked()]);
+    const p = grp({ path: "/w/wt-x", sessions: [sess({ id: "b", workdir: "/w/wt-x" })] });
+    expect(clusterByWorktree(p, true).map((c) => c.key)).toEqual(["/w/wt-x"]);
+  });
+  it("adds nothing when the repo has no roster yet", () => {
+    const p = grp({ sessions: [sess({ id: "a", workdir: "/w/epi" })] });
+    expect(clusterByWorktree(p, true).map((c) => c.key)).toEqual(["/w/epi"]);
   });
 });
 


### PR DESCRIPTION
Branch switching was already covered by the 4s HEAD poll. **Creating a worktree was not covered at all** — sidebar clusters are derived from sessions, so `git worktree add` produced no visible change until you launched something into the new checkout.

Nothing here watches the filesystem, on purpose (the reason the task discovery cache gives: no thread, no crate, no per-project lifecycle). So the fix is to use a signal we already receive and throw away, and to make the polling behind it cost less than it did.

## The hook stream is the trigger; git stays the authority

`PostToolUse` carries the Bash command verbatim — verified against the real CLI:

```json
"hook_event_name": "PostToolUse", "tool_name": "Bash",
"tool_input": { "command": "git checkout -b probe-branch", … }
```

`phase.ts` hands a settled tool call to a new `onSessionTouched` seam — same shape as `onTurnEnd`, so `phase.ts` stays a leaf and its suite still runs it standalone. `main.ts` wires that to two things: queue the workdir for a working-set re-read, and, when `gitMutates` matches, poke `refreshGitViews` on a 250ms debounce.

**`gitMutates` decides only whether to look, never what changed.** That's what makes it safe to keep loose, and the tests pin both directions: a false positive (`git checkout -- file.ts`) costs one re-read that renders nothing; a false negative (`git co`, a script, an MCP git server) costs at most one poll interval. The poll stays, and remains the only thing that catches a branch you switch in your own terminal.

## Two commands, two costs

`list_worktrees` is a `status` per checkout plus a `merge-base` per branch — right for the ⑃ dialog, far too heavy to poll. New **`worktree_heads`** answers "which checkouts exist and what is on each HEAD" from `.git/HEAD` and `.git/worktrees/*/{gitdir,HEAD}` with **no git process at all**. That's what lets the sidebar hold a roster and render a session-less checkout as a dimmed row you can launch into — with `colorKey` pinned to the repo root, so it joins its project instead of splintering into one of its own. The result doubles as the change stamp.

Its test caught a real bug, not a fixture artifact: git writes the *resolved* path into `gitdir`, so deriving the main checkout's path any other way produces a second spelling of the same root — and the sidebar groups by exact string equality, so one worktree would have rendered as two. Fixed by going through `repo_root_of`/`physical_cwd`: the same asymmetry a58218c fixed, reached from a new direction, which is the argument for that function being the only way in.

## Riding the same polling budget

- **`git_diffstat`**: 3–4 spawns → one `status --porcelain=v2 --branch` (which carries the upstream and ahead/behind that `upstream_state` cost two more), with the `--numstat` walk skipped entirely on a clean tree — the steady state for most open folders. The existing test gains the two paths the rewrite makes newly reachable: a detached HEAD prints no `# branch.ab` to parse, and a clean tree returns without the second walk.
- **`refreshDirtyStates`** stops re-reading every folder every 5s. Stale folders come from the hook stream; a 15s sweep covers what no hook sees (your editor, a build, an external session). The tool list behind it is an allowlist of *readers*, so a tool added later defaults to wrong-but-cheap rather than silently missing writes. Idle costs nothing; a busy folder is *more* responsive than before — re-read on the tick after the edit rather than up to 5s later.
- **`session_resources`** swaps cpu/mem for disk I/O (sysinfo → `proc_pid_rusage`), replacing a `ps` spawn every 4s with one syscall and taking per-session resources off the macOS-only list. cpu/mem measured the one thing a Claude session is never short of; this is an I/O-bound workload, and a runaway agent shows up as sustained throughput long before it shows up as CPU. Log-scaled against 32 MB/s, because a linear bar sits at zero for everything short of the case it must show. Its test asserts the counter actually moves — a silently-zero counter renders as a confident, permanently-idle gauge rather than as a bug.

**Not done, deliberately:** the `episko-debug.json` write amplification. `dev` had already fixed it independently (compact JSON, `generatedAt` out of the comparison, 60s heartbeat), with measurements. Nothing worth adding on top.

## Gates

All run locally, all green:

| Gate | Result |
| --- | --- |
| `pnpm exec tsc --noEmit` | clean |
| `pnpm build` | clean |
| `vitest` | **408** passed (was 392) |
| `cargo test` | **89** passed (was 87) |
| `cargo check` | no warnings |
| `cargo clippy --all-targets -- -D warnings` | clean |

No new `cfg` arms, so the cfg flip has nothing to add here.

One thing worth watching in CI: `process_disk_usage_actually_counts_bytes` asserts the per-process write counter moves after an 8 MiB fsync'd write. It passes on macOS. If it fails on the Windows leg that is real information rather than a flake — it would mean the I/O readout shows a permanent zero there, and the gauge would be lying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)