### PR TITLE
One title bar: the app header replaces the native one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,7 @@ Four smaller P4 affordances, all in the frontend:
 
 | Module | Lines | What |
 | --- | --- | --- |
-| `lib.rs` | 456 | `run()`, `AppState`/`Session`, the tray mirror, the panic hook, `write_debug_file`/`log_frontend`, `confirm_quit`, and the `invoke_handler!` list |
+| `lib.rs` | 494 | `run()`, `AppState`/`Session`, the window (see One title bar), the tray mirror, the panic hook, `write_debug_file`/`log_frontend`, `confirm_quit`, and the `invoke_handler!` list |
 | `tasks.rs` | 2,399 | runnable discovery — see Runnables above |
 | `git.rs` | 1,877 | worktrees, branches, the working-set diff, the toolbar's fetch/pull/push, commit info |
 | `usage.rs` | 1,286 | transcripts (incl. History's whole-machine scan) + the token ledger — everything read out of `~/.claude` |
@@ -271,9 +271,9 @@ Four conventions hold across them:
 
 ## Frontend (`src/`, `index.html`, `src/styles.css`) — 37 modules
 
-**No framework, and no longer one file.** ~8,100 lines across 37 modules; `main.ts` is 686 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
+**No framework, and no longer one file.** ~8,150 lines across 37 modules; `main.ts` is 719 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
 
-What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (~70 lines — it is the seam map, and belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, and the nine `setInterval`s.
+What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (~70 lines — it is the seam map, and belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, the window controls (see One title bar), and the nine `setInterval`s.
 
 **Tested logic modules** (eleven — no DOM, no Tauri, no render imports; these are what the 408 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
 
@@ -398,6 +398,54 @@ branch chip and the open ⑃ dialog cannot disagree about what is checked out wh
 - **terminal / iterm** — `spawn_external_terminal` writes an executable `.command` wrapper and hands it to `open -a`.
 
 `available_terminals` reports which are installed so the UI only offers working ones.
+
+## One title bar, and it is the header
+
+The app draws its own header, so a native title bar above it was a second bar
+saying less. It is gone on both platforms, but by different routes, and the
+difference is the point:
+
+- **macOS keeps its decorations.** `titleBarStyle: "Overlay"` + `hiddenTitle` hide
+  the bar while floating the *real* traffic lights over `.top`;
+  `trafficLightPosition` centres them in its 40px and `html.mac`'s `padding-left`
+  leaves them room. Drawing our own would lose the green button, which zooms or
+  goes fullscreen depending on how you hold it. In fullscreen the OS takes the
+  lights back into its own sliding overlay, so `html.fs` closes that gap.
+- **Windows has no such style**, so the frame goes entirely (`decorations: false`)
+  and `#winCtl` draws minimize / maximize / close.
+- **A browser gets neither.** The same HTML opens on vite's port in dev, where
+  there is no window behind it — and `IS_WIN` is a *user-agent* read, so it is
+  still true in Chrome. Everything that acts on the native window is therefore
+  gated on **`IS_TAURI`** (`dom.ts`, from the `isTauri` global tauri defines
+  before any page script), including the platform class itself: no class, so the
+  CSS shows no controls and reserves no traffic-light gap.
+
+Four things about that split are easy to get wrong:
+
+- **The window is built in `setup()`, not by the config** (`"create": false`).
+  `decorations` is not a per-platform config key, and a `tauri.windows.conf.json`
+  would replace the whole `windows` array (json merge-patch), so every shared key
+  would exist twice and drift. **Flipping it after creation is not the same
+  thing:** tauri attaches its undecorated-resize child window only when the webview
+  is created over an *already* undecorated window, so a late flip yields a window
+  whose edges cannot be dragged at all — the WebView2 child swallows the hit test
+  and nothing behind it answers. `from_config` keeps one definition and cfg-gates
+  the single flag that differs. (What tao does *not* do is drop `WS_CAPTION`: it
+  zeroes the non-client area instead, which is what keeps the shadow, the rounded
+  corners and snap. So a style-bit check reads "decorated" either way — measure
+  `GetClientRect` against `GetWindowRect` instead. It was 1px inset here, 30 on a
+  build with the bar.)
+- **Dragging is `data-tauri-drag-region="deep"` on the header**, which excludes
+  clickable elements for us — but only what the DOM calls clickable. `#kbar` is a
+  `<div>` that listens for a click, so it opts out explicitly (`="false"`); without
+  that the drag swallows the mouseup its click needs and ⌘K stops opening, with
+  nothing in any log to say so.
+- **Close goes through the OS close request** (`win.close()`), so it lands in the
+  same `quit-requested` confirm as Ctrl+Q instead of stepping around the guard.
+- **Maximize is only *asked* for.** The glyph flips on the `onResized` that comes
+  back, which is also what catches Win+↑, a snap, and the double-click the drag
+  region handles itself. The same listener is what tells macOS it entered
+  fullscreen.
 
 ## External (non-Episko) sessions
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -155,6 +155,26 @@ A regression in either is silent.
 - [ ] **Caffeinate** asserts and releases (the icon reads armed vs asserting).
 - [ ] **The window survives a resize** — panes refit, no stuck scrollback.
 
+### The title bar, which is the header (no native one behind it)
+
+Nothing here has automated cover: the frame is drawn by the OS on one side and by
+`#winCtl` on the other, and each platform only ever sees its own half.
+
+- [ ] **There is one bar, not two**, and the window still moves: drag the header
+      (its background, the logo, the empty space around ⌘K) and the window follows;
+      double-clicking it maximizes. **⌘K still opens on a single click** — the search
+      bar opts out of the drag region, and a regression there is silent.
+- [ ] **Windows:** minimize / maximize / close all work from the header, the middle
+      glyph flips to the restore pair when maximized **and back** (also after Win+↑
+      and a snap, which don't go through our button), and ✕ still raises the quit
+      guard rather than killing live sessions. Then **resize from every edge and
+      corner** and drag the window to a screen edge to snap — an undecorated window
+      resizes through a child window tauri only attaches at creation, so this is what
+      catches it having been lost.
+- [ ] **macOS:** the traffic lights sit in the header, vertically centred, without
+      overlapping the logo — and all three work, the green one included (both zoom
+      and, held, fullscreen). In fullscreen the header must close the gap they leave.
+
 ### Logs, after all of the above
 
 - [ ] `episko.log` ends with `exit · clean shutdown`. A log that just stops is

--- a/index.html
+++ b/index.html
@@ -9,9 +9,16 @@
   </head>
   <body>
     <div class="app" id="app">
-      <header class="top">
+      <!--
+        This header IS the title bar — there is no native one behind it (see the
+        window block in lib.rs). `deep` makes the whole strip draggable except its
+        clickable elements, which tauri's drag script excludes for us; the ⌘K bar
+        opts out explicitly because it is a <div> that listens for a click, and a
+        drag would eat the mouseup that click needs.
+      -->
+      <header class="top" data-tauri-drag-region="deep">
         <div class="brand"><div class="logo"></div><b>Episko</b></div>
-        <div class="kbar" id="kbar"><span>⌕</span><span>Jump to a session, launch a project…</span><span class="kbd"><kbd>⌘</kbd><kbd>K</kbd></span></div>
+        <div class="kbar" id="kbar" data-tauri-drag-region="false"><span>⌕</span><span>Jump to a session, launch a project…</span><span class="kbd"><kbd>⌘</kbd><kbd>K</kbd></span></div>
         <div class="top-right">
           <button class="attn-badge" id="attnBadge"><span class="bdot"></span><span id="attnBadgeTxt"></span></button>
           <div class="caf" id="caf">
@@ -33,6 +40,25 @@
           <button class="ibtn" id="histBtn" title="Session history — every past conversation, all projects" aria-label="Session history">◷</button>
           <button class="ibtn" id="themeBtn" title="Toggle theme" aria-label="Toggle theme">◐</button>
           <button class="ibtn" id="setBtn" title="Settings (⌘,)" aria-label="Settings">⚙</button>
+        </div>
+        <!--
+          Window controls. Windows only (html.win) — macOS keeps its real traffic
+          lights, which float over this header instead. A child of the header
+          rather than of .top-right, because only there can it stretch to the full
+          40px and sit flush in the corner, which is where a thrown pointer lands.
+          The middle button swaps glyph via .maxed.
+        -->
+        <div class="wctl" id="winCtl">
+          <button class="wc" id="winMin" title="Minimize" aria-label="Minimize">
+            <svg viewBox="0 0 10 10" aria-hidden="true"><path d="M0 5h10" /></svg>
+          </button>
+          <button class="wc" id="winMax" title="Maximize" aria-label="Maximize">
+            <svg class="ic-max" viewBox="0 0 10 10" aria-hidden="true"><rect x=".5" y=".5" width="9" height="9" /></svg>
+            <svg class="ic-restore" viewBox="0 0 10 10" aria-hidden="true"><path d="M2.5 2.5v-2h7v7h-2" /><rect x=".5" y="2.5" width="7" height="7" /></svg>
+          </button>
+          <button class="wc wclose" id="winClose" title="Close" aria-label="Close">
+            <svg viewBox="0 0 10 10" aria-hidden="true"><path d="M0 0l10 10M10 0L0 10" /></svg>
+          </button>
         </div>
       </header>
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,10 @@
     "opener:default",
     "dialog:default",
     "updater:default",
-    "process:default"
+    "process:default",
+    "core:window:allow-start-dragging",
+    "core:window:allow-minimize",
+    "core:window:allow-toggle-maximize",
+    "core:window:allow-close"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -252,6 +252,44 @@ pub fn run() {
             let handle = app.handle().clone();
             std::thread::spawn(move || run_telemetry_server(server, handle));
 
+            // ---- The window (one title bar, not two) ----
+            // The app draws its own header, so the native title bar above it is a
+            // second one saying less. macOS can hide it and keep the parts worth
+            // keeping: `titleBarStyle: "Overlay"` + `hiddenTitle` in tauri.conf.json
+            // float the real traffic lights over our header (the green one is
+            // *zoom/fullscreen* — no <button> reproduces that), and
+            // `trafficLightPosition` centres them in its 40px. Windows has no such
+            // style, so there the frame goes entirely and the header draws its own
+            // minimize/maximize/close (`#winCtl`).
+            //
+            // Hence this window is built here rather than by the config (`create:
+            // false` above): `decorations` is not a per-platform config key, and a
+            // `tauri.windows.conf.json` would replace the whole `windows` array —
+            // json merge-patch, so every shared key would exist twice and drift.
+            // Flipping it *after* creation is not the same thing either: tauri only
+            // attaches its undecorated-resize child window when the webview is
+            // created over an already-undecorated window, so a late flip yields a
+            // window whose edges cannot be dragged at all (the WebView2 child
+            // swallows the hit test). `from_config` keeps one definition and
+            // cfg-gates the single flag that differs.
+            //
+            // One thing falls out for free: the webview now starts *after*
+            // `app.manage`, so the frontend cannot invoke a command before the
+            // state that command expects exists.
+            #[allow(unused_mut)] // `mut` is only used by the windows arm below
+            let mut win_cfg = app
+                .config()
+                .app
+                .windows
+                .first()
+                .cloned()
+                .expect("main window config in tauri.conf.json");
+            #[cfg(windows)]
+            {
+                win_cfg.decorations = false;
+            }
+            tauri::WebviewWindowBuilder::from_config(app, &win_cfg)?.build()?;
+
             // macOS menu-bar (tray) icon — its menu mirrors the sidebar and is
             // rebuilt from the frontend via `update_tray`.
             let tray_menu = MenuBuilder::new(app)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,11 @@
         "title": "Episko",
         "width": 1200,
         "height": 800,
-        "dragDropEnabled": true
+        "dragDropEnabled": true,
+        "create": false,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "trafficLightPosition": { "x": 14, "y": 14 }
       }
     ],
     "security": {

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -40,6 +40,15 @@ export function dropScrim() {
 const UA = typeof navigator === "undefined" ? "" : navigator.userAgent;
 export const IS_MAC = UA.includes("Mac");
 export const IS_WIN = UA.includes("Windows");
+// Which OS is a different question from whether there is a *window* — in dev the
+// frontend is plain HTML on vite's port, so it opens in a browser too, and there
+// the user-agent still says "Windows" while nothing exists to minimize, maximize
+// or drag. Anything that acts on the native window has to ask this as well (see
+// the title-bar block in main.ts), or a browser tab grows controls that only
+// throw. Tauri defines `isTauri` from an initialization script that runs before
+// any page script, so reading it at module scope is honest; the `window` guard is
+// vitest's node environment again, exactly like the UA read above.
+export const IS_TAURI = typeof window !== "undefined" && "isTauri" in window;
 export const MOD = IS_MAC ? "⌘" : "Ctrl";
 /** Where "open folder" actually lands, so a row, shortcut or command can name it. */
 export const FILE_MANAGER = IS_WIN ? "Explorer" : IS_MAC ? "Finder" : "file manager";

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,12 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { homeDir } from "@tauri-apps/api/path";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { ask } from "@tauri-apps/plugin-dialog";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import "@xterm/xterm/css/xterm.css";
 import { isAgent } from "./types";
-import { $, chord, IS_MAC, toast } from "./dom";
+import { $, chord, IS_MAC, IS_TAURI, IS_WIN, toast } from "./dom";
 import { updateTray } from "./tray";
 import {
   closeAttnPop, closeEnginePop, closeFootMenus, closeShortPop, closeUsagePop,
@@ -110,6 +111,17 @@ void (async () => {
     // later launch can retry. Harmless — nothing was written.
   }
 })();
+
+// The app header IS the title bar — there is no native one behind it (see the
+// window block in lib.rs) — but which half of that the CSS has to draw is a
+// platform fact it cannot read. Stamp it here, at module scope, so the first
+// paint already has it: macOS leaves room for its real traffic lights, Windows
+// shows the controls wired below, and an unported Linux keeps its native frame
+// and needs neither. **Nothing is stamped in a browser** — this same HTML opens
+// on vite's port in dev, where there is no window behind it, so an unqualified
+// `IS_WIN` (a user-agent read) would hand a Chrome tab three buttons that can
+// only throw.
+if (IS_TAURI) document.documentElement.classList.add(IS_MAC ? "mac" : IS_WIN ? "win" : "linux");
 
 // index.html hard-codes the mac glyphs; rewrite its static bits once on other
 // platforms (everything rendered from TS goes through MOD/chord instead, which now
@@ -493,6 +505,30 @@ document.addEventListener("click", (e) => {
 
 $("kbar").addEventListener("click", openPalette);
 $("themeBtn").addEventListener("click", toggleTheme);
+
+// Window controls — the other half of "the header is the title bar". Windows
+// only: macOS's traffic lights are the real ones, and its green button zooms or
+// goes fullscreen depending on how you hold it, which no <button> reproduces.
+// Close goes through the OS close request, so it lands in the same
+// `quit-requested` confirm below as Ctrl+Q rather than stepping around it.
+// Maximize is only *asked* for here — the answer comes back through onResized,
+// which is also how Win+↑, a snap and the drag region's own double-click get the
+// glyph right; on macOS the same listener catches entering fullscreen, where the
+// OS reclaims the traffic lights and the room the header leaves for them.
+if (IS_TAURI && (IS_MAC || IS_WIN)) {
+  const win = getCurrentWindow();
+  const syncWin = async () => {
+    if (IS_WIN) $("winCtl").classList.toggle("maxed", await win.isMaximized());
+    else document.documentElement.classList.toggle("fs", await win.isFullscreen());
+  };
+  if (IS_WIN) {
+    $("winMin").addEventListener("click", () => { void win.minimize(); });
+    $("winMax").addEventListener("click", () => { void win.toggleMaximize(); });
+    $("winClose").addEventListener("click", () => { void win.close(); });
+  }
+  void win.onResized(() => { void syncWin(); });
+  void syncWin();
+}
 $("railCollapse").addEventListener("click", toggleRail);
 $("railSort").addEventListener("click", cycleSort);
 $("inspBtn").addEventListener("click", toggleInsp);

--- a/src/styles.css
+++ b/src/styles.css
@@ -100,6 +100,25 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .ibtn { width: 26px; height: 26px; border-radius: 8px; cursor: pointer; display: grid; place-items: center; font-size: 13px; color: var(--muted); background: var(--surface); border: 1px solid var(--hair); }
 .ibtn:hover { color: var(--text); border-color: var(--hair-strong); }
 
+/* The title bar, which is this header — there is no native one (see lib.rs).
+   Two platforms, two halves of the job. macOS floats its real traffic lights
+   over the header, so all the CSS owes them is room; in fullscreen the OS takes
+   them back into its own sliding overlay, and the gap would be empty (html.fs,
+   set from main.ts). Windows has no frame at all, so #winCtl draws the buttons:
+   flush into the corner and full height, because that corner is where a thrown
+   pointer lands. .wclose alone takes the OS's red, the one colour a user should
+   never have to aim for twice. */
+html.mac .top { padding-left: 78px; }
+html.mac.fs .top { padding-left: 12px; }
+.wctl { display: none; align-self: stretch; margin-right: -12px; }
+html.win .wctl { display: flex; }
+.wctl .wc { width: 42px; padding: 0; border: 0; cursor: pointer; display: grid; place-items: center; color: var(--muted); background: transparent; }
+.wctl .wc svg { width: 10px; height: 10px; fill: none; stroke: currentColor; stroke-width: 1; }
+.wctl .wc:hover { color: var(--text); background: color-mix(in srgb, var(--text) 10%, transparent); }
+.wctl .wclose:hover { color: #fff; background: #e81123; }
+.wctl .ic-restore, .wctl.maxed .ic-max { display: none; }
+.wctl.maxed .ic-restore { display: block; }
+
 /* caffeinate split button — icon toggles the last-used preset, caret opens the
    preset dropdown. The whole control reflects on/off via the .on class. */
 .caf { display: inline-flex; align-items: stretch; height: 26px; border-radius: 8px; overflow: hidden; color: var(--muted); background: var(--surface); border: 1px solid var(--hair); box-shadow: inset 0 1px 0 var(--lift); }


### PR DESCRIPTION
The app draws its own header, so the OS title bar above it was a second bar saying
less. This removes it — but by a different route on each platform, and the difference
is the point.

| | Where the window buttons are | Who draws them |
| --- | --- | --- |
| macOS | left | the OS — the real traffic lights, floated over our header |
| Windows | right | us (`#winCtl`) |
| a browser | nowhere | nobody — there is no window behind the page |

**macOS keeps its decorations.** `titleBarStyle: "Overlay"` + `hiddenTitle` hide the
bar while keeping the real traffic lights; `trafficLightPosition` centres them in the
header's 40px and `html.mac`'s `padding-left` leaves them room, dropped again by
`html.fs` in fullscreen where the OS reclaims them into its own sliding overlay.
Drawing our own would lose the green button, which zooms or goes fullscreen depending
on how you hold it.

**Windows has no such style**, so the frame goes entirely and the header draws
minimize / maximize / close, flush in the corner at full height.

### Why the window moved into `setup()`

`decorations` is not a per-platform config key, and a `tauri.windows.conf.json` would
replace the whole `windows` array (json merge-patch), so every shared key would exist
twice and drift. So the config keeps one definition with `"create": false` and
`WebviewWindowBuilder::from_config` builds it, cfg-gating the single flag that differs.

Flipping `decorations` *after* creation would have been the smaller diff and is
wrong: tauri attaches its undecorated-resize child window only when the webview is
created over an *already* undecorated window, so a late flip leaves a window whose
edges cannot be dragged at all — the WebView2 child swallows the hit test and nothing
behind it answers. A side benefit falls out: the webview now starts after
`app.manage`, so the frontend cannot invoke a command before the state it expects
exists.

### Three things that are easy to get wrong

- **Dragging** is `data-tauri-drag-region="deep"` on the header, which excludes
  clickable elements for us — but only what the DOM calls clickable. `#kbar` is a
  `<div>` that listens for a click, so it opts out explicitly; without that the drag
  eats the mouseup its click needs and ⌘K silently stops opening.
- **Close** goes through the OS close request, so it still meets the `quit-requested`
  guard instead of stepping around it. Maximize is only *asked* for — the glyph flips
  on the `onResized` that comes back, which is also what catches Win+↑ and a snap.
- **A browser gets nothing.** `IS_WIN` is a user-agent read, still true in Chrome
  where the frontend also opens on vite's port. Everything touching the native window
  is now gated on `IS_TAURI` (`dom.ts`), the platform class included.

### Verification

`tsc`, 408 vitest, 86 cargo, `clippy --all-targets -D warnings`, plus the CLAUDE.md
cfg flip to lint the non-Windows arms (only the known `reveal_path` false positive).

On the running Windows build, measured rather than eyeballed: the client area insets
**1px** from the window top where a build with the bar insets **30**, and the
`TAURI_DRAG_RESIZE_BORDERS` child window **is** attached, so edge-resizing survives.
The header was also rendered headlessly in both themes and both maximize states, and
in browser and macOS layouts.

**What I could not check: the macOS half.** It was written on Windows, so the traffic
lights' vertical offset (`{x: 14, y: 14}`, computed for a 40px bar) wants an eyeball
on a Mac — that one config line is the only thing to nudge if they sit high or low.
`RELEASE.md` gains the click-through for all of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
