### PR TITLE
Choose the permission mode a session starts in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,13 +41,13 @@ in the block above before pushing, and match the toolchain CI uses (`stable` for
 
 **Package manager: `pnpm`** for this repo (there's a `pnpm-lock.yaml`; both CI workflows use `pnpm install --frozen-lockfile`, and `packageManager` in `package.json` pins the version for corepack/CI). Use pnpm here, not npm. Windows code-signing / release-signing setup lives in `src-tauri/SIGNING.md`.
 
-Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **368 vitest + cargo (82 on macOS, 79 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
+Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **368 vitest + cargo (83 on macOS, 80 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
 
 **vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which nine those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
 
 What is **untested by design**: the render, view and DOM-owning modules on both sides of the app — snapshotting template literals mostly re-asserts itself. Anything touching the DOM, PTYs, or live telemetry is still verified by **running the app and exercising it** — the statusLine half of telemetry only fires in interactive mode, so it cannot be checked end to end with `claude -p`. Split that one carefully, because the split is not where it looks: whether the generated statusLine command *works* is checked headlessly and in CI (the shell runs it for real — see the constraint above). What needs a live REPL is only whether **Claude still picks the shell and payload we expect**. That costs a TTY, not tokens: a session you launch and never prompt makes no API call, and the statusLine fires on start and every `refreshInterval` seconds regardless. It's a `RELEASE.md` click-through, and a cheap one. `tsc` (strict) is the real linter. Requires `claude` on PATH, the Node in `.nvmrc` (`nvm use`; `engines` floors it at 24), and Rust stable + Tauri system deps.
 
-CLI *mechanics*, though, often can be checked headlessly — drive `claude -p` against a **throwaway** session in a temp dir and inspect the resulting `.jsonl` (never a real session: resuming appends to it). That is what the one `#[ignore]`d test does (`claude_cli_still_honours_our_instrumentation` in `telemetry.rs`): it runs the real binary and asserts Claude Code's hook schema and transcript layout still match what this app reads. It is **not** in CI — it needs auth and spends tokens — and is run via `cargo test -- --ignored` as part of `RELEASE.md`'s checklist.
+CLI *mechanics*, though, often can be checked headlessly — drive `claude -p` against a **throwaway** session in a temp dir and inspect the resulting `.jsonl` (never a real session: resuming appends to it). That is what `claude_cli_still_honours_our_instrumentation` (`telemetry.rs`) does: it runs the real binary and asserts Claude Code's hook schema and transcript layout still match what this app reads. It is **not** in CI — it needs auth and spends tokens — and is run via `cargo test -- --ignored` as part of `RELEASE.md`'s checklist. It is one of **two** `#[ignore]`d tests, and the other one is cheaper than its gating suggests: `claude_cli_still_accepts_every_permission_mode_we_offer` (`pty.rs`) spends no tokens and needs no auth (`--version` short-circuits *after* the CLI has validated the flag), and is `#[ignore]`d purely because CI has no `claude` binary. Both run in the same `--ignored` pass, so the checklist gains nothing to remember.
 
 **`RELEASE.md` holds the manual release procedure** — what CI already guarantees, the click-through for the OS edge, and the tag/verify steps. Anything that can only be checked by running the app belongs there, not here.
 
@@ -230,17 +230,17 @@ Four smaller P4 affordances, all in the frontend:
 
 ## Backend (`src-tauri/src/`) — ten modules
 
-`main.rs` only calls `episko_lib::run()`. `lib.rs` is **bootstrap, not the backend**: 449 lines out of ~7,600. Dependencies point downward, `platform.rs` at the bottom.
+`main.rs` only calls `episko_lib::run()`. `lib.rs` is **bootstrap, not the backend**: 449 lines out of ~8,200 (the counts below are whole files, in-file `#[cfg(test)] mod tests` included — that is most of `telemetry.rs`). Dependencies point downward, `platform.rs` at the bottom.
 
 | Module | Lines | What |
 | --- | --- | --- |
 | `lib.rs` | 449 | `run()`, `AppState`/`Session`, the tray mirror, the panic hook, `write_debug_file`/`log_frontend`, `confirm_quit`, and the `invoke_handler!` list |
-| `tasks.rs` | 2,394 | runnable discovery — see Runnables above |
+| `tasks.rs` | 2,399 | runnable discovery — see Runnables above |
 | `git.rs` | 1,532 | worktrees, branches, the working-set diff, the toolbar's fetch/pull/push, commit info |
-| `usage.rs` | 819 | transcripts + the token ledger — everything read out of `~/.claude` |
-| `pty.rs` | 705 | the four launch engines, `stream_pty_session`, the PTY lifecycle |
-| `platform.rs` | 683 | OS leaves (top half) + OS integrations (bottom half) |
-| `telemetry.rs` | 469 | `write_instrument_settings`, `run_telemetry_server`, `resolve_permission` |
+| `usage.rs` | 896 | transcripts + the token ledger — everything read out of `~/.claude` |
+| `telemetry.rs` | 857 | `write_instrument_settings`, `run_telemetry_server`, `resolve_permission` |
+| `pty.rs` | 829 | the four launch engines, the permission-mode whitelist, `stream_pty_session`, the PTY lifecycle |
+| `platform.rs` | 690 | OS leaves (top half) + OS integrations (bottom half) |
 | `external.rs` | 339 | the `~/.claude/sessions` registry, `ProcTable`, terminal focus |
 | `icons.rs` | 184 | project favicon/logo probing |
 | `testutil.rs` | 24 | `scratch_dir`, `cfg(test)` only |
@@ -260,7 +260,7 @@ Four conventions hold across them:
 
 ## Frontend (`src/`, `index.html`, `src/styles.css`) — 34 modules
 
-**No framework, and no longer one file.** ~7,200 lines across 34 modules; `main.ts` is 642 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
+**No framework, and no longer one file.** ~7,500 lines across 34 modules; `main.ts` is 660 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (~70 lines — it is the seam map, and belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, and the nine `setInterval`s.
 
@@ -329,7 +329,7 @@ And the things that hold however the files are arranged:
   *shell* pane's handler; no pane is both, so the two never collide.)
 - **Event wiring**: `listen("pty-output" | "pty-exit" | "telemetry" | "permission" | "tray-select")` at the bottom of `main.ts`. Telemetry is routed by `data.session_id?.toLowerCase()` — session ids are matched case-insensitively, so keep them lowercase.
 - `applyHook` maps lifecycle events → a `Phase` state machine (idle/thinking/working/done/error/ended) and attention flags; `applyStatusline` fills model/context%/cost/duration. **Rate limits are account-wide**, held in a single `rl` object and shown identically on every session, not per-session.
-- **Persistence is all `localStorage`**, ~20 keys prefixed `cc-` (favorites, drag order, colours, icons, engine, font size, sort/grouping, frecency, caffeinate, the `cc-usage` daily cost rollup, the `cc-restore` roster, and the task keys `cc-task-{prefs,pins,hidden,onstop,runner,inputs}` + `cc-trusted`). `grep '"cc-'` for the current set.
+- **Persistence is all `localStorage`**, ~20 keys prefixed `cc-` (favorites, drag order, colours, icons, engine, permission mode, font size, sort/grouping, frecency, caffeinate, the `cc-usage` daily cost rollup, the `cc-restore` roster, and the task keys `cc-task-{prefs,pins,hidden,onstop,runner,inputs}` + `cc-trusted`). `grep '"cc-'` for the current set.
 - **Debug console** (🐞 button, bottom-right): an in-app event log + live state via `dlog()`/`dbgSnapshot()`. It flags **unrouted telemetry** (the routing-drift class of bug above) and JS errors, and mirrors a snapshot to `$TMPDIR/cc-launcher/episko-debug.json` (written by the `write_debug_file` command) so an external tool or an LLM agent can read live app state while it runs.
 - **Two-tier logging — live snapshot vs. durable timeline.** The `episko-debug.json` snapshot is a *state-of-now* blob that is overwritten each flush and does **not** survive a crash (the frontend never flushes if the process dies). The durable tier is the backend rolling `episko.log` (+ `panic.log`) in the OS app-log dir (macOS `~/Library/Logs/io.respeak.episko/`), via `tauri-plugin-log` and a panic hook — the only on-disk trace of a panic that unwinds cleanly out of `main` (no crash dump / WER otherwise). Every `dlog()` line tees into it through the `log_frontend` command (tagged `[ui]`), so the UI and backend event streams land in **one time-ordered file**. A `episko.log` that stops without an `exit · clean shutdown` line is itself evidence of an abnormal termination. Use the snapshot for "what is it doing *now*", the rolling log for "why did it *die*".
 
@@ -342,6 +342,38 @@ And the things that hold however the files are arranged:
 - **terminal / iterm** — `spawn_external_terminal` writes an executable `.command` wrapper and hands it to `open -a`.
 
 `available_terminals` reports which are installed so the UI only offers working ones.
+
+## Permission mode — how a session starts (Settings ⌘, → **Sessions**)
+
+Orthogonal to the engine above: `permMode` (`cc-perm-mode`, `ALL_PERM_MODES` in
+`state.ts`) is passed to all three claude spawners as `mode` and becomes
+`claude --permission-mode <m>`. Four things about it are deliberate:
+
+- **The standard mode passes no flag.** `permission_mode_arg` in `pty.rs` maps
+  `"default"` (and Claude's own `manual` spelling) to `None`, because an absent
+  `--permission-mode` is already ask-me-each-time. `--help` doesn't list `default`
+  among its choices, so emitting it would depend on an undocumented alias.
+- **The mode names are a whitelist, not a passthrough.** `permission_mode_arg`
+  returns `&'static str`, so nothing the frontend sends reaches a command line.
+  That matters because `spawn_external_terminal` interpolates the launch into a
+  generated `.command` **shell script** — the one launch path with a shell in it.
+  An unrecognised mode launches standard rather than failing.
+- **It is only the *starting* mode, and nothing tracks it afterwards.** Claude's own
+  ⇧⇥ switches mode inside a live session, so a recorded "this pane's mode" would go
+  stale and lie; no `Sess` field holds one. The new-session dialog shows a chip for
+  a non-default mode (`#wtMode`) because that is the last moment the choice is still
+  true.
+- **Three of the six turn Episko's permission cockpit off**, and silently: `dontAsk`,
+  `bypassPermissions` and (mostly) `auto` mean Claude raises no permission request,
+  so the blocking `PermissionRequest` hook never fires and a pane that would have
+  asked simply doesn't. The picker's hint says so; keep it saying so.
+
+Claude Code validates the mode against its own choice list and exits if it doesn't
+know one, which kills the pane before it starts — the same class of external
+contract as the hook schema. `claude_cli_still_accepts_every_permission_mode_we_offer`
+(`pty.rs`, `#[ignore]`d) checks it against the real binary for **no tokens and no
+auth** (`--version` short-circuits after the choice is validated); it is in
+`RELEASE.md` only because CI hasn't got the binary.
 
 ## External (non-Episko) sessions
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@ Every push and PR to `dev`/`main` runs, on **both macOS and Windows** (`ci.yml`)
 
 - `pnpm build` — `tsc --noEmit` (strict) plus the vite build
 - `pnpm test` — 368 vitest tests over the logic modules
-- `cargo check --locked` and `cargo test --locked` — 82 tests on macOS, 79 on
+- `cargo check --locked` and `cargo test --locked` — 83 tests on macOS, 80 on
   Windows (the platform tests are `cfg`-gated, so the count differs by leg)
 - `cargo clippy --all-targets --locked -- -D warnings`
 
@@ -30,18 +30,26 @@ permission round trip, and whether Claude Code's own interfaces still match ours
 
 ## Before tagging
 
-### 1. The CLI contract test — run it, it is not in CI
+### 1. The CLI contract tests — run them, they are not in CI
 
 ```sh
 cd src-tauri
 cargo test --locked -- --ignored --nocapture
 ```
 
-Runs one real `claude -p` against a throwaway session in a temp dir and asserts our
-hooks reach our server, that routing still uses our launch id, and that the
-transcript still carries the fields the cost ledger reads. **It needs `claude` on
-PATH and an authenticated account, and it spends tokens** — which is exactly why it
-is `#[ignore]`d and lives here rather than in the PR gate.
+Two tests, both against the real binary, in one pass:
+
+- `claude_cli_still_honours_our_instrumentation` runs one real `claude -p` against a
+  throwaway session in a temp dir and asserts our hooks reach our server, that routing
+  still uses our launch id, and that the transcript still carries the fields the cost
+  ledger reads. **It needs `claude` on PATH and an authenticated account, and it spends
+  tokens** — which is exactly why it is `#[ignore]`d and lives here rather than in the
+  PR gate.
+- `claude_cli_still_accepts_every_permission_mode_we_offer` runs `claude
+  --permission-mode <m> --version` for each mode Settings offers. Claude Code validates
+  the flag against its own choice list, so a mode renamed or dropped upstream turns
+  every launch in that mode into a pane that dies before it starts. This one costs **no
+  tokens and needs no auth** — it is `#[ignore]`d only because CI has no `claude`.
 
 A failure here is the highest-signal failure in this document: it means a Claude Code
 release changed something under us, and the app would otherwise have gone quiet
@@ -122,6 +130,12 @@ A regression in either is silent.
       is a *blocking* hook — if the UI doesn't answer, Claude hangs, so a failure here
       is a hard blocker.
 - [ ] **Answering in the CLI instead** also clears the badge on the next lifecycle event.
+- [ ] **A non-default permission mode reaches the session.** Settings › Sessions →
+      **Plan**, then `＋ Session`: the new-session dialog shows the Plan chip and the
+      pane comes up in plan mode (Claude's own indicator says so, and it refuses to
+      edit). Set it back to **Manual** afterwards — every launch, including a restore,
+      reads this preference. Worth one pass in an *external* engine too, since that is
+      the only path where the flag goes through a generated shell script.
 
 ### Identity across rotations
 

--- a/index.html
+++ b/index.html
@@ -155,6 +155,8 @@
         <div class="wt-headrow">
           <span class="wt-path" id="wtPath"></span>
           <span class="wt-eng" id="wtEng"></span>
+          <!-- Only shown when the launch is NOT the standard ask-me mode (see openWt). -->
+          <span class="wt-eng" id="wtMode" hidden></span>
           <button class="wt-chip" id="wtRefresh" type="button" title="Re-read worktrees and branches">
             <span class="ic">⟳</span><span id="wtAge">now</span>
           </button>

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -67,6 +67,40 @@ fn apply_utf8_locale(cmd: &mut CommandBuilder) {
     }
 }
 
+/// The permission mode a session starts in — `claude --permission-mode`, chosen in
+/// Settings › Sessions and passed by every spawner. Two properties are load-bearing:
+///
+/// - **It maps to a `&'static str`; the caller's string never reaches a command
+///   line.** Here that would only be one argv element, but `spawn_external_terminal`
+///   writes its launch into a generated `.command` *shell script*, so the whitelist is
+///   what keeps the one path with a shell in it honest. An unrecognised mode launches
+///   standard rather than not at all — a new mode name in some future frontend must
+///   not be able to make a session refuse to start.
+/// - **The standard mode passes no flag.** Claude's ask-me-each-time behaviour is what
+///   an absent `--permission-mode` already means, and its own `--help` doesn't list
+///   `default` among the choices (only `manual`), so spelling it out would lean on an
+///   undocumented alias to say what silence says.
+fn permission_mode_arg(mode: Option<&str>) -> Option<&'static str> {
+    match mode?.trim() {
+        "plan" => Some("plan"),
+        "acceptEdits" => Some("acceptEdits"),
+        "auto" => Some("auto"),
+        "dontAsk" => Some("dontAsk"),
+        "bypassPermissions" => Some("bypassPermissions"),
+        "" | "default" | "manual" => None,
+        other => {
+            log::warn!("ignoring unknown permission mode {other:?} — launching standard");
+            None
+        }
+    }
+}
+
+// A `#[tauri::command]`'s parameter list *is* its wire format: the frontend calls it by
+// naming each one, and every one here is a distinct fact about the launch. Bundling
+// them into a struct to satisfy the lint would change that contract on both sides (and
+// the round-trip the `Exec` test pins for `spawn_task`) while making the call site say
+// strictly less.
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub(crate) fn spawn_claude(
     app: AppHandle,
@@ -76,6 +110,7 @@ pub(crate) fn spawn_claude(
     rows: u16,
     cols: u16,
     resume: Option<String>,
+    mode: Option<String>,
 ) -> Result<(), String> {
     let port = state.port;
     // A resume must land in the session's ORIGINAL cwd: Claude looks the id up in
@@ -112,6 +147,11 @@ pub(crate) fn spawn_claude(
     }
     cmd.arg("--settings");
     cmd.arg(&settings_path);
+    let perm = permission_mode_arg(mode.as_deref());
+    if let Some(m) = perm {
+        cmd.arg("--permission-mode");
+        cmd.arg(m);
+    }
     cmd.cwd(&workdir);
     for (k, v) in std::env::vars() {
         cmd.env(k, v);
@@ -123,8 +163,9 @@ pub(crate) fn spawn_claude(
     apply_utf8_locale(&mut cmd);
 
     log::info!(
-        "spawn claude · {session_id} · {workdir}{}",
-        resume.as_deref().map(|r| format!(" · resume {r}")).unwrap_or_default()
+        "spawn claude · {session_id} · {workdir}{}{}",
+        resume.as_deref().map(|r| format!(" · resume {r}")).unwrap_or_default(),
+        perm.map(|m| format!(" · {m}")).unwrap_or_default()
     );
     let child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
     drop(pair.slave);
@@ -402,6 +443,7 @@ pub(crate) fn spawn_ghostty(
     accent: String,
     title: String,
     resume: Option<String>,
+    mode: Option<String>,
 ) -> Result<(), String> {
     let port = state.port;
     if resume.is_some() && !std::path::Path::new(&workdir).is_dir() {
@@ -433,6 +475,10 @@ pub(crate) fn spawn_ghostty(
     }
     cmd.arg("--settings");
     cmd.arg(&settings_path);
+    if let Some(m) = permission_mode_arg(mode.as_deref()) {
+        cmd.arg("--permission-mode");
+        cmd.arg(m);
+    }
     for (k, v) in std::env::vars() {
         cmd.env(k, v);
     }
@@ -480,6 +526,7 @@ pub(crate) fn spawn_external_terminal(
     _engine: String,
     _title: String,
     _resume: Option<String>,
+    _mode: Option<String>,
 ) -> Result<(), String> {
     Err("external terminals aren't supported on Windows yet — use the embedded terminal".to_string())
 }
@@ -498,6 +545,7 @@ pub(crate) fn spawn_external_terminal(
     engine: String,
     title: String,
     resume: Option<String>,
+    mode: Option<String>,
 ) -> Result<(), String> {
     let port = state.port;
     if resume.is_some() && !std::path::Path::new(&workdir).is_dir() {
@@ -518,8 +566,14 @@ pub(crate) fn spawn_external_terminal(
         Some(prev) => format!("--resume {}", sh_quote(prev)),
         None => format!("--session-id {}", sh_quote(&session_id)),
     };
+    // The one launch path that goes through a shell, so the whitelist in
+    // `permission_mode_arg` is what makes interpolating this safe: it can only ever be
+    // one of six literals, never anything the frontend sent.
+    let mode_args = permission_mode_arg(mode.as_deref())
+        .map(|m| format!(" --permission-mode {m}"))
+        .unwrap_or_default();
     let body = format!(
-        "#!/bin/zsh\n# Episko session: {title}\nexport PATH={path}\ncd {wd} || exit 1\nexec {claude} {id_args} --settings {settings}\n",
+        "#!/bin/zsh\n# Episko session: {title}\nexport PATH={path}\ncd {wd} || exit 1\nexec {claude} {id_args}{mode_args} --settings {settings}\n",
         title = title.replace(['\n', '\r'], " "),
         path = sh_quote(&augmented_path()),
         wd = sh_quote(&workdir),
@@ -702,4 +756,74 @@ mod tests {
         assert_eq!(String::from_utf8_lossy(&piped.stdout).trim(), "2");
     }
 
+    /// Every mode Settings offers, and nothing else. The whitelist is the security
+    /// boundary for `spawn_external_terminal`, which interpolates this into a generated
+    /// `.command` script — so what matters is not only that the six known spellings
+    /// survive, but that everything else collapses to "no flag" instead of reaching a
+    /// shell. The standard mode passing no flag is the other half: an absent
+    /// `--permission-mode` is what ask-me-each-time already means.
+    #[test]
+    fn permission_mode_is_whitelisted_and_the_standard_mode_passes_no_flag() {
+        for m in ["plan", "acceptEdits", "auto", "dontAsk", "bypassPermissions"] {
+            assert_eq!(permission_mode_arg(Some(m)), Some(m), "{m} should reach the command line");
+        }
+        // The standard mode is spelled by silence, whichever name it arrives under.
+        assert_eq!(permission_mode_arg(None), None);
+        assert_eq!(permission_mode_arg(Some("default")), None);
+        assert_eq!(permission_mode_arg(Some("manual")), None);
+        assert_eq!(permission_mode_arg(Some("")), None);
+        assert_eq!(permission_mode_arg(Some("  ")), None);
+        // Case matters: these are Claude Code's own spellings, and a near-miss must not
+        // be quietly "corrected" into a mode the user didn't pick.
+        assert_eq!(permission_mode_arg(Some("acceptedits")), None);
+        assert_eq!(permission_mode_arg(Some("PLAN")), None);
+        // Nothing that could do something in a shell script gets through.
+        for hostile in ["plan; rm -rf /", "plan --dangerously-skip-permissions", "$(id)", "plan\nrm x"] {
+            assert_eq!(permission_mode_arg(Some(hostile)), None, "{hostile:?} must not reach a command line");
+        }
+    }
+
+    /// The mode names are an external contract, exactly like the hook schema the
+    /// `#[ignore]`d test in telemetry.rs guards: they go on Claude Code's command line
+    /// verbatim, and Claude Code validates them against its own choice list — a mode
+    /// renamed or dropped upstream turns every launch in that mode into an instant
+    /// "option argument is invalid" and a pane that dies before it starts.
+    ///
+    /// Unlike that test this one costs **no tokens and needs no auth**: `--version`
+    /// short-circuits before any API call, while commander still validates the choice
+    /// first. It is `#[ignore]`d only because it needs the real binary, which CI hasn't
+    /// got — so it belongs to the release checklist. It also asserts the negative case,
+    /// because a build that stopped validating modes at all would otherwise pass.
+    #[test]
+    #[ignore = "runs the real `claude` binary (no tokens, no auth) — `cargo test -- --ignored`"]
+    fn claude_cli_still_accepts_every_permission_mode_we_offer() {
+        let claude = resolve_claude();
+        let try_mode = |m: &str| {
+            std::process::Command::new(&claude)
+                .arg("--permission-mode")
+                .arg(m)
+                .arg("--version")
+                .env("PATH", augmented_path())
+                .output()
+                .unwrap_or_else(|e| panic!("could not run `claude` at {claude:?}: {e}\n\
+                     This test needs Claude Code installed and on PATH."))
+        };
+
+        for m in ["plan", "acceptEdits", "auto", "dontAsk", "bypassPermissions"] {
+            let out = try_mode(m);
+            assert!(
+                out.status.success(),
+                "`claude --permission-mode {m}` was rejected ({}). Settings offers this \
+                 mode, so every launch in it would fail:\n{}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        // Proof the check above means something: an invalid mode must still be refused.
+        let bogus = try_mode("episko-not-a-mode");
+        assert!(
+            !bogus.status.success(),
+            "claude accepted a nonsense --permission-mode, so the assertions above prove nothing"
+        );
+    }
 }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -18,10 +18,12 @@ import { activeCwd } from "./panes";
 import { renderMini, renderSidebar } from "./sidebar";
 import { renderSettings } from "./settings";
 import {
-  FAVORITES, saveFavorites, sessions, setFavorites, setSortMode, SORT_META,
-  SORT_MODES, sortMode, setWtGroup as setWtGroupState, wtGroup,
+  FAVORITES, permMode, permModeDef, saveFavorites, sessions, setFavorites,
+  setPermMode as setPermModeState, setSortMode, SORT_META, SORT_MODES, sortMode,
+  setWtGroup as setWtGroupState, wtGroup,
   type SortMode, type WtGroup,
 } from "./state";
+import type { PermMode } from "./types";
 
 // Every action here ends in a repaint of everything, which main.ts owns.
 let renderAll: () => void = () => {};
@@ -78,6 +80,21 @@ export function setWtGroup(m: WtGroup) {
 }
 // Dev affordance until the settings window ships: episkoWtGroup("chip") in the console.
 (window as unknown as { episkoWtGroup: typeof setWtGroup }).episkoWtGroup = setWtGroup;
+
+// Which permission mode the NEXT session launches in — the same shape as the sort and
+// the grouping above (state assigns, this persists and announces). Announced rather
+// than silent because it changes what a session may do before you get a chance to see
+// it: a pane started in Bypass or Don't ask never raises a permission card at all, so
+// there is no later moment where the choice becomes visible. Only new launches move;
+// a running session keeps whatever mode it is in (Claude's ⇧⇥ owns that).
+export function setPermMode(m: PermMode) {
+  setPermModeState(m);
+  localStorage.setItem("cc-perm-mode", permMode);
+  toast(permMode === "default"
+    ? "New sessions ask before acting"
+    : `New sessions start in ${permModeDef(permMode).label} mode`);
+  renderSettings(); // keep the settings picker in sync if it's open
+}
 
 export function setSort(m: SortMode, announce = true) {
   setSortMode(m);

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ import { applyFontSize, bumpFont, refit } from "./terminal";
 import {
   addProject, addProjectPath, cycleSort, effectiveTheme, openProjectFolder,
   removeFavorite, resolvePermission, revealActiveFolder, setActionsRenderAll,
-  setSort, setTheme, setWtGroup, toggleInsp, toggleRail, toggleTheme,
+  setPermMode, setSort, setTheme, setWtGroup, toggleInsp, toggleRail, toggleTheme,
 } from "./actions";
 import {
   activeCwd, activeProjectCtx, closeSession, handToTerminal, launch, launchShell,
@@ -185,11 +185,11 @@ setActionsRenderAll(renderAll);
 setMirrorSetActive(setActive);
 setMirrorLaunch(launch);
 setMirrorRenderAll(renderAll);
-// The settings window changes eight things it does not own; this is the whole of
+// The settings window changes nine things it does not own; this is the whole of
 // what it can reach back for.
 setSettingsHost({
   setTheme, effectiveTheme, setSort, setEngine, bumpFont, applyFontSize, refreshTokens,
-  setWtGroup,
+  setWtGroup, setPermMode,
 });
 // The task panels run tasks, hand commands to terminals and put panes on stage —
 // none of which they own.

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -38,7 +38,8 @@ import { probeIcon } from "./icons";
 import { execCmd, exitWaiters, taskPrefs, type TaskLaunchOpts } from "./tasks";
 import {
   accentFor, activeId, dirtyByFolder, dormants, engineDef, externals, extMirrorId,
-  pastMirrorId, sessions, setActiveId, setDormants, termEngine, termFontSize,
+  pastMirrorId, permMode, permModeDef, sessions, setActiveId, setDormants, termEngine,
+  termFontSize,
 } from "./state";
 
 // The one thing a pane's lifecycle cannot own: `renderAll()` repaints every surface
@@ -93,12 +94,18 @@ export async function launch(project: string, workdir: string, opts: { colorKey?
   // sidebar doesn't show the same conversation twice, live and dormant.
   if (opts.resume) setDormants(dormants.filter((d) => d.resumeId !== opts.resume));
   queueRosterSave();
-  dlog("info", `${opts.resume ? "resume" : "launch"} ${project} · ${id.slice(0, 8)} · ${termEngine}${opts.worktree ? " · worktree" : ""}${opts.resume ? ` · from ${opts.resume.slice(0, 8)}` : ""}`);
+  // The permission mode a launch starts in (Settings › Sessions). "default" is
+  // Claude's own ask-me behaviour, which is what passing NO flag means — so it goes
+  // over the wire as null rather than as a spelling of the standard mode. Read here
+  // rather than taken as an opt, exactly like termEngine: it is a preference, and a
+  // restore is as much a new launch as anything else.
+  const mode = permMode === "default" ? null : permMode;
+  dlog("info", `${opts.resume ? "resume" : "launch"} ${project} · ${id.slice(0, 8)} · ${termEngine}${mode ? ` · ${permModeDef(permMode).label}` : ""}${opts.worktree ? " · worktree" : ""}${opts.resume ? ` · from ${opts.resume.slice(0, 8)}` : ""}`);
 
   try {
-    if (termEngine === "ghostty") await invoke("spawn_ghostty", { sessionId: id, workdir, accent, title: project, resume: opts.resume ?? null });
-    else if (external) await invoke("spawn_external_terminal", { sessionId: id, workdir, engine: termEngine, title: project, resume: opts.resume ?? null });
-    else await invoke("spawn_claude", { sessionId: id, workdir, rows: term!.rows || 24, cols: term!.cols || 80, resume: opts.resume ?? null });
+    if (termEngine === "ghostty") await invoke("spawn_ghostty", { sessionId: id, workdir, accent, title: project, resume: opts.resume ?? null, mode });
+    else if (external) await invoke("spawn_external_terminal", { sessionId: id, workdir, engine: termEngine, title: project, resume: opts.resume ?? null, mode });
+    else await invoke("spawn_claude", { sessionId: id, workdir, rows: term!.rows || 24, cols: term!.cols || 80, resume: opts.resume ?? null, mode });
   } catch (e) {
     dlog("error", `launch failed (${project} · ${id.slice(0, 8)}): ${e}`);
     toast("launch failed: " + e);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,10 +14,10 @@
 
 import { $, dropScrim, toast } from "./dom";
 import { basename, esc, tilde } from "./format";
-import type { Engine } from "./types";
+import type { Engine, PermMode } from "./types";
 import {
-  availEngines, engineDef, setTermFontSize, SORT_META, SORT_MODES, sortMode,
-  termEngine, termFontSize, wtGroup,
+  ALL_PERM_MODES, availEngines, engineDef, permMode, setTermFontSize, SORT_META,
+  SORT_MODES, sortMode, termEngine, termFontSize, wtGroup,
   type SortMode, type WtGroup,
 } from "./state";
 import {
@@ -42,11 +42,14 @@ export interface SettingsHost {
   // nor regroup the sidebar. It arrives through the host because ./actions imports
   // this module (for renderSettings) and a direct import back would be a cycle.
   setWtGroup: (m: WtGroup) => void;
+  // Same reason as setWtGroup: the app-level one (./actions), which persists and
+  // announces — state.ts's same-named setter only assigns.
+  setPermMode: (m: PermMode) => void;
 }
 let host: SettingsHost = {
   setTheme: () => {}, effectiveTheme: () => "dark", setSort: () => {}, setEngine: () => {},
   bumpFont: () => {}, applyFontSize: () => {}, refreshTokens: () => {},
-  setWtGroup: () => {},
+  setWtGroup: () => {}, setPermMode: () => {},
 };
 export function setSettingsHost(h: SettingsHost) { host = h; }
 
@@ -97,6 +100,10 @@ const SET_TABS: SetTab[] = [
       { kind: "seg", set: "engine", label: "Launch engine", hint: "Where a new session's terminal opens.",
         active: () => termEngine,
         segs: () => availEngines.map((id) => { const d = engineDef(id); return { value: id, label: d.label, sub: d.sub, glyph: id === "embedded" ? "▤" : "⧉" }; }) },
+      { kind: "seg", set: "permmode", label: "Permission mode",
+        hint: "The mode a new session starts in. ⇧⇥ inside a session still switches mode from there — this only decides where it begins. The last three stop Claude asking at all, which also means no permission cards here.",
+        active: () => permMode,
+        segs: () => ALL_PERM_MODES.map((m) => ({ value: m.id, label: m.label, sub: m.sub, glyph: m.glyph })) },
       { kind: "seg", set: "sort", label: "Sidebar sort", hint: "How projects and sessions are ordered in the sidebar.",
         active: () => sortMode,
         segs: () => SORT_MODES.map((m) => ({ value: m, label: SORT_SHORT[m], sub: SORT_META[m].label, glyph: SORT_META[m].glyph })) },
@@ -282,6 +289,7 @@ function applySetting(set: string, val: string) {
   if (set === "theme") host.setTheme(val as "dark" | "light");
   else if (set === "engine") host.setEngine(val as Engine);
   else if (set === "sort") host.setSort(val as SortMode);
+  else if (set === "permmode") host.setPermMode(val as PermMode);
   else if (set === "wtgroup") host.setWtGroup(val as WtGroup);
   else if (set === "prov") {
     const p = val as Provider;

--- a/src/state.ts
+++ b/src/state.ts
@@ -21,7 +21,7 @@
 // scope*, so `import { store } from "./localstorage"` must sit on the line above
 // this module's import (see test/localstorage.ts).
 import { basename, hslToHex } from "./format";
-import type { DiffStat, Engine, ExtSession, Restorable, Sess } from "./types";
+import type { DiffStat, Engine, ExtSession, PermMode, Restorable, Sess } from "./types";
 
 export interface Favorite { name: string; path: string }
 const DEFAULT_FAVORITES: Favorite[] = [];
@@ -134,6 +134,29 @@ export function setTermFontSize(v: number) { termFontSize = v; }
 export function setAvailEngines(l: Engine[]) { availEngines = l; }
 export let termEngine: Engine = (localStorage.getItem("cc-term-engine") as Engine) || "embedded";
 export function setTermEngine(e: Engine) { termEngine = e; }
+// --- how a new session starts (claude --permission-mode) -----------------------
+// A persisted preference like the engine above, and the same split: the type is in
+// ./types (it crosses to the backend), the label table stays in the UI layer.
+// Labels follow Claude Code's own names for these modes, so the picker and the
+// indicator the REPL shows after ⇧⇥ can't read as two different things.
+//
+// Ordered by how much the mode hands over: Manual asks about everything, Bypass
+// about nothing. The last three stop Claude asking, and therefore stop Episko's
+// permission cards too — the hint in Settings › Sessions says so, since a pane that
+// never raises one looks identical to a pane nobody has asked anything.
+export interface PermModeDef { id: PermMode; label: string; sub: string; glyph: string }
+export const ALL_PERM_MODES: PermModeDef[] = [
+  { id: "default",           label: "Manual",       sub: "Asks before anything risky — Episko's permission cards", glyph: "◇" },
+  { id: "plan",              label: "Plan",         sub: "Reads and plans; runs nothing until you accept",         glyph: "⊙" },
+  { id: "acceptEdits",       label: "Accept edits", sub: "File edits go through; commands still ask",              glyph: "✎" },
+  { id: "auto",              label: "Auto",         sub: "A model classifier answers the prompts for you",         glyph: "◈" },
+  { id: "dontAsk",           label: "Don't ask",    sub: "Never prompts — anything not pre-approved is denied",    glyph: "⊘" },
+  { id: "bypassPermissions", label: "Bypass",       sub: "No permission checks at all. Claude confirms once",      glyph: "⚠" },
+];
+export function permModeDef(id: PermMode): PermModeDef { return ALL_PERM_MODES.find((m) => m.id === id) || ALL_PERM_MODES[0]; }
+export let permMode: PermMode = (localStorage.getItem("cc-perm-mode") as PermMode) || "default";
+if (!ALL_PERM_MODES.some((m) => m.id === permMode)) permMode = "default";
+export function setPermMode(m: PermMode) { permMode = m; }
 // Uncommitted-changes cache, keyed by folder rather than session, because it feeds
 // the sidebar's per-project dot and the external inspector's diff card as well as
 // the active session: `Sess.git` only stays fresh for the session on stage, so

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,13 @@ export type SessKind = "claude" | "shell" | "task";
 // this only decides which window the PTY is attached to. The label/availability
 // table (ALL_ENGINES, available_terminals) stays in the UI layer that offers them.
 export type Engine = "embedded" | "ghostty" | "terminal" | "iterm";
+// How a new claude session treats tool calls at launch (`claude --permission-mode`).
+// Orthogonal to Engine: this decides what the session may do, not where its terminal
+// lives, and it applies to every engine. The spellings are Claude Code's own, because
+// they go on the command line verbatim (bar `default`, which means "pass no flag" —
+// see `permission_mode_arg` in pty.rs). Only the *starting* mode: Claude's own ⇧⇥
+// still switches mode inside a running session, and nothing here tracks that.
+export type PermMode = "default" | "plan" | "acceptEdits" | "auto" | "dontAsk" | "bypassPermissions";
 // Always ask through this rather than re-testing the string: whether telemetry,
 // cost and git actions apply to a pane is one decision, made in one place.
 export const isAgent = (s: Sess) => s.kind === "claude";

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -19,7 +19,7 @@ import { $, dropScrim, toast } from "./dom";
 import { dlog } from "./debug";
 import { basename, esc } from "./format";
 import type { DiffStat, GitActionResult, Phase, Sess } from "./types";
-import { engineDef, sessions, termEngine } from "./state";
+import { engineDef, permMode, permModeDef, sessions, termEngine } from "./state";
 
 type LaunchOpts = { colorKey?: string; worktree?: string | null; branch?: string; resume?: string };
 let launch: (project: string, workdir: string, opts?: LaunchOpts) => Promise<void> = async () => {};
@@ -151,6 +151,15 @@ export async function openWt(project: string, repoDir: string, knownBranch?: str
   const eng = engineDef(termEngine);
   $("wtEng").textContent = `${termEngine === "embedded" ? "▤" : "⧉"} ${eng.label}`;
   ($("wtEng") as HTMLElement).title = `New sessions open in ${eng.label}`;
+  // What this launch will be allowed to do, next to where it will open — but only when
+  // that isn't the standard ask-me mode, so the chip means "something is different
+  // here" rather than becoming furniture. A session that starts in Bypass or Plan
+  // otherwise looks exactly like any other until it acts (or refuses to).
+  const pm = permModeDef(permMode);
+  const modeEl = $("wtMode") as HTMLElement;
+  modeEl.hidden = permMode === "default";
+  modeEl.textContent = `${pm.glyph} ${pm.label}`;
+  modeEl.title = `Starts in ${pm.label} mode — ${pm.sub} (Settings › Sessions)`;
   $("scrim").classList.add("show"); $("wtDlg").classList.add("show");
   setTimeout(() => ($("wtQ") as HTMLInputElement).focus(), 30);
   clearInterval(wtAgeT); wtAgeT = window.setInterval(wtTickAge, 1000);


### PR DESCRIPTION
Settings ⌘, → **Sessions** now picks the mode every new claude session starts in. `permMode` (`cc-perm-mode`) rides through all three claude spawners and becomes `claude --permission-mode <m>` — identical for all four engines, like the instrumentation itself.

Every launch used to be Claude's standard ask-me-each-time mode, which is the right default and the wrong only option: a session opened to read a codebase wants plan mode, one grinding through a mechanical refactor wants accept-edits, and both were a ⇧⇥ away *after* the session was up and had already asked.

Six modes, Claude Code's own names, ordered by how much they hand over: **Manual · Plan · Accept edits · Auto · Don't ask · Bypass**.

## Four decisions worth reviewing

- **Manual passes no flag at all.** An absent `--permission-mode` already *is* ask-me-each-time, and `claude --help` doesn't list `default` among its choices (only `manual`) — spelling it out would lean on an undocumented alias to say what silence says. `"default"` goes over the wire as `null`.
- **The mode names are a whitelist in Rust, not a passthrough.** `permission_mode_arg` returns `&'static str`, because `spawn_external_terminal` interpolates the launch into a generated `.command` **shell script** — the one launch path with a shell in it. An unrecognised mode logs and launches standard rather than refusing to start.
- **It is only the *starting* mode.** ⇧⇥ moves it inside a live session, so no `Sess` field records one — it would go stale and lie. The new-session dialog gets a chip for a non-default mode instead, since that is the last moment the choice is still true.
- **Three of the six switch the permission cockpit off, silently.** Under Don't ask, Bypass and mostly Auto, Claude raises no permission request, so the blocking `PermissionRequest` hook never fires and a pane that would have asked simply doesn't. The picker's hint says so, and the setter toasts on change, because there is no later moment where the choice becomes visible.

## Tests

- `permission_mode_is_whitelisted_and_the_standard_mode_passes_no_flag` — the six spellings survive, everything else (including shell-shaped input) collapses to "no flag". **83 cargo on macOS, 80 on Windows.**
- `claude_cli_still_accepts_every_permission_mode_we_offer` — the mode names are an external contract like the hook schema: Claude Code validates them against its own choice list and exits, killing the pane before it starts. Runs each mode against the real binary for **no tokens and no auth** (`--version` short-circuits *after* the flag is validated) and asserts a nonsense mode is still refused, so a build that stopped validating can't pass it. `#[ignore]`d only because CI has no `claude`, so it joins `RELEASE.md`'s existing `--ignored` pass — verified passing against CC 2.1.220.
- Also run locally: clippy clean, 368 vitest, `tsc --noEmit`, `pnpm build`, the cfg flip over `pty.rs` for the Windows arms, and an import-cycle sweep (none across 35 modules).

**Not verified by any of that:** the picker rendering, the dialog chip, and a real plan-mode launch — DOM and PTY, untested by design. Added as a `RELEASE.md` click-through item (worth one pass in an external engine too, the only path where the flag goes through a shell script).

Doc drift corrected in passing: `telemetry.rs` was listed at 469 lines against 857 actual, the frontend at ~7,200 against ~7,500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)