### PR TITLE
sidebar: the ⑃ cluster header as the surface for a checkout — quick launch, and a context menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,7 @@ Four conventions hold across them:
 
 ## Frontend (`src/`, `index.html`, `src/styles.css`) — 37 modules
 
-**No framework, and no longer one file.** ~8,100 lines across 37 modules; `main.ts` is 686 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
+**No framework, and no longer one file.** ~8,300 lines across 37 modules; `main.ts` is 686 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (~70 lines — it is the seam map, and belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, and the nine `setInterval`s.
 
@@ -295,7 +295,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 
 **Markup-only views**, untested by design: `usageview`, `inspectorview`, `sidebarview`.
 
-**DOM-owning / render**, untested by design: `sidebar`, `footer`, `tray`, `inspector`, `debug`, `worktree` (the new-session dialog, the biggest single module at 932 lines), `settings`, `taskui`, `palui`, `projmenu`, `caffeinate`, `diffview`, `mirror`, `historyui`, `update`.
+**DOM-owning / render**, untested by design: `sidebar`, `footer`, `tray`, `inspector`, `debug`, `worktree` (the new-session dialog and the worktree removal flows, the biggest single module at 976 lines), `settings`, `taskui`, `palui`, `projmenu`, `caffeinate`, `diffview`, `mirror`, `historyui`, `update`.
 
 **Behaviour** — IPC and DOM all the way down, so untested too, and therefore the thinnest ice in the app: `panes` (the three spawners + a pane's lifecycle), `terminal` (the xterm plumbing), `taskrun` (run on stop), `actions` (the app-level verbs), `icons` (the per-project glyph store).
 
@@ -387,7 +387,30 @@ carries the upstream and ahead/behind that `upstream_state` cost two more proces
 with the `--numstat` walk skipped entirely on a clean tree.
 
 Everything lands through `refreshGitViews` → `renderAll()`, so the sidebar, the header's
-branch chip and the open ⑃ dialog cannot disagree about what is checked out where.
+branch chip and the open ⑃ dialog cannot disagree about what is checked out where. A
+removal is the one change to that roster the app makes *itself*, so both removal paths
+call `refreshGitViews` on success rather than waiting for the poll — `renderAll` only
+paints the roster, it never re-reads it, so without this the cluster you just deleted
+stays on screen.
+
+**The ⑃ cluster header is the surface for a checkout** (subheader mode). It renders
+whether or not anything runs beneath it, which is what lets the roster's discovery show:
+a worktree an agent created appears as a dimmed header (`.wtvacant`) rather than as a
+row that says "no session". It carries a `＋` (→ `launchWorktree`, which keys the new
+session's `colorKey` to the **repo root**, or the pane splits off into a project group of
+its own) and a **right-click menu** in `projmenu.ts` — terminal, folder, copy path, the ⑃
+dialog, and remove. That menu shares `#ctxMenu` with the project one: `data-wt` is
+matched *ahead* of `data-key` in the `contextmenu` handler, because a cluster sits inside
+a project group and a combined `closest()` would be decided by tree distance rather than
+by what was clicked. Chip mode has no headers, so the "no session" row survives there
+alone.
+
+**Removal is keyed by path, not by session** (`removeWorktreeAt`) — a cluster can hold
+none, one or several, and an empty one is exactly the checkout you most want to prune.
+It closes the Episko sessions living there (the backend refuses while one runs), but
+**refuses outright when an external session is in the checkout**: the backend can't see
+one, so `git worktree remove` would delete the folder out from under an agent in someone
+else's terminal. The menu says so on the row rather than letting the click fail.
 
 ## Four launch engines, one telemetry path
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,9 +403,22 @@ dialog, and remove. That menu shares `#ctxMenu` with the project one: `data-wt` 
 matched *ahead* of `data-key` in the `contextmenu` handler, because a cluster sits inside
 a project group and a combined `closest()` would be decided by tree distance rather than
 by what was clicked. Chip mode has no headers, so the "no session" row survives there
-alone. Opening the ⑃ dialog from that menu passes `openWt`'s `focusDir`, which selects
-the checkout's row *and* retitles the dialog `Worktrees` — headed "New session" it reads
-as the launcher whatever is highlighted in it.
+alone.
+
+**`openWt` has two modes, and the difference is framing, not machinery.** `launch` is
+the original — "where should this session start?", so every branch in the repo is a row.
+`manage` is what a ⑃ cluster's context menu opens (`{ manage: true, focusDir }`): the
+caller already knows where a session would go, so what it wants is the checkouts. The
+detail pane was *always* a management surface — folder, HEAD, working tree, merged-or-
+not, the removal flow, every warning about a locked/detached/vanished checkout — so
+manage mode only drops what surrounds it: **branches wait for a query** (unfiltered they
+bury the handful of checkouts you came for, but gating rather than dropping keeps "add a
+worktree on an existing branch" reachable, which the create row can't offer for a name
+that is already a branch), the **engine chip** goes, and the count reads `N checkouts`
+rather than `N destinations`. The title is load-bearing on its own: headed "New session"
+it reads as the launcher whatever is highlighted in it. **⏎ still starts a session in
+both** — changing what Enter does between two modes of one dialog is a worse trap than a
+verb that is occasionally not what you came for.
 
 **The main checkout is not a worktree, and says so twice.** `clusterGlyph` gives it `⌂`
 — the glyph the dialog's Repo row and the project menu's "Open project folder" already

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,7 +403,17 @@ dialog, and remove. That menu shares `#ctxMenu` with the project one: `data-wt` 
 matched *ahead* of `data-key` in the `contextmenu` handler, because a cluster sits inside
 a project group and a combined `closest()` would be decided by tree distance rather than
 by what was clicked. Chip mode has no headers, so the "no session" row survives there
-alone.
+alone. Opening the ⑃ dialog from that menu passes `openWt`'s `focusDir`, which selects
+the checkout's row *and* retitles the dialog `Worktrees` — headed "New session" it reads
+as the launcher whatever is highlighted in it.
+
+**The main checkout is not a worktree, and says so twice.** `clusterGlyph` gives it `⌂`
+— the glyph the dialog's Repo row and the project menu's "Open project folder" already
+use — and `branchHue` seeds it from its **path** rather than its branch, so it comes out
+wearing the project header's own accent (a hand-picked colour included). Both exist
+because `⑃ develop` above three `feat/*` clusters is four worktrees to anyone who
+doesn't already know which branch name meant "the original". Every chip and header goes
+through those two helpers, so subheader and chip mode cannot disagree.
 
 **Removal is keyed by path, not by session** (`removeWorktreeAt`) — a cluster can hold
 none, one or several, and an empty one is exactly the checkout you most want to prune.

--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
     -->
     <div class="wtdlg" id="wtDlg" role="dialog" aria-modal="true" aria-label="New session">
       <div class="wt-head">
-        <div class="wt-title"><b>New session</b><span class="wt-proj" id="wtProj"></span></div>
+        <div class="wt-title"><b id="wtTitle">New session</b><span class="wt-proj" id="wtProj"></span></div>
         <div class="wt-headrow">
           <span class="wt-path" id="wtPath"></span>
           <span class="wt-eng" id="wtEng"></span>

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,8 +47,8 @@ import {
   setReorderGuard, setSidebarRenderAll, setSidebarSetSort,
 } from "./sidebar";
 import {
-  closeBranchPop, closeWt, setWtCloseSession,
-  setWtHandToTerminal, setWtLaunch, setWtRenderAll, setWtSetActive,
+  closeBranchPop, closeWt, setWtCloseSession, setWtHandToTerminal, setWtLaunch,
+  setWtRefreshGit, setWtRenderAll, setWtSetActive,
 } from "./worktree";
 import {
   dbgLog, dbgSnapshot, dlog, flushDebug, renderDbgBadge, renderDbgPanel, telem,
@@ -172,11 +172,11 @@ setPaletteHost({
   cycleSort, toggleInsp, toggleRail, toggleTheme, requestLaunch,
   revealActiveFolder, openProjectFolder,
 });
-// Same reasoning, six callees: a context-menu row starts panes and edits the project
+// Same reasoning, seven callees: a context-menu row starts panes and edits the project
 // list, none of which the menu owns.
 setProjMenuHost({
-  renderAll, requestLaunch, launchShell, openProjectFolder, addProjectPath,
-  removeFavorite,
+  renderAll, requestLaunch, launchWorktree, launchShell, openProjectFolder,
+  addProjectPath, removeFavorite,
 });
 // Run-on-stop and the task inspector's actions reach back for three pane operations.
 setTaskRunSetActive(setActive);
@@ -213,6 +213,8 @@ setWtCloseSession(closeSession);
 setWtSetActive(setActive);
 setWtRenderAll(renderAll);
 setWtHandToTerminal(handToTerminal);
+// …and removing one changes what checkouts exist, which only a git re-read notices.
+setWtRefreshGit(refreshGitViews);
 // The drag guard and the reorder click guard moved with the sidebar into ./sidebar.
 
 // ---------- model ----------

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,8 +25,8 @@ import {
 } from "./actions";
 import {
   activeCwd, activeProjectCtx, closeSession, handToTerminal, launch, launchShell,
-  launchTask, openPlainTerminal, refreshBranches, refreshSessionStats, renderHeader,
-  requestLaunch, runGit, scheduleDismiss, setActive, setPanesRenderAll,
+  launchTask, launchWorktree, openPlainTerminal, refreshBranches, refreshSessionStats,
+  renderHeader, requestLaunch, runGit, scheduleDismiss, setActive, setPanesRenderAll,
   syncStageButtons,
 } from "./panes";
 import {
@@ -445,7 +445,7 @@ document.addEventListener("click", (e) => {
   if (dot) { const owner = dot.closest<HTMLElement>("[data-key]"); if (owner?.dataset.key) { openColorPopover(owner.dataset.key, e.clientX, e.clientY + 6); return; } }
   // data-forget and data-resume sit INSIDE a data-past row, so they must be matched
   // (and dispatched) ahead of it or the row's own click would swallow them.
-  const el = t.closest<HTMLElement>("[data-perm],[data-git],[data-diff],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-sel],[data-launch],[data-pal],[data-rail],[data-toast]");
+  const el = t.closest<HTMLElement>("[data-perm],[data-git],[data-diff],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-sel],[data-wtadd],[data-launch],[data-pal],[data-rail],[data-toast]");
   if (!el) return;
   if (el.dataset.perm) resolvePermission(el.dataset.permid || "", el.dataset.perm);
   else if (el.dataset.git) runGit(el.dataset.gitsid || "", el.dataset.git);
@@ -459,6 +459,7 @@ document.addEventListener("click", (e) => {
   else if (el.dataset.ext) openExternal(el.dataset.ext);
   else if (el.dataset.past) openDormant(el.dataset.past);
   else if (el.dataset.sel) { setActive(el.dataset.sel); closeAttnPop(); }
+  else if (el.dataset.wtadd) launchWorktree(el.dataset.proj || basename(el.dataset.wtadd), el.dataset.root || el.dataset.wtadd, el.dataset.wtadd, el.dataset.branch || "");
   else if (el.dataset.launch) requestLaunch(el.dataset.proj || basename(el.dataset.launch), el.dataset.launch);
   else if (el.dataset.pal) openPalette();
   else if (el.dataset.rail) toggleRail();

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -136,6 +136,16 @@ export function requestLaunch(project: string, path: string) {
   launch(project, path, { colorKey: path });
 }
 
+// The sidebar's per-worktree ＋ (subheader grouping). Unlike requestLaunch this never
+// opens the worktree dialog: the cluster header the button sits on *is* the answer
+// that dialog asks for, so offering it again would only re-ask what was just clicked.
+// `root` is the repo root — the colorKey every session in the project groups by, which
+// a worktree's own path is not (get that wrong and the new session splits off into a
+// project group of its own).
+export function launchWorktree(project: string, root: string, dir: string, branch: string) {
+  launch(project, dir, { colorKey: root, worktree: dir === root ? null : branch, branch });
+}
+
 // A plain login shell in an embedded xterm pane — no Claude, no telemetry.
 // Returns the new session id so a caller can write into the shell (see handToTerminal).
 export async function launchShell(project: string, workdir: string, opts: { colorKey?: string; worktree?: string | null; branch?: string } = {}): Promise<string> {

--- a/src/projmenu.ts
+++ b/src/projmenu.ts
@@ -1,8 +1,10 @@
-// The project context menu and the appearance panel it shares with the sidebar's
-// colour dots. One module because they are one interaction: the panel opens either
-// standalone at the cursor or as the menu's Appearance submenu, and each closes the
-// other — the panel clears the menu's `.sub-open` row, and every button in it commits
-// and so closes the whole stack.
+// The project context menu, the worktree one, and the appearance panel they share
+// with the sidebar's colour dots. One module because they are one interaction: the
+// panel opens either standalone at the cursor or as the menu's Appearance submenu,
+// and each closes the other — the panel clears the menu's `.sub-open` row, and every
+// button in it commits and so closes the whole stack. The two menus share the one
+// `#ctxMenu` element and its `.mp-*` skin for the same reason; only one can be open,
+// so each opener clears the other's target.
 //
 // Cosmetic, in Phase-1 terms: nothing here is on renderAll()'s path. It paints on
 // right-click and on a dot click, and nowhere else.
@@ -12,24 +14,26 @@ import { $, FILE_MANAGER, toast } from "./dom";
 import { basename, esc, tilde } from "./format";
 import { closeFootMenus } from "./footer";
 import { clearIcon, customIcons, iconFor, pickCustomIcon, resetCustomIcon } from "./icons";
-import { openWt } from "./worktree";
+import { openWt, removeWorktreeAt } from "./worktree";
 import { isAgent } from "./types";
 import {
-  accentFor, activeId, colorOverrides, engineDef, FAVORITES, sessions, termEngine,
+  accentFor, activeId, colorOverrides, engineDef, externals, FAVORITES, sessions,
+  termEngine,
 } from "./state";
 
-// The six things a menu row does that this module does not own — panes, the project
+// The seven things a menu row does that this module does not own — panes, the project
 // list and the repaint all belong to main.ts. Past the ~4 where per-callee setters
 // stop reading as anything but noise, so it takes one host (settings.ts's deviation).
 let host: {
   renderAll: () => void;
   requestLaunch: (project: string, path: string) => void;
+  launchWorktree: (project: string, root: string, dir: string, branch: string) => void;
   launchShell: (project: string, workdir: string, opts: { colorKey?: string }) => void;
   openProjectFolder: (key: string) => void;
   addProjectPath: (dir: string) => void;
   removeFavorite: (path: string) => void;
 } = {
-  renderAll: () => {}, requestLaunch: () => {}, launchShell: () => {},
+  renderAll: () => {}, requestLaunch: () => {}, launchWorktree: () => {}, launchShell: () => {},
   openProjectFolder: () => {}, addProjectPath: () => {}, removeFavorite: () => {},
 };
 export function setProjMenuHost(h: typeof host) { host = h; }
@@ -125,9 +129,12 @@ const ctxRowHtml = (r: CtxRow) =>
   `<button class="mp-item ${r.cls || ""}" data-ctx="${r.act}"><span class="mp-ic">${r.ic}</span>`
   + `<span class="mp-main"><span class="mp-l">${esc(r.label)}</span>${r.sub ? `<span class="mp-s">${esc(r.sub)}</span>` : ""}</span>`
   + (r.chev ? `<span class="mp-chev">›</span>` : "") + `</button>`;
+const ctxRowsHtml = (rows: (CtxRow | null)[]) =>
+  rows.map((r) => (r ? ctxRowHtml(r) : `<div class="mp-sep"></div>`)).join("");
 
 function openCtxMenu(key: string, x: number, y: number) {
   closeColorPop();
+  wtTarget = null; // one #ctxMenu, one target — see the module header
   ctxKey = key;
   const fav = FAVORITES.some((f) => f.path === key);
   const live = [...sessions.values()].filter((s) => s.colorKey === key && isAgent(s)).length;
@@ -155,7 +162,7 @@ function openCtxMenu(key: string, x: number, y: number) {
     `<div class="mp-head">`
     + (ic ? `<img class="mp-hico" src="${ic}" alt="" />` : `<span class="mp-hsw" style="background:${accentFor(key)}"></span>`)
     + `<span class="mp-hmain"><span class="mp-hname">${esc(projName(key))}</span><span class="mp-hpath">${esc(tilde(key))}</span></span></div>`
-    + rows.map((r) => (r ? ctxRowHtml(r) : `<div class="mp-sep"></div>`)).join("");
+    + ctxRowsHtml(rows);
   placePop(menu, x, y);
   // A worktree only means something in a git repo. Ask *after* opening — the menu
   // must feel instant — then either name the branch it would fork from or drop the
@@ -170,8 +177,79 @@ function openCtxMenu(key: string, x: number, y: number) {
     if (sub) sub.textContent = `branch off ${b}`;
   }).catch(() => {});
 }
-export function closeCtxMenu() { $("ctxMenu").classList.remove("show"); ctxKey = null; }
+export function closeCtxMenu() { $("ctxMenu").classList.remove("show"); ctxKey = wtTarget = null; }
 export const ctxMenuOpen = () => $("ctxMenu").classList.contains("show");
+
+// ---------- worktree cluster context menu ----------
+// Right-clicking a ⑃ cluster header in the sidebar. The header's ＋ already covers
+// the one verb worth a single click; everything else a checkout can be — opened,
+// walked to in a terminal, pruned — lives here rather than as four more glyphs
+// crowding an 11px row.
+//
+// Deliberately NOT the project menu with different rows: a cluster is one checkout,
+// and its verbs act on `dir` while still belonging to `root` (the colorKey the whole
+// project groups under). Conflating them is what would put a worktree session in a
+// project group of its own — the same trap `launchWorktree` exists to avoid.
+type WtTarget = { dir: string; root: string; project: string; branch: string; isMain: boolean };
+let wtTarget: WtTarget | null = null;
+
+// What removing this checkout would actually cost, said before it is clicked. An
+// external session blocks it outright (the backend can't see one, and git would
+// delete the folder out from under it), so that row is disabled rather than offered.
+function removeRow(t: WtTarget): CtxRow {
+  const ext = externals.filter((e) => e.cwd === t.dir).length;
+  if (ext) return { act: "wtremove", ic: "⌫", label: "Remove worktree…", sub: `blocked — ${ext} session${ext > 1 ? "s" : ""} running outside Episko`, cls: "dis" };
+  const live = [...sessions.values()].filter((s) => s.workdir === t.dir).length;
+  const sub = live
+    ? `closes ${live} session${live > 1 ? "s" : ""}, then deletes the folder`
+    : "deletes the folder; the branch only if merged";
+  return { act: "wtremove", ic: "⌫", label: "Remove worktree…", sub, cls: "mp-danger" };
+}
+
+function openWtMenu(t: WtTarget, x: number, y: number) {
+  closeColorPop();
+  ctxKey = null; // one #ctxMenu, one target — see the module header
+  wtTarget = t;
+  const live = [...sessions.values()].filter((s) => s.workdir === t.dir && isAgent(s)).length;
+  const rows: (CtxRow | null)[] = [
+    { act: "wtlaunch", ic: "＋", label: "New session here", sub: live ? `${live} already running in this checkout` : "start Claude Code on this branch" },
+    { act: "wtterm", ic: "❯", label: "Open terminal here", sub: termEngine === "embedded" ? "shell pane inside Episko" : engineDef(termEngine).label },
+    null,
+    { act: "wtfolder", ic: "⌂", label: "Open checkout folder", sub: FILE_MANAGER },
+    { act: "wtcopy", ic: "⧉", label: "Copy path" },
+    null,
+    { act: "wtdialog", ic: "⑃", label: "All worktrees…", sub: "create, switch, prune" },
+    null,
+    // The main checkout is not removable and never will be — git refuses it. Saying so
+    // beats dropping the row, which would read as "Episko forgot how to prune this one".
+    t.isMain
+      ? { act: "", ic: "⌫", label: "Remove worktree…", sub: "this is the repo's main checkout", cls: "dis" }
+      : removeRow(t),
+  ];
+  const menu = $("ctxMenu");
+  menu.innerHTML =
+    `<div class="mp-head"><span class="mp-hsw" style="background:${accentFor(t.branch || t.dir)}"></span>`
+    + `<span class="mp-hmain"><span class="mp-hname">⑃ ${esc(t.branch)}</span><span class="mp-hpath">${esc(tilde(t.dir))}</span></span></div>`
+    + ctxRowsHtml(rows);
+  placePop(menu, x, y);
+}
+
+$("ctxMenu").addEventListener("click", (e) => {
+  const b = (e.target as HTMLElement).closest<HTMLElement>("[data-ctx]");
+  if (!b || !wtTarget || b.classList.contains("dis")) return;
+  const t = wtTarget;
+  closeCtxMenu(); closeColorPop();
+  switch (b.dataset.ctx) {
+    case "wtlaunch": host.launchWorktree(t.project, t.root, t.dir, t.branch); break;
+    case "wtterm": openTerminalIn(t.project, t.dir); break;
+    case "wtfolder": host.openProjectFolder(t.dir); break;
+    case "wtcopy": copyPath(t.dir); break;
+    // The dialog is the repo's, not the checkout's — open it on the root, which is
+    // also the only cwd `git worktree add` can be driven from.
+    case "wtdialog": openWt(t.project, t.root); break;
+    case "wtremove": void removeWorktreeAt(t.project, t.root, t.dir, t.branch); break;
+  }
+});
 
 // A plain shell in this project's folder — embedded gets an in-app pane, the
 // external engines their own window (the same split as openPlainTerminal).
@@ -220,7 +298,22 @@ $("ctxMenu").addEventListener("click", (e) => {
     case "removeproj": host.removeFavorite(key); toast(`Removed ${name}`); break;
   }
 });
+// `data-wt` is matched first and on its own element: a ⑃ cluster header sits inside a
+// project group, so a single `[data-key],[data-wt]` closest() would be decided by
+// which happens to be nearer in the tree rather than by what was actually clicked.
 document.addEventListener("contextmenu", (e) => {
+  const wt = (e.target as HTMLElement).closest<HTMLElement>("[data-wt]");
+  if (wt?.dataset.wt) {
+    e.preventDefault();
+    openWtMenu({
+      dir: wt.dataset.wt,
+      root: wt.dataset.root || wt.dataset.wt,
+      project: wt.dataset.proj || basename(wt.dataset.wt),
+      branch: wt.dataset.branch || basename(wt.dataset.wt),
+      isMain: wt.dataset.main === "1",
+    }, e.clientX, e.clientY);
+    return;
+  }
   const el = (e.target as HTMLElement).closest<HTMLElement>("[data-key]");
   if (!el || !el.dataset.key) return;
   e.preventDefault();

--- a/src/projmenu.ts
+++ b/src/projmenu.ts
@@ -245,10 +245,10 @@ $("ctxMenu").addEventListener("click", (e) => {
     case "wtfolder": host.openProjectFolder(t.dir); break;
     case "wtcopy": copyPath(t.dir); break;
     // The dialog is the repo's, not the checkout's — it opens on the root, which is
-    // also the only cwd `git worktree add` can be driven from. But it opens *at* this
-    // checkout (4th arg): reached from a cluster header it is the worktree list, not
-    // the launcher, and landing on the repo row would make it read as the latter.
-    case "wtdialog": openWt(t.project, t.root, null, t.dir); break;
+    // also the only cwd `git worktree add` can be driven from. But in *manage* mode
+    // and focused at this checkout: reached from a cluster header it is the worktree
+    // list, not the launcher, and every difference between the two is in `openWt`.
+    case "wtdialog": openWt(t.project, t.root, null, { manage: true, focusDir: t.dir }); break;
     case "wtremove": void removeWorktreeAt(t.project, t.root, t.dir, t.branch); break;
   }
 });

--- a/src/projmenu.ts
+++ b/src/projmenu.ts
@@ -244,9 +244,11 @@ $("ctxMenu").addEventListener("click", (e) => {
     case "wtterm": openTerminalIn(t.project, t.dir); break;
     case "wtfolder": host.openProjectFolder(t.dir); break;
     case "wtcopy": copyPath(t.dir); break;
-    // The dialog is the repo's, not the checkout's — open it on the root, which is
-    // also the only cwd `git worktree add` can be driven from.
-    case "wtdialog": openWt(t.project, t.root); break;
+    // The dialog is the repo's, not the checkout's — it opens on the root, which is
+    // also the only cwd `git worktree add` can be driven from. But it opens *at* this
+    // checkout (4th arg): reached from a cluster header it is the worktree list, not
+    // the launcher, and landing on the repo row would make it read as the latter.
+    case "wtdialog": openWt(t.project, t.root, null, t.dir); break;
     case "wtremove": void removeWorktreeAt(t.project, t.root, t.dir, t.branch); break;
   }
 });

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -134,8 +134,9 @@ export function initProjectDnD() {
   container.addEventListener("pointerdown", (e) => {
     if (e.button !== 0 || !e.isPrimary) return;
     const t = e.target as HTMLElement;
-    // Leave the interactive bits (launch +, remove ✕, colour dot) to their own clicks.
-    if (t.closest(".padd, .plaunch, .premove, .pdot, .pdirty")) return;
+    // Leave the interactive bits (launch +, per-worktree +, remove ✕, colour dot) to
+    // their own clicks.
+    if (t.closest(".padd, .wtadd, .plaunch, .premove, .pdot, .pdirty")) return;
     const g = t.closest<HTMLElement>(".pgroup");
     if (!g) return;
     candidate = g;

--- a/src/sidebarview.ts
+++ b/src/sidebarview.ts
@@ -62,9 +62,15 @@ export function groupBody(p: ProjGroup): string {
     if (cl.length >= 2) return cl.map((c) => {
       const col = branchHue(c), n = c.sessions.length + c.externals.length;
       const body = c.sessions.map((s) => sessionRow(s)).join("") + c.externals.map((e) => extRow(e)).join("");
+      // The cluster header already answers the only question the worktree dialog
+      // would ask — which checkout — so its ＋ launches straight into `c.key`.
+      // `data-root` carries the repo root separately: it is the colorKey every
+      // session in this project groups by, and a worktree's own path is not it.
+      const add = `<span class="wtadd" data-wtadd="${esc(c.key)}" data-proj="${esc(p.name)}" data-root="${esc(p.path)}"`
+        + ` data-branch="${esc(c.branch)}" title="New session in ${esc(c.branch)}">＋</span>`;
       return `<div class="wthead"><span class="wtglyph" style="color:${col}">⑃</span>`
         + `<span class="wtname" style="color:${col}" title="${esc(c.branch)}">${esc(c.branch)}</span>`
-        + `<span class="wtcount">${n}</span></div>`
+        + `<span class="wtcount">${n}</span>${add}</div>`
         + `<div class="wtsessions" style="--wtc:${col}">${body}</div>`;
     }).join("");
   } else if (wtGroup === "chip") {

--- a/src/sidebarview.ts
+++ b/src/sidebarview.ts
@@ -26,7 +26,25 @@ export const extWorking = (e: ExtSession) => !!e.status && !["idle", "sleeping",
 
 // A stable colour per branch, from the same hash as project accents so the sidebar's
 // colour language stays consistent (a branch and a project just seed different hues).
-const branchHue = (c: WtCluster) => accentFor(c.branch || c.key);
+//
+// The main checkout is the exception, and deliberately: it is seeded by its *path*,
+// which is the project's own key — so it comes out wearing the exact accent the
+// project header does, including a colour the user picked by hand. Seeded by its
+// branch it would draw a fourth unrelated hue for the one cluster that isn't a
+// separate thing at all.
+const branchHue = (c: WtCluster) => accentFor(c.isMain ? c.key : (c.branch || c.key));
+// ⑃ forks off something; the repo's own checkout is the something. Wearing the same
+// glyph as its worktrees left the project folder identifiable only by knowing which
+// branch name meant "the original", which is not knowledge the sidebar should assume —
+// a repo whose default is `develop` sitting under three `feat/*` worktrees reads as
+// four worktrees. ⌂ is the glyph the ⑃ dialog's Repo row and the project menu's "Open
+// project folder" already use for exactly this folder.
+const clusterGlyph = (c: WtCluster) => (c.isMain ? "⌂" : "⑃");
+const clusterTip = (c: WtCluster) => (c.isMain ? `${c.branch} — the project folder itself` : c.branch);
+// The branch chip a row wears in chip mode, colour-coded and hover-expanded.
+const clusterChip = (c: WtCluster) =>
+  `<span class="chip" style="--wtc:${branchHue(c)}" title="${esc(clusterTip(c))}">`
+  + `<span class="fork">${clusterGlyph(c)}</span><span class="lbl">${esc(c.branch)}</span></span>`;
 
 // `chip` (chip mode only) tags the row with its worktree's colour-coded branch,
 // which expands from a bare ⑃ to the branch name on row hover.
@@ -41,9 +59,7 @@ function sessionRow(s: Sess, chip?: WtCluster): string {
   // build reads exactly like a broken session in the rail.
   const glyph = s.kind === "shell" ? (s.phase === "ended" ? GLYPH.ended : "❯") : GLYPH[k];
   const gcls = s.kind === "shell" ? (s.phase === "ended" ? GCLASS.ended : "g-idle") : GCLASS[k];
-  const chipHtml = chip
-    ? `<span class="chip" style="--wtc:${branchHue(chip)}"><span class="fork">⑃</span><span class="lbl">${esc(chip.branch)}</span></span>`
-    : "";
+  const chipHtml = chip ? clusterChip(chip) : "";
   // A red ✕ says the turn broke; the row's tooltip says why, because "API overloaded"
   // and "auth failed" are the same glyph and completely different problems.
   const tip = s.phase === "error" && s.apiErr ? `${label} — ${apiErrText(s.apiErr)}` : label;
@@ -76,8 +92,9 @@ export function groupBody(p: ProjGroup): string {
       // whole row on saying so.
       const add = `<span class="wtadd" data-wtadd="${esc(c.key)}" data-proj="${esc(p.name)}" data-root="${esc(p.path)}"`
         + ` data-branch="${esc(c.branch)}" title="New session in ${esc(c.branch)}">＋</span>`;
-      return `<div class="wthead${n ? "" : " wtvacant"}" ${wtMenuAttrs(p, c)}><span class="wtglyph" style="color:${col}">⑃</span>`
-        + `<span class="wtname" style="color:${col}" title="${esc(c.branch)}">${esc(c.branch)}</span>`
+      return `<div class="wthead${n ? "" : " wtvacant"}" ${wtMenuAttrs(p, c)}>`
+        + `<span class="wtglyph" style="color:${col}">${clusterGlyph(c)}</span>`
+        + `<span class="wtname" style="color:${col}" title="${esc(clusterTip(c))}">${esc(c.branch)}</span>`
         + `<span class="wtcount">${n || ""}</span>${add}</div>`
         // No rows, no rail: an empty `.wtsessions` would draw a stub of left border
         // under a header that has nothing beneath it.
@@ -120,8 +137,7 @@ function wtEmptyRow(p: ProjGroup, c: WtCluster): string {
   // `o3` widens the grid for the chip and arms its hover-expand, exactly as sessionRow does.
   return `<div class="srow wtempty o3" data-wtadd="${esc(c.key)}" ${wtMenuAttrs(p, c)} title="No session here yet — start one in ${esc(tilde(c.key))}">
     <span class="sglyph g-idle">＋</span>
-    <span class="sbranch">no session</span>
-    <span class="chip" style="--wtc:${branchHue(c)}"><span class="fork">⑃</span><span class="lbl">${esc(c.branch)}</span></span></div>`;
+    <span class="sbranch">no session</span>${clusterChip(c)}</div>`;
 }
 // Dormant rows always sit below the live ones, outside any worktree cluster.
 export function dormantRows(p: ProjGroup): string {
@@ -149,9 +165,7 @@ export function dormantBusy(d: Restorable): boolean {
 }
 function extRow(e: ExtSession, chip?: WtCluster): string {
   const working = extWorking(e);
-  const chipHtml = chip
-    ? `<span class="chip" style="--wtc:${branchHue(chip)}"><span class="fork">⑃</span><span class="lbl">${esc(chip.branch)}</span></span>`
-    : "";
+  const chipHtml = chip ? clusterChip(chip) : "";
   return `<div class="srow extrow${chip ? " o3e" : ""} ${e.session_id === extMirrorId() ? "active" : ""}" data-ext="${e.session_id}" data-key="${esc(e.cwd)}">
     <span class="sglyph ${working ? "g-work" : "g-idle"}">${working ? "●" : "○"}</span>
     <span class="sbranch">${esc(e.name || basename(e.cwd))}</span>${chipHtml}

--- a/src/sidebarview.ts
+++ b/src/sidebarview.ts
@@ -76,7 +76,7 @@ export function groupBody(p: ProjGroup): string {
       // whole row on saying so.
       const add = `<span class="wtadd" data-wtadd="${esc(c.key)}" data-proj="${esc(p.name)}" data-root="${esc(p.path)}"`
         + ` data-branch="${esc(c.branch)}" title="New session in ${esc(c.branch)}">＋</span>`;
-      return `<div class="wthead${n ? "" : " wtvacant"}"><span class="wtglyph" style="color:${col}">⑃</span>`
+      return `<div class="wthead${n ? "" : " wtvacant"}" ${wtMenuAttrs(p, c)}><span class="wtglyph" style="color:${col}">⑃</span>`
         + `<span class="wtname" style="color:${col}" title="${esc(c.branch)}">${esc(c.branch)}</span>`
         + `<span class="wtcount">${n || ""}</span>${add}</div>`
         // No rows, no rail: an empty `.wtsessions` would draw a stub of left border
@@ -94,6 +94,14 @@ export function groupBody(p: ProjGroup): string {
   }
   return flat();
 }
+// What identifies one checkout to the worktree context menu (./projmenu). `data-wt`
+// is the marker its contextmenu handler matches on, and it must be matched *ahead* of
+// the `data-key` project menu — a cluster is a checkout, not the repo it belongs to.
+// The rest is everything the menu's verbs need without a second lookup.
+export function wtMenuAttrs(p: ProjGroup, c: WtCluster): string {
+  return `data-wt="${esc(c.key)}" data-root="${esc(p.path)}" data-proj="${esc(p.name)}"`
+    + ` data-branch="${esc(c.branch)}"${c.isMain ? ` data-main="1"` : ""}`;
+}
 // A checkout that exists on disk with nothing running in it. Rendered rather than
 // dropped for the same reason a blocked task is: a missing row reads as "Episko didn't
 // notice my worktree", which is exactly the gap this path was built to close.
@@ -110,7 +118,7 @@ export function groupBody(p: ProjGroup): string {
 // the cluster header's ＋ uses.
 function wtEmptyRow(p: ProjGroup, c: WtCluster): string {
   // `o3` widens the grid for the chip and arms its hover-expand, exactly as sessionRow does.
-  return `<div class="srow wtempty o3" data-wtadd="${esc(c.key)}" data-root="${esc(p.path)}" data-proj="${esc(p.name)}" data-branch="${esc(c.branch)}" title="No session here yet — start one in ${esc(tilde(c.key))}">
+  return `<div class="srow wtempty o3" data-wtadd="${esc(c.key)}" ${wtMenuAttrs(p, c)} title="No session here yet — start one in ${esc(tilde(c.key))}">
     <span class="sglyph g-idle">＋</span>
     <span class="sbranch">no session</span>
     <span class="chip" style="--wtc:${branchHue(c)}"><span class="fork">⑃</span><span class="lbl">${esc(c.branch)}</span></span></div>`;

--- a/src/styles.css
+++ b/src/styles.css
@@ -241,17 +241,20 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .wtglyph { flex: none; width: 13px; text-align: center; font-size: 11px; line-height: 1; }
 .wtname { min-width: 0; font-size: 11px; font-weight: 600; letter-spacing: -.01em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .wtcount { flex: none; margin-left: auto; font: 600 9px var(--font-mono); color: var(--muted-2); }
-/* Per-cluster ＋ — a session straight into that checkout, no dialog. Dimmed until the
-   header is hovered so a repo with five worktrees isn't five loud plus signs. */
-.wtadd { flex: none; margin-left: 5px; padding: 0 2px; font-size: 12px; line-height: 1; color: var(--muted-2); opacity: .4; cursor: pointer; border-radius: 5px; transition: opacity .12s, color .12s; }
+/* Per-cluster ＋ — a session straight into that checkout, no dialog. Hidden until the
+   header is hovered, the same way .plaunch is: a repo with five worktrees is five
+   headers, and a standing ＋ on each turns the list into a column of plus signs.
+   Opacity, not display — the count sits on `margin-left: auto`, so removing the ＋
+   from flow would slide it right every time the pointer left the row. */
+.wtadd { flex: none; margin-left: 5px; padding: 0 2px; font-size: 12px; line-height: 1; color: var(--muted-2); opacity: 0; cursor: pointer; border-radius: 5px; transition: opacity .12s, color .12s; }
 .wthead:hover .wtadd { opacity: 1; }
 .wtadd:hover { color: var(--text); background: var(--surface-2); }
 .wtsessions { padding-left: 8px; margin-left: 6px; border-left: 1px solid color-mix(in srgb, var(--wtc, var(--hair)) 45%, transparent); display: flex; flex-direction: column; gap: 1px; }
 /* A cluster with nothing running in it. The header is the whole row — it renders with
-   or without sessions, so an idle checkout costs one line instead of two, and its ＋
-   stays legible unhovered because it is the only thing there is to do here. */
+   or without sessions, so an idle checkout costs one line instead of two. Dimmed, but
+   still hover-to-＋ like every other header: it is one of a list, and the one thing it
+   must do unprompted is say the checkout is there. */
 .wthead.wtvacant .wtglyph, .wthead.wtvacant .wtname { opacity: .55; }
-.wthead.wtvacant .wtadd { opacity: .75; }
 /* chip mode has no cluster headers, so an idle checkout still needs a row of its own:
    present, but clearly not a session */
 .srow.wtempty .sbranch { font-style: italic; color: var(--muted-2); }

--- a/src/styles.css
+++ b/src/styles.css
@@ -167,8 +167,12 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .rail-add::after { width: 1.6px; height: 10px; }
 
 .pgroup { margin-bottom: 3px; }
-/* While reordering (pointer-driven), suppress text selection across the whole list. */
+/* While reordering (pointer-driven), suppress text selection across the whole list —
+   and hold the grabbing cursor over every row the pointer crosses, since the buttons
+   and rows below are pointer/default the rest of the time. The #id beats their classes,
+   so no !important is needed. */
 #projects.reordering { user-select: none; }
+#projects.reordering, #projects.reordering * { cursor: grabbing; }
 /* The dragged group fades in place; a .dropmark separator line shows where it lands. */
 .pgroup.dragging { opacity: .38; }
 .pgroup.dragging .phead { cursor: grabbing; }
@@ -201,11 +205,13 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .pcount { flex: none; margin-left: auto; font: 600 10px var(--font-mono); color: var(--muted-2); background: var(--surface-2); padding: 1px 6px; border-radius: 6px; }
 /* project has uncommitted changes in one of its folders — sits right after the name */
 .pdirty { flex: none; width: 6px; height: 6px; border-radius: 50%; background: var(--st-working); box-shadow: 0 0 5px color-mix(in srgb, var(--st-working) 70%, transparent); }
-.padd { flex: none; font-size: 13px; color: var(--muted-2); padding: 0 2px; }
+/* The header body is the drag handle (cursor: grab), but its buttons are not — they
+   click, so they say so. Same for every other interactive bit nested in a .pgroup. */
+.padd { flex: none; font-size: 13px; color: var(--muted-2); padding: 0 2px; cursor: pointer; }
 .padd:hover { color: var(--text); }
 .phead.empty-p .pname { color: var(--muted-2); font-weight: 550; }
 .phead.empty-p .pdot { opacity: .5; }
-.plaunch { flex: none; margin-left: auto; font-size: 10px; color: var(--muted-2); opacity: 0; transition: opacity .12s; }
+.plaunch { flex: none; margin-left: auto; font-size: 10px; color: var(--muted-2); opacity: 0; cursor: pointer; transition: opacity .12s; }
 .phead.empty-p:hover .plaunch { opacity: 1; }
 .premove { flex: none; margin-left: 7px; opacity: 0; color: var(--muted-2); font-size: 10px; cursor: pointer; transition: opacity .12s, color .12s; }
 .phead.empty-p:hover .premove { opacity: .75; }
@@ -235,6 +241,11 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .wtglyph { flex: none; width: 13px; text-align: center; font-size: 11px; line-height: 1; }
 .wtname { min-width: 0; font-size: 11px; font-weight: 600; letter-spacing: -.01em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .wtcount { flex: none; margin-left: auto; font: 600 9px var(--font-mono); color: var(--muted-2); }
+/* Per-cluster ＋ — a session straight into that checkout, no dialog. Dimmed until the
+   header is hovered so a repo with five worktrees isn't five loud plus signs. */
+.wtadd { flex: none; margin-left: 5px; padding: 0 2px; font-size: 12px; line-height: 1; color: var(--muted-2); opacity: .4; cursor: pointer; border-radius: 5px; transition: opacity .12s, color .12s; }
+.wthead:hover .wtadd { opacity: 1; }
+.wtadd:hover { color: var(--text); background: var(--surface-2); }
 .wtsessions { padding-left: 8px; margin-left: 6px; border-left: 1px solid color-mix(in srgb, var(--wtc, var(--hair)) 45%, transparent); display: flex; flex-direction: column; gap: 1px; }
 /* toplevel mode: the branch suffix on a per-worktree group header */
 .pwt { margin-left: 5px; color: var(--muted-2); font-weight: 550; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -237,7 +237,15 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 /* subheader mode: a ⑃-branch cluster header, its sessions nested under a tinted rule */
 /* padding-left 0 + a 13px glyph box centres the ⑃ (box centre 6.5px) on the
    .wtsessions border-left below it (margin-left 6px + 0.5px half-border) */
-.wthead { display: flex; align-items: center; gap: 7px; padding: 4px 8px 2px 0; margin-top: 1px; }
+/* `cursor: default`, not `text` and not `pointer`: the header body does nothing on a
+   left click (the ＋ and the right-click menu are what act), so an I-beam invites a
+   selection nobody wants and a hand would promise a click that isn't there.
+   `user-select: none` for the same reason — dragging across it only ever highlighted
+   the branch name. The reorder's `#projects.reordering *` still outspecifies both. */
+.wthead { display: flex; align-items: center; gap: 7px; padding: 4px 8px 2px 0; margin-top: 1px; border-radius: 7px; cursor: default; user-select: none; }
+/* The whole header lights, not just the ＋ — it is one hover target (right-click menu,
+   ＋, and the rows it names), so lighting only the ＋ made the rest look inert. */
+.wthead:hover { background: var(--surface); }
 .wtglyph { flex: none; width: 13px; text-align: center; font-size: 11px; line-height: 1; }
 .wtname { min-width: 0; font-size: 11px; font-weight: 600; letter-spacing: -.01em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .wtcount { flex: none; margin-left: auto; font: 600 9px var(--font-mono); color: var(--muted-2); }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1086,6 +1086,10 @@ select.in-ctl { cursor: pointer; }
 .ctxmenu .mp-chev { margin-left: auto; padding-left: 6px; color: var(--muted-2); font-size: 13px; }
 .ctxmenu .mp-item.sub-open { background: var(--surface); }
 .ctxmenu .mp-danger .mp-ic, .ctxmenu .mp-danger .mp-l { color: var(--st-attention); }
+/* A verb that cannot run stays listed and says why — dropping the row would read as
+   "Episko forgot how to do this". Same shape the branch popover uses for its own. */
+.ctxmenu .mp-item.dis { cursor: not-allowed; opacity: .55; }
+.ctxmenu .mp-item.dis:hover { background: transparent; }
 
 /* "x needs you" dropdown (multiple sessions awaiting attention) */
 .attn-badge.multi::after { content: "▾"; font-size: 8px; margin-left: 1px; opacity: .7; }

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -147,34 +147,59 @@ function wtUpstreamHtml(b: BranchInfo): string {
     + (b.behind ? ` · ↓${b.behind} unpulled` : "");
 }
 
-// `focusDir` opens the dialog **at** a checkout rather than at the repo: the row for
-// that directory is selected, so the detail pane is about it from the first frame.
-// That is also what makes this the worktree view rather than the launcher — the one
-// caller that passes it (a ⑃ cluster's context menu) already knows where a session
-// would go, so what it wants is the list itself: what exists, what's dirty, what can
-// be pruned. Retitled to say so, because a dialog headed "New session" reads as a
-// launcher whatever is highlighted in it.
-export async function openWt(project: string, repoDir: string, knownBranch?: string | null, focusDir?: string) {
+// One dialog, two doors. **launch** is the original: "where should this session
+// start?", so every branch in the repo is a row, because starting on one is the whole
+// point. **manage** is what a ⑃ cluster's context menu opens — the caller already knows
+// where a session would go, so what it wants is the checkouts themselves: what exists,
+// what's dirty, what can be pruned.
+//
+// The difference is framing, not machinery. The detail pane was always a management
+// surface (folder, HEAD, working tree, merged-or-not, the removal flow and every
+// warning about a locked / detached / vanished checkout); what made it read as a
+// launcher is what surrounds it. So manage mode drops the three pieces that are about
+// *starting* something and keeps the rest:
+//
+//   - **Branches only once you type.** With an empty query the list is the repo plus
+//     its worktrees — a couple of rows. In launch mode that same list is padded with
+//     every branch, which in a real repo buries the four checkouts you came to look
+//     at. Typing still surfaces them, because creating a worktree on a branch is
+//     management and a manager that can't add one is a viewer.
+//   - **No engine chip.** "New sessions open in Embedded" answers a question nobody
+//     asked here.
+//   - **"N checkouts", not "N destinations"** — a destination is somewhere you launch.
+//
+// ⏎ still starts a session, and the row's own `verb` still says so. Changing what
+// Enter does between two modes of one dialog is a worse trap than a verb that is
+// occasionally not what you came for, and the detail pane's buttons are right there.
+type WtMode = "launch" | "manage";
+let wtMode: WtMode = "launch";
+export async function openWt(project: string, repoDir: string, knownBranch?: string | null, opts: { manage?: boolean; focusDir?: string } = {}) {
   wtCtx = { project, repoDir };
   wtSel = 0; wtArmed = ""; wtBusy = false; wtBase = ""; wtSwitchTo = ""; wtFetchedAt = 0;
   wtRepoBranch = knownBranch || "";   // seeded by requestLaunch, which already asked
-  ($("wtQ") as HTMLInputElement).value = "";
-  const title = focusDir ? "Worktrees" : "New session";
-  $("wtTitle").textContent = title;   // one dialog, two doors — reset it every open
+  wtMode = opts.manage ? "manage" : "launch";
+  const manage = wtMode === "manage";
+  const q = $("wtQ") as HTMLInputElement;
+  q.value = "";
+  q.placeholder = manage ? "Filter checkouts, or type a branch to add one…" : "Filter, or type a new branch name…";
+  const title = manage ? "Worktrees" : "New session";
+  $("wtTitle").textContent = title;   // every one of these resets: the element is shared
   $("wtDlg").setAttribute("aria-label", title);
+  $("wtList").setAttribute("aria-label", manage ? "Checkouts" : "Session destinations");
   $("wtProj").textContent = project;
   $("wtPath").textContent = repoDir;
   const eng = engineDef(termEngine);
   $("wtEng").textContent = `${termEngine === "embedded" ? "▤" : "⧉"} ${eng.label}`;
   ($("wtEng") as HTMLElement).title = `New sessions open in ${eng.label}`;
+  ($("wtEng") as HTMLElement).style.display = manage ? "none" : "";
   $("scrim").classList.add("show"); $("wtDlg").classList.add("show");
-  setTimeout(() => ($("wtQ") as HTMLInputElement).focus(), 30);
+  setTimeout(() => q.focus(), 30);
   clearInterval(wtAgeT); wtAgeT = window.setInterval(wtTickAge, 1000);
   await wtLoad();
   // After the first read, since that is what builds the rows to search. A checkout git
   // no longer lists (removed under us) simply leaves the repo row selected.
-  if (focusDir && wtCtx) {   // …and not if it was closed while the read was in flight
-    const i = wtRows.findIndex((d) => d.dir === focusDir);
+  if (opts.focusDir && wtCtx) {   // …and not if it was closed while the read was in flight
+    const i = wtRows.findIndex((d) => d.dir === opts.focusDir);
     if (i > 0) { wtSel = i; wtRender(); }
   }
 }
@@ -324,8 +349,14 @@ function wtBuild(): Dest[] {
   // Branches you could start a NEW worktree on. The current branch (the repo row) and
   // any already checked out (the worktrees above) are excluded — git refuses either a
   // second time, so offering them would only produce an error.
+  //
+  // In manage mode they wait for a query: unfiltered, every branch in the repo sits
+  // below the handful of checkouts you opened this to look at. Gated on `q` rather than
+  // dropped, because "add a worktree on an existing branch" is management too — and
+  // dropping them would strand it, since the create row suppresses itself for a name
+  // that is already a branch.
   const STALE = 45 * 86400, now = Date.now() / 1000;
-  for (const b of wtBranches) {
+  for (const b of wtMode === "manage" && !q ? [] : wtBranches) {
     if (b.current || b.checked_out || !hit(b.name)) continue;
     const clash = wtWts.find((w) => !w.is_main && basename(w.path) === wtSlug(b.name));
     out.push({
@@ -370,7 +401,8 @@ function wtRender() {
     html += `<div class="wt-empty"><b>Nothing matches that</b>Clear the filter, or type a branch name to create one</div>`;
   }
   $("wtList").innerHTML = html;
-  $("wtCount").textContent = wtLoading ? "" : wtRows.length ? `${wtRows.length} destinations` : "";
+  $("wtCount").textContent = wtLoading || !wtRows.length ? ""
+    : `${wtRows.length} ${wtMode === "manage" ? (wtRows.length === 1 ? "checkout" : "checkouts") : "destinations"}`;
   $("wtVerb").textContent = cur ? cur.verb : "—";
   $("wtDetail").innerHTML = wtDetailHtml(cur);
   $("wtList").querySelector(".wt-item.on")?.scrollIntoView({ block: "nearest" });

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -19,7 +19,7 @@ import { $, dropScrim, toast } from "./dom";
 import { dlog } from "./debug";
 import { basename, esc } from "./format";
 import type { DiffStat, GitActionResult, Phase, Sess } from "./types";
-import { engineDef, sessions, termEngine } from "./state";
+import { engineDef, externals, sessions, termEngine } from "./state";
 
 type LaunchOpts = { colorKey?: string; worktree?: string | null; branch?: string; resume?: string };
 let launch: (project: string, workdir: string, opts?: LaunchOpts) => Promise<void> = async () => {};
@@ -34,6 +34,12 @@ export function setWtRenderAll(fn: typeof renderAll) { renderAll = fn; }
 // window) and the launch engine — main.ts territory, same as the four above.
 let handToTerminal: (project: string, workdir: string, cmd: string, opts?: { colorKey?: string; worktree?: string | null; branch?: string }) => Promise<void> = async () => {};
 export function setWtHandToTerminal(fn: typeof handToTerminal) { handToTerminal = fn; }
+// A removal here is the one change to "what checkouts exist" the app makes itself, so
+// it is the one it must not wait on the poll to notice — the sidebar's ⑃ roster comes
+// from `worktree_heads`, which `renderAll` only paints, never re-reads. A hook rather
+// than an import because panes.ts already imports this module.
+let refreshGitViews: () => Promise<void> = async () => {};
+export function setWtRefreshGit(fn: typeof refreshGitViews) { refreshGitViews = fn; }
 
 // Every answer to "where should this session run?" is a directory, so every answer
 // is a row: the repo itself, its worktrees, its branches, and whatever you type.
@@ -834,35 +840,63 @@ async function wtDoRemove(deleteBranch: boolean) {
       return;
     }
     wtArmed = "";
-    await wtLoad(true);
+    await wtLoad(true);                 // this dialog's own list…
+    if (r.ok) await refreshGitViews();  // …and the ⑃ roster the sidebar draws behind it
   } catch (e) {
     dlog("error", `worktree remove failed: ${e}`);
     toast("worktree: " + e);
   } finally { wtBusy = false; renderAll(); }
 }
 
-// The action-panel "Remove this worktree" flow: guard uncommitted work, then close
-// the session and remove its worktree (safe-deleting the branch if it's merged).
-export async function removeWorktreeSession(s: Sess) {
-  const repoDir = s.colorKey, path = s.workdir, branch = s.branch;
+// The action-panel "Remove this worktree" flow: a session names its own checkout, so
+// this is just the path-keyed removal below pointed at it.
+export function removeWorktreeSession(s: Sess) {
+  return removeWorktreeAt(s.project, s.colorKey, s.workdir, s.branch);
+}
+// Remove the checkout at `path`, whatever is (or isn't) running in it: guard
+// uncommitted work, close the sessions living there, then remove the worktree and
+// safe-delete its branch. The sidebar's ⑃ cluster menu is the other caller, and it
+// is why this is keyed by path rather than by session — a cluster can hold none,
+// one or several, and an empty one is exactly the checkout you most want to prune.
+//
+// The backend refuses while an *Episko* session runs in the tree, so those are closed
+// here first. It cannot see an external one, so that case is refused rather than
+// worked around: `git worktree remove` would delete the folder out from under an
+// agent running in someone else's terminal.
+export async function removeWorktreeAt(project: string, repoDir: string, path: string, branch: string) {
+  const label = branch || basename(path);
+  if (externals.some((e) => e.cwd === path)) {
+    toast(`${label}: a session outside Episko is running there — close it first`);
+    return;
+  }
+  const live = wtSessionsIn(path);
   // Never close a session that still has a dirty tree — hand the decision (and a
   // shell) over instead. git_diffstat is null for a non-repo; treat that as "clean
   // enough to try", since the backend still refuses (without forcing) if it's wrong.
   const ds = await invoke<DiffStat | null>("git_diffstat", { workdir: path }).catch(() => null);
   if (ds && ds.dirty > 0) {
-    toast(`${branch || "worktree"}: uncommitted changes — commit or discard first`);
-    await handToTerminal(s.project, path, "git status", { colorKey: repoDir, worktree: s.worktree, branch });
+    toast(`${label}: uncommitted changes — commit or discard first`);
+    await handToTerminal(project, path, "git status", { colorKey: repoDir, worktree: branch, branch });
     return;
   }
-  if (!await ask(`Remove the worktree at ${basename(path)}/?\n\nIts session closes, the folder goes, and its branch is deleted only if it's fully merged.`,
+  const closes = live.length === 0 ? "Nothing is running in it"
+    : live.length === 1 ? "Its session closes"
+    : `Its ${live.length} sessions close`;
+  if (!await ask(`Remove the worktree at ${basename(path)}/?\n\n${closes}, the folder goes, and its branch is deleted only if it's fully merged.`,
     { title: "Remove worktree", kind: "warning", okLabel: "Remove", cancelLabel: "Cancel" })) return;
-  closeSession(s.id);
-  await invoke("kill_session", { sessionId: s.id }).catch(() => {}); // ensure the backend guard sees it gone
+  for (const s of live) {
+    closeSession(s.id);
+    await invoke("kill_session", { sessionId: s.id }).catch(() => {}); // ensure the backend guard sees it gone
+  }
   try {
     const r = await invoke<GitActionResult>("remove_worktree", { repoDir, path, branch, deleteBranch: true });
-    dlog(r.ok ? "info" : "warn", `worktree remove · ${branch || path} · ${r.summary}`);
-    if (r.ok) toast(r.summary);
-    else if (r.suggest) { toast(`${r.summary} → opening a terminal`); await handToTerminal(s.project, repoDir, r.suggest, { colorKey: repoDir }); }
+    dlog(r.ok ? "info" : "warn", `worktree remove · ${label} · ${r.summary}`);
+    // The cluster this was invoked from is drawn from the ⑃ roster, which only a
+    // re-read drops — renderAll alone would leave the header on screen until the poll.
+    if (r.ok) { toast(r.summary); await refreshGitViews(); }
+    // The handoff must run from the repo root, never the worktree being deleted —
+    // git refuses to remove the tree you're standing in.
+    else if (r.suggest) { toast(`${r.summary} → opening a terminal`); await handToTerminal(project, repoDir, r.suggest, { colorKey: repoDir }); }
     else toast(r.summary);
   } catch (e) {
     dlog("error", `worktree remove failed: ${e}`);

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -147,11 +147,21 @@ function wtUpstreamHtml(b: BranchInfo): string {
     + (b.behind ? ` · ↓${b.behind} unpulled` : "");
 }
 
-export async function openWt(project: string, repoDir: string, knownBranch?: string | null) {
+// `focusDir` opens the dialog **at** a checkout rather than at the repo: the row for
+// that directory is selected, so the detail pane is about it from the first frame.
+// That is also what makes this the worktree view rather than the launcher — the one
+// caller that passes it (a ⑃ cluster's context menu) already knows where a session
+// would go, so what it wants is the list itself: what exists, what's dirty, what can
+// be pruned. Retitled to say so, because a dialog headed "New session" reads as a
+// launcher whatever is highlighted in it.
+export async function openWt(project: string, repoDir: string, knownBranch?: string | null, focusDir?: string) {
   wtCtx = { project, repoDir };
   wtSel = 0; wtArmed = ""; wtBusy = false; wtBase = ""; wtSwitchTo = ""; wtFetchedAt = 0;
   wtRepoBranch = knownBranch || "";   // seeded by requestLaunch, which already asked
   ($("wtQ") as HTMLInputElement).value = "";
+  const title = focusDir ? "Worktrees" : "New session";
+  $("wtTitle").textContent = title;   // one dialog, two doors — reset it every open
+  $("wtDlg").setAttribute("aria-label", title);
   $("wtProj").textContent = project;
   $("wtPath").textContent = repoDir;
   const eng = engineDef(termEngine);
@@ -161,6 +171,12 @@ export async function openWt(project: string, repoDir: string, knownBranch?: str
   setTimeout(() => ($("wtQ") as HTMLInputElement).focus(), 30);
   clearInterval(wtAgeT); wtAgeT = window.setInterval(wtTickAge, 1000);
   await wtLoad();
+  // After the first read, since that is what builds the rows to search. A checkout git
+  // no longer lists (removed under us) simply leaves the repo row selected.
+  if (focusDir && wtCtx) {   // …and not if it was closed while the read was in flight
+    const i = wtRows.findIndex((d) => d.dir === focusDir);
+    if (i > 0) { wtSel = i; wtRender(); }
+  }
 }
 
 // Both lists cost several git calls (a status probe per checkout, a rev-list per ref),


### PR DESCRIPTION
## What

Supersedes the original scope of this PR. The `＋` on each `⑃` cluster header
landed first; then `dev` grew the worktree roster (#40), which had shipped its own
answer to the same question — a `＋ no session` row. Merging the two resolved that,
and the header turned out to be the right place to hang everything *else* a
checkout can be, too.

Three things, in the order they were committed.

### 1. The merge: the cluster header wins

The `＋ no session` row goes. It cost two lines per idle checkout to state what
the header already showed, and a repo with four worktrees you aren't currently
working in gave up four rows of sidebar to say so.

The header renders whether or not anything runs beneath it, so an empty cluster is
now one dimmed line (`.wtvacant`) carrying the same `＋`. An empty cluster also
drops its `.wtsessions`, which would otherwise draw a stub of left border under a
header with no rows.

`wtEmptyRow` survives for **chip** mode alone, which has no cluster headers to hang
anything on — without the row an idle checkout would have nowhere at all to appear
there, which is the gap the roster was built to close.

The two launch paths were the same function written twice, so `data-wtlaunch` folds
into `data-wtadd` → `launchWorktree`. That is also the more correct of the two: it
passes `worktree: null` for the repo's own checkout, where the old row would have
labelled the main tree a worktree of itself.

### 2. Right-click a `⑃` cluster header

The header's `＋` covers the one verb worth a single click. Everything else a
checkout can be — walked to in a terminal, opened, copied, pruned — would have been
four more glyphs crowding an 11px row, so it goes behind a context menu instead.
Removing a worktree in particular had no home in the sidebar at all: you opened the
`⑃` dialog, found the row again, and armed it there.

It is deliberately **not** the project menu with different rows. A cluster is one
checkout, and its verbs act on `dir` while it still belongs to `root` — the colorKey
the whole project groups under. Get that backwards and a session started here splits
off into a project group of its own, the same trap `launchWorktree` exists to avoid.
`data-wt` is matched *ahead* of `data-key` in the `contextmenu` handler for the same
reason: a cluster header sits inside a project group, so one combined `closest()`
would be decided by tree distance rather than by what was clicked.

**Removal is keyed by path, not by session.** `removeWorktreeSession` was the action
panel's and could only ever mean "this pane's checkout" — a cluster holds none, one
or several, and the empty one is exactly the checkout you most want to prune. It
becomes a one-line call into `removeWorktreeAt`, which keeps every guard it had
(dirty tree → a terminal with `git status`, never `--force`, branch deleted only if
merged) and adds the two the plural case needs:

- **An external session refuses the removal outright.** The backend's guard reads
  `AppState.sessions`, so it cannot see one — and `git worktree remove` would delete
  the folder out from under an agent running in someone else's terminal. The menu row
  says so and greys itself rather than letting the click fail.
- **The confirm counts what closes.** "Its 3 sessions close" and "Nothing is running
  in it" are very different things to agree to.

Both removal paths now call `refreshGitViews` on success. The sidebar's `⑃` roster
comes from `worktree_heads`, which `renderAll` only ever *paints* — so without the
re-read the cluster you just deleted sat there until the next poll.

### 3. The `＋` is hover-only

`.4` unhovered still read as a column of plus signs down a repo with several
worktrees — the noise the row it replaced was removed for. Hidden until the header
is hovered, the way `.plaunch` already is on an empty project head. The
vacant-cluster exception went with it: holding that one `＋` at `.75` made the idle
checkouts the loudest thing in the list, which is backwards.

Still opacity rather than display — `.wtcount` sits on `margin-left: auto`, so
taking the `＋` out of flow would slide the count right every time the pointer left.

## Also in here (from the original PR)

**Cursors that mean what they say.** `.padd` and `.plaunch` sat inside `.phead`,
which is `cursor: grab` because it's the reorder drag handle — so both buttons
inherited the grab hand. They're `pointer` now, as is `.wtadd`. A live reorder holds
`grabbing` across every row the pointer crosses (`#projects.reordering *` — the `#id`
outspecifies those classes, so no `!important`). The project header *body* keeps
`grab`: it genuinely is the drag handle.

## Verification

`pnpm exec tsc --noEmit`, the 408 vitest tests and `pnpm build` all pass, and a
cycle check confirms no import cycles. `CLAUDE.md` is updated in the same commits.

The sidebar and the menu are render/DOM code and untested by design, so the
hover-reveal, the right-click and the removal itself still want a click-through in
the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
