### PR TITLE
fix: Ctrl+Shift+C/V copy and paste in shell and task panes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,8 +338,20 @@ And the things that hold however the files are arranged:
   handled separately in `winClaudePaste`, alongside it, via
   `attachCustomKeyEventHandler` — note xterm keeps only **one** such handler, so a
   new key rule belongs in that function or in `claudeInput`, never in a second
-  `attachCustomKeyEventHandler` call. (`macShellKeys`, also in `terminal.ts`, is the
-  *shell* pane's handler; no pane is both, so the two never collide.)
+  `attachCustomKeyEventHandler` call. A shell pane's one handler is `shellKeys` and a
+  task pane's is `clipboardKeys`, both also in `terminal.ts`; no pane is more than one
+  kind, so the three never collide.
+- **Copy/paste in a shell or task pane is Ctrl+Shift+C/V, and it is ours.** The
+  unshifted chords aren't available: Ctrl+C is the interrupt those panes exist to send,
+  and xterm eats Ctrl+V into a dead `^V`. So `clipboardKeys` claims the shifted pair —
+  the same chords Windows Terminal, GNOME Terminal and VS Code's terminal use — while
+  macOS's ⌘C/⌘V still reach the WebView's native copy/paste untouched. It reads and
+  writes through **`tauri-plugin-clipboard-manager`, not `navigator.clipboard`**:
+  `readText()` in the WebView is behind the `clipboard-read` permission, which wry only
+  auto-grants for a webview built with `enable_clipboard_access()` (Tauri leaves it
+  off), so the browser path would raise a WebView2 permission prompt on Windows and
+  WKWebView's paste-confirmation button on macOS. Pasting goes through `term.paste`
+  rather than `write_pty` so bracketed-paste mode and `\r\n`→`\r` still apply.
 - **Event wiring**: `listen("pty-output" | "pty-exit" | "telemetry" | "permission" | "tray-select")` at the bottom of `main.ts`. Telemetry is routed by `data.session_id?.toLowerCase()` — session ids are matched case-insensitively, so keep them lowercase.
 - `applyHook` maps lifecycle events → a `Phase` state machine (idle/thinking/working/done/error/ended) and attention flags; `applyStatusline` fills model/context%/cost/duration. **Rate limits are account-wide**, held in a single `rl` object and shown identically on every session, not per-session.
 - **A turn that died is not a turn that finished, and only one hook knows which.** Claude Code fires `StopFailure` (not `Stop`) when the API kills a turn — a 529, a rate limit, a dead key — carrying an `error` enum (`overloaded`, `rate_limit`, `authentication_failed`, `max_output_tokens`, …) and the `error_details` text the pane shows. Everything *after* that point looks identical to a clean finish: the same 60-second idle `Notification` (`notification_type: "idle_prompt"`) arrives either way. Unguarded it relabelled the turn "your turn" and turned the red ✕ green a minute after the failure — which shipped, and is why `Sess.apiErr` exists. It is set by `StopFailure`, cleared only when the session genuinely starts another turn (`UserPromptSubmit` / `PreToolUse` / `SessionStart` / `SessionEnd`), and **`endTurn` is the single place that decides done vs. error** — both `Stop` and the idle nudge go through it, and the run-on-stop rule is skipped while it's set. Every surface that spells a state out reads `phaseText(s)`, not `PILL_TEXT[s.phase]`, so the reason travels with the glyph: "API overloaded" means wait, "auth failed" means go fix your credentials, and a bare ✕ means neither.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -109,6 +109,12 @@ A regression in either is silent.
       In a **shell** pane the same keystroke must still kill the process outright.
 - [ ] **Windows only: Ctrl+V pastes an image** into a claude pane (copy a screenshot
       first). Plain text paste must still work in the same pane.
+- [ ] **Ctrl+Shift+C / Ctrl+Shift+V copy and paste** in a **shell** pane and in a
+      **task** pane. Select output with the mouse, Ctrl+Shift+C (a "Copied" toast, and
+      it must land in another app's clipboard), then Ctrl+Shift+V into a prompt and see
+      the text arrive intact. Neither chord may raise an OS clipboard-permission
+      prompt — one means the WebView served it rather than the plugin. Plain Ctrl+C in
+      those panes must still interrupt, and on macOS ⌘C/⌘V must still work.
 - [ ] **The sidebar still repaints when it should.** `renderSidebar` now skips the
       `innerHTML` write when the markup is byte-identical, so watch that a phase
       change, an arriving permission, a new session, and closing one *all* still move

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.11.1
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.3.2
+        version: 2.3.2
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.1
         version: 2.7.1
@@ -457,6 +460,9 @@ packages:
     resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
   '@tauri-apps/plugin-dialog@2.7.1':
     resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
@@ -986,6 +992,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-dialog@2.7.1':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -86,6 +86,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +549,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +658,12 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -849,7 +885,7 @@ checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser",
- "foldhash",
+ "foldhash 0.2.0",
  "html5ever",
  "precomputed-hash",
  "selectors",
@@ -984,6 +1020,7 @@ dependencies = [
  "sysinfo",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-opener",
@@ -1023,6 +1060,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1103,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1117,6 +1166,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,6 +1186,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1368,6 +1429,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,6 +1621,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,6 +1644,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1870,6 +1961,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2320,6 +2412,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2394,6 +2495,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -2632,6 +2734,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2704,6 +2816,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -2943,6 +3066,12 @@ name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -4004,6 +4133,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4291,6 +4435,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4619,6 +4777,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4890,6 +5059,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.13.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4999,6 +5238,12 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -5535,6 +5780,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5604,6 +5867,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"
@@ -5796,6 +6076,21 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,10 @@ base64 = "0.22.1"
 tauri-plugin-dialog = "2.7.1"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+# Terminal copy/paste. The WebView's own `navigator.clipboard.readText()` is behind
+# a permission prompt in both WebView2 and WKWebView (see the comment in `run()`),
+# so the clipboard is read and written from the host side instead.
+tauri-plugin-clipboard-manager = "2"
 # Runnable discovery: .episko/tasks.toml, and format-preserving writes back to it.
 toml = "0.9"
 toml_edit = "0.25.13"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,8 @@
     "opener:default",
     "dialog:default",
     "updater:default",
-    "process:default"
+    "process:default",
+    "clipboard-manager:allow-read-text",
+    "clipboard-manager:allow-write-text"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -216,6 +216,13 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        // Terminal copy/paste (Ctrl+Shift+C / Ctrl+Shift+V) reads and writes the
+        // clipboard from here rather than through `navigator.clipboard`: reading it
+        // in the WebView needs the `clipboard-read` permission, which wry only
+        // auto-grants when the webview was built with `enable_clipboard_access()`
+        // (Tauri leaves it off), so WebView2 would raise its own permission prompt
+        // and WKWebView its paste-confirmation button. See `clipboardKeys`.
+        .plugin(tauri_plugin_clipboard_manager::init())
         // Windows analog of the macOS Cmd+Q catcher in `setup` below: Windows gets
         // no app menu (see there), so quitting means closing the window. Intercept
         // the close and run the same frontend confirm flow — only `confirm_quit`

--- a/src/footer.ts
+++ b/src/footer.ts
@@ -10,7 +10,7 @@
 // refreshes the usage one only while it is actually shown).
 
 import { invoke } from "@tauri-apps/api/core";
-import { $, FILE_MANAGER, toast } from "./dom";
+import { $, FILE_MANAGER, IS_MAC, toast } from "./dom";
 import { dlog } from "./debug";
 import { esc, fmtUntil } from "./format";
 import { abbr } from "./phase";
@@ -102,7 +102,11 @@ export function closeFootMenus(keep?: string) {
   for (const [id, close] of menus) if (id !== keep) close();
 }
 // Keyboard shortcuts, listed in the footer's ⌘ Shortcuts popover. Keep in sync with
-// the global keydown handler (the sole source of truth for what these actually do).
+// the global keydown handler (the sole source of truth for what these actually do) —
+// bar the last row, which belongs to a terminal pane and lives in `clipboardKeys`.
+// That one is spelled per-platform because it genuinely differs: ⌘C/⌘V reach the
+// WebView's native copy/paste on macOS, while everywhere else Ctrl+C is the interrupt
+// and Ctrl+V a dead key, so only the shifted pair is left.
 const SHORTCUTS: { label: string; chords: string[][] }[] = [
   { label: "Command palette", chords: [["⌘", "K"]] },
   { label: "Switch to session 1–9", chords: [["⌘", "1–9"]] },
@@ -113,6 +117,10 @@ const SHORTCUTS: { label: string; chords: string[][] }[] = [
   { label: "Toggle inspector", chords: [["⌘", "I"]] },
   { label: "Settings", chords: [["⌘", ","]] },
   { label: "Terminal font size", chords: [["⌘", "+"], ["⌘", "−"], ["⌘", "0"]] },
+  {
+    label: "Copy / paste in a terminal",
+    chords: IS_MAC ? [["⌘", "C"], ["⌘", "V"]] : [["Ctrl", "⇧", "C"], ["Ctrl", "⇧", "V"]],
+  },
 ];
 function renderShortPop() {
   const rows = SHORTCUTS.map((s) => {

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -29,7 +29,7 @@ import {
 } from "./types";
 import { gitMutates } from "./gitwatch";
 import { fmtMb, fmtRate } from "./format";
-import { claudeInput, cleanTitle, fitSession, loadWebgl, macShellKeys, MONO, winClaudePaste } from "./terminal";
+import { claudeInput, cleanTitle, clipboardKeys, fitSession, loadWebgl, MONO, shellKeys, winClaudePaste } from "./terminal";
 import { gitBusy, setGitBusy } from "./inspectorview";
 import { renderInspector } from "./inspector";
 import { renderMini, renderSidebar } from "./sidebar";
@@ -159,7 +159,8 @@ export async function launchShell(project: string, workdir: string, opts: { colo
   loadWebgl(term);
   term.open(pane);
   term.onData((d) => invoke("write_pty", { sessionId: id, data: d }));
-  term.attachCustomKeyEventHandler(macShellKeys(id)); // Terminal.app-style ⌥/⌘ nav for the shell
+  // One handler, both rules: Terminal.app-style ⌥/⌘ nav and Ctrl+Shift+C/V.
+  term.attachCustomKeyEventHandler(shellKeys(id, term));
   const s: Sess = {
     // resumeId is inert for a shell — it has no transcript and saveRoster skips it.
     id, project, accent: accentFor(colorKey), workdir, colorKey, resumeId: id,
@@ -210,6 +211,8 @@ export async function launchTask(r: Runnable, project: string, opts: TaskLaunchO
   term.open(pane);
   // Tasks are interactive: a prompt, a y/N, a dev server's "r" to reload all work.
   term.onData((d) => invoke("write_pty", { sessionId: id, data: d }));
+  // …and a run's output is the thing you most want out of a pane, so it copies too.
+  term.attachCustomKeyEventHandler(clipboardKeys(term));
 
   const cmd = execCmd(r);
   const s: Sess = {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -12,6 +12,7 @@
 // Nerd Font arrives — the WebGL renderer bakes tofu boxes into it otherwise.
 
 import { invoke } from "@tauri-apps/api/core";
+import { readText, writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { Terminal } from "@xterm/xterm";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { IS_WIN, toast } from "./dom";
@@ -32,13 +33,69 @@ export function loadWebgl(term: Terminal) {
   } catch { /* WebGL unavailable — DOM renderer is fine */ }
 }
 
+// The whole custom key rule for a shell pane, in one handler — xterm keeps only the
+// *last* `attachCustomKeyEventHandler`, so a second call anywhere silently discards
+// the first. Task panes take `clipboardKeys` alone: the ⌥/⌘ word-nav below is a login
+// shell's business, and a task pane is running a program, not a prompt.
+export function shellKeys(id: string, term: Terminal): (e: KeyboardEvent) => boolean {
+  const clip = clipboardKeys(term), nav = macShellKeys(id);
+  return (e) => clip(e) && nav(e);
+}
+
+// Ctrl+Shift+C / Ctrl+Shift+V — copy and paste for the panes that cannot have the
+// plain chords. Ctrl+C is the interrupt a shell or task pane exists to send, and xterm
+// turns Ctrl+V into a dead ^V (see `winClaudePaste`), so the shifted pair is the only
+// copy/paste a terminal has left — which is exactly why Windows Terminal, GNOME
+// Terminal and VS Code's terminal all use it. Unshifted ⌘C/⌘V on macOS are untouched:
+// xterm passes them to the WebView, which copies and pastes natively.
+//
+// Both halves go through the Tauri clipboard plugin rather than `navigator.clipboard`.
+// Writing would work either way, but `readText()` in the WebView sits behind the
+// `clipboard-read` permission — a WebView2 prompt on Windows, WKWebView's paste-
+// confirmation button on macOS — because Tauri does not build the webview with wry's
+// `enable_clipboard_access()`. The host side has no such gate, so paste stays silent
+// and immediate on both.
+export function clipboardKeys(term: Terminal): (e: KeyboardEvent) => boolean {
+  return (e) => {
+    if (e.type !== "keydown" || !e.ctrlKey || !e.shiftKey || e.altKey || e.metaKey) return true;
+    const k = e.key.toLowerCase();
+    if (k !== "c" && k !== "v") return true;
+    // Returning false only stops *xterm* from handling the key; the WebView still gets
+    // its own default (devtools' inspect-element on Ctrl+Shift+C), hence both.
+    e.preventDefault();
+    if (k === "c") void copySelection(term);
+    else void pasteClipboard(term);
+    return false;
+  };
+}
+
+async function copySelection(term: Terminal) {
+  const sel = term.getSelection();
+  if (!sel) return; // nothing selected — a no-op, as in every other terminal
+  try { await writeText(sel); toast("Copied"); }
+  catch (e) { dlog("error", `clipboard write failed: ${e}`); toast("Couldn't copy — clipboard unavailable"); }
+}
+
+// `term.paste` rather than a direct `write_pty`: it is xterm's own paste path, so the
+// text gets \r\n→\r normalisation and bracketed-paste wrapping when the program asked
+// for it, then leaves through `onData` — the same route typing takes, whichever spawner
+// owns the pane. A read that throws is nearly always an empty clipboard or one holding
+// something that isn't text (arboard reports both as unavailable), so the toast says
+// that rather than crying failure; the real error still reaches the debug console.
+async function pasteClipboard(term: Terminal) {
+  let text = "";
+  try { text = await readText(); }
+  catch (e) { dlog("error", `clipboard read failed: ${e}`); toast("Nothing to paste — no text on the clipboard"); return; }
+  if (text) term.paste(text);
+}
+
 // macOS terminal key conventions for the embedded shell. xterm.js emits xterm's
 // modified-arrow sequences (Option+Left = \e[1;3D etc.), which a plain login zsh
 // doesn't bind by default — so word-nav keys self-insert garbage like ";3D".
 // Terminal.app instead maps them to the Meta/emacs sequences zsh binds out of the
 // box; we do the same here so the embedded shell navigates like a normal terminal.
 // Only plain-shell PTYs get this (Claude's REPL handles its own key input).
-export function macShellKeys(id: string): (e: KeyboardEvent) => boolean {
+function macShellKeys(id: string): (e: KeyboardEvent) => boolean {
   const send = (data: string, e: KeyboardEvent): boolean => { e.preventDefault(); invoke("write_pty", { sessionId: id, data }); return false; };
   return (e: KeyboardEvent) => {
     if (e.type !== "keydown") return true;
@@ -106,8 +163,8 @@ export function claudeInput(id: string): (d: string) => void {
 //
 // NOTE: xterm keeps only **one** custom key-event handler per terminal, so a new key
 // rule for a claude pane belongs in here or in `claudeInput` above — never in a second
-// `attachCustomKeyEventHandler` call. (`macShellKeys` is safe: it is the *shell* pane's
-// handler, and no pane is both.)
+// `attachCustomKeyEventHandler` call. (`shellKeys` is safe: it is the *shell* pane's
+// one handler, and no pane is both.)
 export function winClaudePaste(id: string, term: Terminal, pane: HTMLElement) {
   if (!IS_WIN) return;
   term.attachCustomKeyEventHandler((e) =>


### PR DESCRIPTION
Copying with Ctrl+Shift+C and pasting with Ctrl+Shift+V did nothing in a `❯ Terminal` pane or a `▶ Run` pane. Both now work.

## Why neither worked

Two separate causes, which is why neither half functioned:

- **Ctrl+Shift+C** — xterm.js only turns a ctrl chord into a control byte when shift is *not* held, so it fell through to the WebView, which has no copy binding for it. Nothing was listening at all.
- **Ctrl+Shift+V** — same fall-through, then relying on Blink's `PasteAndMatchStyle` firing a paste event into xterm's hidden textarea. It doesn't in WebView2.

The unshifted pair can't stand in: Ctrl+C is the interrupt those panes exist to send, and xterm eats Ctrl+V into a dead `^V`.

## The change

`clipboardKeys` claims the shifted pair — the chords Windows Terminal, GNOME Terminal and VS Code's terminal all use — while macOS's ⌘C/⌘V keep reaching the WebView's native copy/paste untouched. Pasting goes through `term.paste` rather than `write_pty`, so bracketed-paste mode and `\r\n`→`\r` still apply.

Shell panes take `shellKeys`, which composes it with the existing ⌥/⌘ word-nav — xterm keeps only **one** custom key handler, so a second `attachCustomKeyEventHandler` would have silently discarded the first. Task panes take `clipboardKeys` alone.

## The dependency, and why

The clipboard is read and written from the host via **`tauri-plugin-clipboard-manager`**, not `navigator.clipboard`. Writing would work either way, but `readText()` sits behind the `clipboard-read` permission, which wry only auto-grants for a webview built with `enable_clipboard_access()` — Tauri leaves it off — so the browser path would raise a WebView2 permission prompt on Windows and WKWebView's paste-confirmation button on macOS.

Worth a reviewer's opinion: the plugin pulls `arboard` with image-data on (no feature to turn it off from our side), so the lockfile grew by 29 crates, about half of them image codecs and Linux backends we never build. The alternative is ~25 lines of `arboard`-direct commands in `platform.rs`'s OS-integration half with `default-features = false`.

## Verification

`tsc`, 408 vitest, `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings` and `pnpm build` all green.

The keypresses themselves are the DOM/PTY edge with no automated cover, so they are a **`RELEASE.md` click-through**, which this adds: copy from a shell and a task pane, paste back, no OS clipboard prompt, plain Ctrl+C still interrupts, ⌘C/⌘V still work on macOS.

## Known gap, deliberately out of scope

A **claude** pane still has no copy on Windows — Ctrl+C is forwarded as the interrupt and Ctrl+Shift+C does nothing. Extending `clipboardKeys` into `winClaudePaste` would close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
