### PR TITLE
feat: notice when an agent leaves the checkout it was launched in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Mac has the same symlink — but it is one both legs will find at once.
 
 **Package manager: `pnpm`** for this repo (there's a `pnpm-lock.yaml`; both CI workflows use `pnpm install --frozen-lockfile`, and `packageManager` in `package.json` pins the version for corepack/CI). Use pnpm here, not npm. Windows code-signing / release-signing setup lives in `src-tauri/SIGNING.md`.
 
-Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **408 vitest + cargo (89 on macOS, 86 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
+Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **423 vitest + cargo (91 on macOS, 88 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
 
 **vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which nine those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
 
@@ -202,7 +202,8 @@ opens Episko.
 ## Project tasks panel (`openTaskManager`)
 
 Pin / hide / create / edit / delete / **override**, reached from ⌘K.
-**`.episko/tasks.toml` is the only file Episko writes** — a discovered VS Code task
+**`.episko/tasks.toml` is the only file Episko writes** (in a user's repo — the one
+other place it writes is `~/.claude`, and only when you press *Move session*; see Drift) — a discovered VS Code task
 or justfile belongs to another tool, so editing one writes an `[override."<id>"]`
 into `tasks.toml` keyed by its discovered id, **never** a mutation of
 `.vscode/tasks.json`. Writes go through `toml_edit`, not a serialize-the-whole-struct
@@ -248,8 +249,8 @@ Four smaller P4 affordances, all in the frontend:
 | `lib.rs` | 456 | `run()`, `AppState`/`Session`, the tray mirror, the panic hook, `write_debug_file`/`log_frontend`, `confirm_quit`, and the `invoke_handler!` list |
 | `tasks.rs` | 2,399 | runnable discovery — see Runnables above |
 | `git.rs` | 1,877 | worktrees, branches, the working-set diff, the toolbar's fetch/pull/push, commit info |
-| `usage.rs` | 1,286 | transcripts (incl. History's whole-machine scan) + the token ledger — everything read out of `~/.claude` |
-| `telemetry.rs` | 857 | `write_instrument_settings`, `run_telemetry_server`, `resolve_permission` |
+| `usage.rs` | 1,470 | transcripts (incl. History's whole-machine scan) + the token ledger — everything read out of `~/.claude` |
+| `telemetry.rs` | 926 | `write_instrument_settings`, `run_telemetry_server`, `resolve_permission` |
 | `platform.rs` | 743 | OS leaves (top half, incl. `norm_path`/`physical_cwd`) + OS integrations (bottom half) |
 | `pty.rs` | 803 | the four launch engines, `stream_pty_session`, the PTY lifecycle |
 | `external.rs` | 339 | the `~/.claude/sessions` registry, `ProcTable`, terminal focus |
@@ -271,11 +272,11 @@ Four conventions hold across them:
 
 ## Frontend (`src/`, `index.html`, `src/styles.css`) — 37 modules
 
-**No framework, and no longer one file.** ~8,100 lines across 37 modules; `main.ts` is 686 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
+**No framework, and no longer one file.** ~8,300 lines across 37 modules; `main.ts` is 689 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (~70 lines — it is the seam map, and belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, and the nine `setInterval`s.
 
-**Tested logic modules** (eleven — no DOM, no Tauri, no render imports; these are what the 408 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
+**Tested logic modules** (eleven — no DOM, no Tauri, no render imports; these are what the 423 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
 
 | Module | What |
 | --- | --- |
@@ -289,7 +290,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 | `grouping.ts` | what the sidebar shows and in what order; `urgencyRank`, `needsYou`, `nextAfterClose` |
 | `tasks.ts` | the frontend half of Runnables: `stopRuleBlocked`, `launchWithDeps`, `applyRunner`, `${input:…}` glue |
 | `history.ts` | History's rules: `histProject` (regrafting a row onto a project), `histBusy`, the scope/search predicates, day buckets |
-| `gitwatch.ts` | `gitMutates` — whether a shell command an agent ran is worth re-reading git for |
+| `gitwatch.ts` | `gitMutates` — whether a shell command an agent ran is worth re-reading git for; `driftTarget`/`driftUpdate` — which checkout its *writes* are landing in |
 
 **Shared**: `state.ts` (the session map, the stage pointer, every persisted preference) and `dom.ts` (`$`, `toast`, the shared scrim, `IS_MAC`/`MOD`/`chord`).
 
@@ -388,6 +389,64 @@ with the `--numstat` walk skipped entirely on a clean tree.
 
 Everything lands through `refreshGitViews` → `renderAll()`, so the sidebar, the header's
 branch chip and the open ⑃ dialog cannot disagree about what is checked out where.
+
+## Drift — the agent left the checkout it was launched in
+
+The above answers "what is checked out where". This answers the other half, which it
+cannot: **which checkout is this agent's work actually landing in?** An agent that runs
+`git worktree add … -b feat/x` and moves into the new checkout leaves the session pinned
+to the folder it started in, and every surface goes on naming that folder — correctly,
+and uselessly. The worktree roster notices the new checkout (the toast fires, the row
+appears); it is the *session → checkout* link that goes stale.
+
+**`cwd` cannot tell us, and that is a property of Claude Code, not an oversight.**
+Verified against 2.1.220: a `cd` *inside* the session's directory persists and the hook's
+`cwd` follows it, but a `cd` *outside* it is undone — the tool result literally says
+`Shell cwd was reset to …` — and `cwd` never moves. The session that prompted this had 42
+such resets and 622 transcript records all naming the folder it had already left. So any
+design that watches `cwd`, `workspace.current_dir` or the transcript is watching a field
+that is pinned by construction for exactly the case that matters.
+
+**What does name the new checkout is `tool_input.file_path`**, absolute on every
+Write/Edit payload (asserted against the real binary in the `#[ignore]`d contract test —
+if it ever goes relative, drift silently stops working rather than failing). Hence:
+
+- **Only writes count.** A `Read` lands anywhere — a sibling repo, `~/.claude`, `$TMPDIR`
+  — and reading is how an agent that moved *ports work across*. Counting reads would make
+  the flag flicker on every glance back at the old checkout.
+- **Both sides resolve to a checkout before being compared** (`driftTarget`), never the
+  file against `workdir` directly. That is what keeps a session launched in a *subfolder*
+  of a checkout (not drift) apart from one launched in a *nested worktree* (drift the
+  moment it writes to the enclosing repo). Longest match wins, for the same reason.
+- **The target must be a checkout the roster already knows.** Unlike `gitMutates`, a
+  false positive here is not a wasted re-read — it puts a wrong branch on screen and
+  offers to relocate a live session into `$TMPDIR`. Unknown folder → no drift.
+- **Latched, not sampled** (`driftUpdate`). Once seen, a drift holds until the agent
+  *writes home* again, which is the only act that means it came back.
+
+Display-only: `Sess.workdir` stays the folder Claude runs in and `--resume` needs. The
+row **does not move** — it stays under the checkout that owns its identity — and instead
+carries a `⤳ branch` marker, the header chip shows `old ⤳ ⑃ new`, and the inspector gets
+a card at the top, above the working set and git buttons it contradicts.
+
+**`moveSessionToDrift` is the one action that writes inside `~/.claude`**, and the second
+exception to "Episko only writes `.episko/tasks.toml`". It has to be an action rather
+than something a user could do by hand: `claude --resume` takes a session id and **no
+path** (there is no path-based resume flag), and looks the conversation up under
+`<enc(cwd)>/<id>.jsonl` — so *no sequence of commands* resumes a session in a folder
+other than the one it started in. The order is the safety argument: **kill, then move,
+then relaunch**. `closeSession` fires `kill_session` without awaiting it, so the await is
+what makes this a move of a *dead* session — a live one would keep the file open (Windows
+refuses the rename outright; POSIX would succeed and leave it writing into the moved
+file). `move_session_transcript` renames rather than copies (two files with one id would
+double-list in History and leave `--resume` ambiguous), carries the `<id>/tool-results`
+sidecar with it, refuses to overwrite, and rejects any id that isn't uuid-shaped before it
+reaches a filename. A failed move still relaunches — in the *original* folder, same
+conversation — so the cost is a restarted pane and nothing else.
+
+Known wart: the moved transcript's first user record still names the old cwd, so
+`transcript_origin` grafts its History row onto the old project. Defensible (the
+conversation did start there) and not worth rewriting records to fix.
 
 ## Four launch engines, one telemetry path
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Mac has the same symlink — but it is one both legs will find at once.
 
 **Package manager: `pnpm`** for this repo (there's a `pnpm-lock.yaml`; both CI workflows use `pnpm install --frozen-lockfile`, and `packageManager` in `package.json` pins the version for corepack/CI). Use pnpm here, not npm. Windows code-signing / release-signing setup lives in `src-tauri/SIGNING.md`.
 
-Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **429 vitest + cargo (91 on macOS, 88 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
+Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **431 vitest + cargo (91 on macOS, 88 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
 
 **vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which nine those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
 
@@ -276,7 +276,7 @@ Four conventions hold across them:
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (~70 lines — it is the seam map, and belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, and the nine `setInterval`s.
 
-**Tested logic modules** (eleven — no DOM, no Tauri, no render imports; these are what the 429 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
+**Tested logic modules** (eleven — no DOM, no Tauri, no render imports; these are what the 431 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
 
 | Module | What |
 | --- | --- |
@@ -450,13 +450,17 @@ be wrong in both directions:
 - **`via: "write"`** → *Move session here.* Nothing has re-homed anything. `claude
   --resume` takes a session id and **no path** (there is no path-based resume flag) and
   looks the conversation up under `<enc(cwd)>/<id>.jsonl`, so *no sequence of commands a
-  user could type* relocates a session. **Kill, then move, then relaunch**: `closeSession`
-  fires `kill_session` without awaiting it, so the await is what makes this a move of a
-  *dead* session (a live one holds the file open — Windows refuses the rename outright;
-  POSIX would succeed and leave it writing into the moved file). `move_session_transcript`
+  user could type* relocates a session. **Kill, wait, move, relaunch** — and the
+  *wait* is not the `invoke` returning. `kill_session` sends a signal and returns, so
+  awaiting it proves only that the signal was sent; the process is reaped on a backend
+  thread that emits `pty-exit` **after** `child.wait()`, and that event is the only
+  evidence the transcript handle is closed. Renaming before it lands is the bug the
+  ordering exists to prevent (Windows refuses to rename an open file; POSIX succeeds and
+  leaves the dying session writing into the moved file). The wait is bounded, so a wedged
+  process cannot strand the pane. `move_session_transcript`
   renames rather than copies (two files with one id would double-list in History and leave
   `--resume` ambiguous), carries the `<id>/tool-results` sidecar, refuses to overwrite, and
-  rejects any id that isn't uuid-shaped before it reaches a filename. A failed move still
+  restricts the id to uuid characters before it reaches a filename (no dot, no separator, so nothing escapes the projects tree). A failed move still
   relaunches — in the *original* folder — so the cost is a restarted pane.
 
 `move_session_transcript` is the only thing Episko ever writes inside `~/.claude`, and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Mac has the same symlink — but it is one both legs will find at once.
 
 **Package manager: `pnpm`** for this repo (there's a `pnpm-lock.yaml`; both CI workflows use `pnpm install --frozen-lockfile`, and `packageManager` in `package.json` pins the version for corepack/CI). Use pnpm here, not npm. Windows code-signing / release-signing setup lives in `src-tauri/SIGNING.md`.
 
-Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **423 vitest + cargo (91 on macOS, 88 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
+Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **429 vitest + cargo (91 on macOS, 88 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
 
 **vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which nine those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
 
@@ -276,7 +276,7 @@ Four conventions hold across them:
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (~70 lines — it is the seam map, and belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, and the nine `setInterval`s.
 
-**Tested logic modules** (eleven — no DOM, no Tauri, no render imports; these are what the 423 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
+**Tested logic modules** (eleven — no DOM, no Tauri, no render imports; these are what the 429 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
 
 | Module | What |
 | --- | --- |
@@ -290,7 +290,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 | `grouping.ts` | what the sidebar shows and in what order; `urgencyRank`, `needsYou`, `nextAfterClose` |
 | `tasks.ts` | the frontend half of Runnables: `stopRuleBlocked`, `launchWithDeps`, `applyRunner`, `${input:…}` glue |
 | `history.ts` | History's rules: `histProject` (regrafting a row onto a project), `histBusy`, the scope/search predicates, day buckets |
-| `gitwatch.ts` | `gitMutates` — whether a shell command an agent ran is worth re-reading git for; `driftTarget`/`driftUpdate` — which checkout its *writes* are landing in |
+| `gitwatch.ts` | `gitMutates` — whether a shell command an agent ran is worth re-reading git for; `driftTarget`/`driftUpdate` — which checkout its work has moved to, from writes *and* `cwd` |
 
 **Shared**: `state.ts` (the session map, the stage pointer, every persisted preference) and `dom.ts` (`$`, `toast`, the shared scrim, `IS_MAC`/`MOD`/`chord`).
 
@@ -392,59 +392,77 @@ branch chip and the open ⑃ dialog cannot disagree about what is checked out wh
 
 ## Drift — the agent left the checkout it was launched in
 
-The above answers "what is checked out where". This answers the other half, which it
-cannot: **which checkout is this agent's work actually landing in?** An agent that runs
-`git worktree add … -b feat/x` and moves into the new checkout leaves the session pinned
-to the folder it started in, and every surface goes on naming that folder — correctly,
-and uselessly. The worktree roster notices the new checkout (the toast fires, the row
-appears); it is the *session → checkout* link that goes stale.
+The section above answers "what is checked out where". This answers the other half,
+which it cannot: **which checkout is this agent's work actually landing in?** The
+worktree roster notices a new checkout (the toast fires, the row appears); it is the
+*session → checkout* link that goes stale.
 
-**`cwd` cannot tell us, and that is a property of Claude Code, not an oversight.**
-Verified against 2.1.220: a `cd` *inside* the session's directory persists and the hook's
-`cwd` follows it, but a `cd` *outside* it is undone — the tool result literally says
-`Shell cwd was reset to …` — and `cwd` never moves. The session that prompted this had 42
-such resets and 622 transcript records all naming the folder it had already left. So any
-design that watches `cwd`, `workspace.current_dir` or the transcript is watching a field
-that is pinned by construction for exactly the case that matters.
+**There are two ways an agent changes checkout, they behave as opposites, and each is
+invisible to the signal that catches the other.** Both were verified against the real
+CLI (2.1.220) and against real sessions — guessing here produced a first cut that
+covered one and read as broken in the other.
 
-**What does name the new checkout is `tool_input.file_path`**, absolute on every
-Write/Edit payload (asserted against the real binary in the `#[ignore]`d contract test —
-if it ever goes relative, drift silently stops working rather than failing). Hence:
+| | **out of** the project dir | **into** the project dir |
+| --- | --- | --- |
+| how | `git worktree add ../x` via Bash | Claude Code's `EnterWorktree` tool |
+| where | a sibling, e.g. `.cc-worktrees/…` | `<repo>/.claude/worktrees/<name>` |
+| hook `cwd` | **pinned** — every `cd` out is undone (`Shell cwd was reset to …`) | **follows** |
+| the transcript | stays where it was | **Claude re-homes it itself** |
+| `gitMutates` | fires | never — no Bash command ran |
+| the signal | a write's `file_path` | `cwd` |
 
-- **Only writes count.** A `Read` lands anywhere — a sibling repo, `~/.claude`, `$TMPDIR`
-  — and reading is how an agent that moved *ports work across*. Counting reads would make
-  the flag flicker on every glance back at the old checkout.
-- **Both sides resolve to a checkout before being compared** (`driftTarget`), never the
-  file against `workdir` directly. That is what keeps a session launched in a *subfolder*
-  of a checkout (not drift) apart from one launched in a *nested worktree* (drift the
-  moment it writes to the enclosing repo). Longest match wins, for the same reason.
+One real session had 42 `Shell cwd was reset to …` and 622 records all naming the folder
+it had already left; another used `EnterWorktree`, made **zero** writes, and had its
+transcript moved out from under Episko by Claude. Neither signal alone covers both.
+
+Hence two signals with different standing, and the asymmetry is the whole design
+(`driftUpdate`):
+
+- **`cwd` may only ever *set* a drift, never clear a write-derived one.** A `cwd` reading
+  "home" proves nothing about where the writes are going — that is exactly the left-hand
+  column, where it reads "home" for the entire life of the drift. Letting it clear would
+  delete the answer on the next hook. It retires only a drift `cwd` itself reported.
+- **Writes latch**, because an agent working in another checkout still reads its original
+  one constantly (usually *why* it moved). Cleared only by a write home.
+- **Both sides resolve to a checkout before being compared**, never the path against
+  `workdir` directly. That is what keeps `cd src/` (not a move), a session launched in a
+  subfolder (not a move) and a nested worktree (a move) all straight at once, and why the
+  longest match wins — `EnterWorktree`'s worktrees live *inside* the repo that contains
+  them.
 - **The target must be a checkout the roster already knows.** Unlike `gitMutates`, a
-  false positive here is not a wasted re-read — it puts a wrong branch on screen and
-  offers to relocate a live session into `$TMPDIR`. Unknown folder → no drift.
-- **Latched, not sampled** (`driftUpdate`). Once seen, a drift holds until the agent
-  *writes home* again, which is the only act that means it came back.
+  false positive is not a wasted re-read — it puts a wrong branch on screen and offers to
+  relocate a live session into `$TMPDIR`.
 
-Display-only: `Sess.workdir` stays the folder Claude runs in and `--resume` needs. The
-row **does not move** — it stays under the checkout that owns its identity — and instead
-carries a `⤳ branch` marker, the header chip shows `old ⤳ ⑃ new`, and the inspector gets
-a card at the top, above the working set and git buttons it contradicts.
+Display is the same either way and **the row does not move**: it stays under the checkout
+that owns its identity, carrying a `⤳ branch` marker, with `old ⤳ ⑃ new` on the header
+chip and a card at the top of the inspector, above the working set and git buttons it
+contradicts.
 
-**`moveSessionToDrift` is the one action that writes inside `~/.claude`**, and the second
-exception to "Episko only writes `.episko/tasks.toml`". It has to be an action rather
-than something a user could do by hand: `claude --resume` takes a session id and **no
-path** (there is no path-based resume flag), and looks the conversation up under
-`<enc(cwd)>/<id>.jsonl` — so *no sequence of commands* resumes a session in a folder
-other than the one it started in. The order is the safety argument: **kill, then move,
-then relaunch**. `closeSession` fires `kill_session` without awaiting it, so the await is
-what makes this a move of a *dead* session — a live one would keep the file open (Windows
-refuses the rename outright; POSIX would succeed and leave it writing into the moved
-file). `move_session_transcript` renames rather than copies (two files with one id would
-double-list in History and leave `--resume` ambiguous), carries the `<id>/tool-results`
-sidecar with it, refuses to overwrite, and rejects any id that isn't uuid-shaped before it
-reaches a filename. A failed move still relaunches — in the *original* folder, same
-conversation — so the cost is a restarted pane and nothing else.
+**`Drift.via` is not decoration — it decides the repair**, and conflating the two would
+be wrong in both directions:
 
-Known wart: the moved transcript's first user record still names the old cwd, so
+- **`via: "cwd"`** → *Follow it here.* The process is already running there and the
+  conversation is already there. Episko is merely behind, so `followSessionDrift` adopts
+  the directory **in place** — no confirm, no kill, no file move, no relaunch; the pane
+  never blinks. It re-points `workdir`/`branch`, drops the stale `git` working set, marks
+  the new folder for a re-read and re-saves the roster (restore must target the folder
+  the transcript is in).
+- **`via: "write"`** → *Move session here.* Nothing has re-homed anything. `claude
+  --resume` takes a session id and **no path** (there is no path-based resume flag) and
+  looks the conversation up under `<enc(cwd)>/<id>.jsonl`, so *no sequence of commands a
+  user could type* relocates a session. **Kill, then move, then relaunch**: `closeSession`
+  fires `kill_session` without awaiting it, so the await is what makes this a move of a
+  *dead* session (a live one holds the file open — Windows refuses the rename outright;
+  POSIX would succeed and leave it writing into the moved file). `move_session_transcript`
+  renames rather than copies (two files with one id would double-list in History and leave
+  `--resume` ambiguous), carries the `<id>/tool-results` sidecar, refuses to overwrite, and
+  rejects any id that isn't uuid-shaped before it reaches a filename. A failed move still
+  relaunches — in the *original* folder — so the cost is a restarted pane.
+
+`move_session_transcript` is the only thing Episko ever writes inside `~/.claude`, and the
+second exception to "Episko only writes `.episko/tasks.toml`".
+
+Known wart: a moved transcript's first user record still names the old cwd, so
 `transcript_origin` grafts its History row onto the old project. Defensible (the
 conversation did start there) and not worth rewriting records to fix.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,7 +15,7 @@ different lifetime — it changes when the OS edge changes, not when the app doe
 Every push and PR to `dev`/`main` runs, on **both macOS and Windows** (`ci.yml`):
 
 - `pnpm build` — `tsc --noEmit` (strict) plus the vite build
-- `pnpm test` — 429 vitest tests over the logic modules
+- `pnpm test` — 431 vitest tests over the logic modules
 - `cargo check --locked` and `cargo test --locked` — 91 tests on macOS, 88 on
   Windows (the platform tests are `cfg`-gated, so the count differs by leg)
 - `cargo clippy --all-targets --locked -- -D warnings`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,8 +15,8 @@ different lifetime — it changes when the OS edge changes, not when the app doe
 Every push and PR to `dev`/`main` runs, on **both macOS and Windows** (`ci.yml`):
 
 - `pnpm build` — `tsc --noEmit` (strict) plus the vite build
-- `pnpm test` — 408 vitest tests over the logic modules
-- `cargo check --locked` and `cargo test --locked` — 89 tests on macOS, 86 on
+- `pnpm test` — 429 vitest tests over the logic modules
+- `cargo check --locked` and `cargo test --locked` — 91 tests on macOS, 88 on
   Windows (the platform tests are `cfg`-gated, so the count differs by leg)
 - `cargo clippy --all-targets --locked -- -D warnings`
 
@@ -135,23 +135,32 @@ A regression in either is silent.
 
 ### Drift — an agent that changes checkout
 
-Nothing here can be checked headlessly: the detection is unit-tested and the CLI
-contract is pinned by the `--ignored` test above, but every surface below is DOM.
+**Two cases, and they behave as opposites** — one is not a spot check for the other.
+Nothing here can be checked headlessly: the rules are unit-tested and the CLI contract is
+pinned by the `--ignored` test above, but every surface below is DOM.
 
-- [ ] **The drift is noticed.** In a session launched in one checkout, have the agent
-      `git worktree add` a new one and **write a file in it**. Within a couple of tool
-      calls the sidebar row gains `⤳ <branch>`, the header chip reads `old ⤳ ⑃ new`, and
-      the inspector shows the *Working in* card **above** the vital.
-- [ ] **The row does not move** — it stays under the checkout the session was launched
-      in, and does not hop back and forth as the agent reads its old files. (A read must
-      never clear the marker; only a *write* back home does.)
-- [ ] **Move session here** ends the session, moves the conversation and resumes it in
-      the new checkout — with its history intact (ask it about something from before the
-      move). Afterwards the marker is gone, the branch chip is the new branch alone, and
+- [ ] **Case 1 — writes move, the session does not.** In a session launched in one
+      checkout, have the agent `git worktree add` a **sibling** worktree (outside the
+      project dir) and **write a file in it**. The sidebar row gains `⤳ <branch>`, the
+      header chip reads `old ⤳ ⑃ new`, and the inspector shows the *Working in* card
+      above the vital, offering **Move session here**.
+- [ ] **The row does not move**, and does not flicker as the agent reads its old files.
+      (Only a *write* back home clears the marker — reads must not.)
+- [ ] **Move session here** confirms, ends the session, and resumes it in the new
+      checkout with its history intact (ask it about something from before the move).
+      Afterwards: marker gone, chip shows the new branch alone, and
       `~/.claude/projects/<enc(new)>/<id>.jsonl` exists while the old one does not.
-- [ ] **A refused move is harmless.** Deny it once at the confirm dialog: nothing
-      changes. (The failure path — relaunch in the original folder — is worth forcing
-      once by pre-creating a file at the destination transcript path.)
+- [ ] **A refused move is harmless** — deny at the confirm dialog and nothing changes.
+
+- [ ] **Case 2 — Claude moves the session itself.** Prompt: *"create a new worktree and
+      run a terminal command in it"*, which drives Claude Code's own `EnterWorktree`
+      tool into `<repo>/.claude/worktrees/<name>`. **No file need be written.** The same
+      marker and card appear, but the button reads **Follow it here**.
+- [ ] **Follow it here is instant and lossless** — no confirm, no restart, the pane does
+      not blink and the terminal keeps its scrollback. Afterwards the header path, the
+      branch, ▶ Run and ❯ Terminal all point at the new checkout.
+- [ ] **The conversation is still resumable afterwards** (Claude had already re-homed the
+      transcript; Episko must not have moved it a second time).
 
 ### Panes that aren't agents
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -133,6 +133,26 @@ A regression in either is silent.
       from the roster. It must resume the *same* conversation — that is `resumeId`, not
       the launch id, doing its job.
 
+### Drift — an agent that changes checkout
+
+Nothing here can be checked headlessly: the detection is unit-tested and the CLI
+contract is pinned by the `--ignored` test above, but every surface below is DOM.
+
+- [ ] **The drift is noticed.** In a session launched in one checkout, have the agent
+      `git worktree add` a new one and **write a file in it**. Within a couple of tool
+      calls the sidebar row gains `⤳ <branch>`, the header chip reads `old ⤳ ⑃ new`, and
+      the inspector shows the *Working in* card **above** the vital.
+- [ ] **The row does not move** — it stays under the checkout the session was launched
+      in, and does not hop back and forth as the agent reads its old files. (A read must
+      never clear the marker; only a *write* back home does.)
+- [ ] **Move session here** ends the session, moves the conversation and resumes it in
+      the new checkout — with its history intact (ask it about something from before the
+      move). Afterwards the marker is gone, the branch chip is the new branch alone, and
+      `~/.claude/projects/<enc(new)>/<id>.jsonl` exists while the old one does not.
+- [ ] **A refused move is harmless.** Deny it once at the confirm dialog: nothing
+      changes. (The failure path — relaunch in the original folder — is worth forcing
+      once by pre-creating a file at the destination transcript path.)
+
 ### Panes that aren't agents
 
 - [ ] **`❯ Terminal`** opens a working shell pane.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -426,6 +426,7 @@ pub fn run() {
             external::list_external_sessions,
             external::focus_external_session,
             usage::read_transcript,
+            usage::move_session_transcript,
             usage::list_past_sessions,
             usage::list_session_history,
             usage::token_usage_by_day,

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -715,9 +715,11 @@ mod tests {
         // lets it run without a UI to answer the permission prompt.
         let mut child = std::process::Command::new(&claude)
             .arg("-p")
-            .arg("Run the shell command `echo pong` using the Bash tool, then reply with nothing else.")
+            .arg("Do exactly two things and reply with nothing else: run the shell \
+                  command `echo pong` using the Bash tool, then use the Write tool to \
+                  create a file named pong.txt containing the word pong.")
             .arg("--allowedTools")
-            .arg("Bash")
+            .arg("Bash,Write")
             .arg("--session-id")
             .arg(&sid)
             .arg("--settings")
@@ -819,6 +821,36 @@ mod tests {
                 .is_some_and(|c| c.contains("echo")),
             "PostToolUse no longer carries `tool_input.command`; the sidebar's git \
              invalidation reads it to know a checkout may have moved: {tool_hook}"
+        );
+
+        // --- 3c. `file_path`, absolute — the only signal that an agent changed checkout ---
+        // Claude Code pins a session's `cwd` to its launch directory and actively undoes
+        // any `cd` that leaves it ("Shell cwd was reset to …"), verified against 2.1.220.
+        // So when an agent creates a worktree and moves into it, `cwd` never changes and
+        // the sidebar would go on naming the checkout it left. What *does* name the new
+        // one is a write's `file_path` — which is why `driftTarget` reads it, and why it
+        // has to be absolute: a path relative to a cwd that never moved would resolve
+        // back into the old checkout and the drift would be invisible.
+        let write_hook = events
+            .iter()
+            .find(|e| e["kind"] == "hook"
+                && e["data"]["hook_event_name"] == "PostToolUse"
+                && e["data"]["tool_name"] == "Write")
+            .unwrap_or_else(|| panic!(
+                "no PostToolUse hook for a Write arrived, though the prompt asked for \
+                 one. Got tools: {:?}",
+                events.iter().filter_map(|e| e["data"]["tool_name"].as_str()).collect::<Vec<_>>()
+            ));
+        let fp = write_hook["data"]["tool_input"]["file_path"]
+            .as_str()
+            .unwrap_or_else(|| panic!(
+                "Write's PostToolUse no longer carries `tool_input.file_path`; drift \
+                 detection has no other signal that an agent changed checkout: {write_hook}"
+            ));
+        assert!(
+            std::path::Path::new(fp).is_absolute(),
+            "Write's `file_path` is no longer absolute ({fp:?}); driftTarget matches it \
+             against checkout roots, which only works for an absolute path"
         );
 
         // `cwd` is how a hook is correlated with the pane's workdir.

--- a/src-tauri/src/usage.rs
+++ b/src-tauri/src/usage.rs
@@ -664,10 +664,194 @@ fn read_transcript_in(base: &Path, cwd: &str, session_id: &str, limit: usize) ->
     Ok(msgs)
 }
 
+/// Re-home a session's transcript so `claude --resume <id>` finds it in `to_workdir`.
+///
+/// This is the **only** thing Episko ever writes inside `~/.claude`, and it exists
+/// because the alternative does not work: `--resume` takes a session id, never a path
+/// (verified against 2.1.220 — there is no path-based resume flag), and it looks the
+/// conversation up in `<projects>/<enc(cwd)>/`. So a session whose agent moved to
+/// another checkout cannot be resumed there by any incantation a user could type; the
+/// transcript has to move with it.
+///
+/// Three things make that safe rather than reckless, and all three are load-bearing:
+///
+/// - **Rename, never copy.** Two files with one id in two project dirs would list the
+///   same conversation twice in History (which walks `projects/*/*.jsonl`) and leave
+///   `--resume` ambiguous about which one it appends to.
+/// - **The sidecar travels too.** Claude keeps tool results in a `<session_id>/`
+///   directory beside the `.jsonl`; leaving it behind orphans the artifacts an older
+///   turn refers to. It is optional — plenty of sessions never make one.
+/// - **Never clobber.** An existing transcript at the destination is a different
+///   conversation with the same id (or this move already happened); either way it is
+///   refused, not overwritten.
+///
+/// The caller must have stopped the session first. Nothing here can tell whether a
+/// `claude` process still holds the source open, and on a live one the rename would
+/// leave it appending to a path that no longer resolves where anyone will look.
+#[tauri::command(async)]
+pub(crate) fn move_session_transcript(
+    session_id: String,
+    from_workdir: String,
+    to_workdir: String,
+) -> Result<String, String> {
+    let base = claude_dir().ok_or_else(|| "no home directory".to_string())?;
+    move_session_transcript_in(&base, &session_id, &from_workdir, &to_workdir)
+}
+
+fn move_session_transcript_in(
+    base: &Path,
+    session_id: &str,
+    from_workdir: &str,
+    to_workdir: &str,
+) -> Result<String, String> {
+    // A session id reaches us from the frontend and is pasted into a filename. Anything
+    // that isn't the uuid shape it should be would let `..` or a separator escape the
+    // projects tree, so it is rejected outright rather than sanitised.
+    if session_id.is_empty()
+        || !session_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-')
+    {
+        return Err(format!("not a valid session id: {session_id}"));
+    }
+    let from_dir = project_transcript_dir(base, from_workdir);
+    let to_dir = project_transcript_dir(base, to_workdir);
+    if from_dir == to_dir {
+        return Err("that session is already in this folder".to_string());
+    }
+    let src = from_dir.join(format!("{session_id}.jsonl"));
+    if !src.is_file() {
+        return Err(format!(
+            "no transcript for this session in {}",
+            from_dir.display()
+        ));
+    }
+    let dst = to_dir.join(format!("{session_id}.jsonl"));
+    if dst.exists() {
+        return Err("a transcript with this id is already in the target folder".to_string());
+    }
+    std::fs::create_dir_all(&to_dir).map_err(|e| format!("could not create {}: {e}", to_dir.display()))?;
+    std::fs::rename(&src, &dst).map_err(|e| format!("could not move the transcript: {e}"))?;
+
+    // The tool-results sidecar, if this session made one. A failure here is reported
+    // but must not fail the move: the transcript is already across, and the sidecar
+    // only holds artifacts from earlier turns.
+    let side_src = from_dir.join(session_id);
+    if side_src.is_dir() {
+        let side_dst = to_dir.join(session_id);
+        if !side_dst.exists() {
+            if let Err(e) = std::fs::rename(&side_src, &side_dst) {
+                log::warn!("moved transcript but not its tool-results sidecar: {e}");
+            }
+        }
+    }
+    Ok(dst.display().to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::testutil::{git, scratch_dir};
+
+    /// Fixture: a transcript (and optionally its tool-results sidecar) where Claude
+    /// would have written it for `workdir`.
+    fn seed_transcript(base: &Path, workdir: &Path, id: &str, body: &str, sidecar: bool) -> PathBuf {
+        let dir = project_transcript_dir(base, &workdir.to_string_lossy());
+        std::fs::create_dir_all(&dir).unwrap();
+        let f = dir.join(format!("{id}.jsonl"));
+        std::fs::write(&f, body).unwrap();
+        if sidecar {
+            let s = dir.join(id).join("tool-results");
+            std::fs::create_dir_all(&s).unwrap();
+            std::fs::write(s.join("artifact.html"), "<p>kept</p>").unwrap();
+        }
+        f
+    }
+
+    /// The move is what makes "resume in the checkout the agent moved to" possible at
+    /// all — `--resume` looks a conversation up by `<enc(cwd)>/<id>.jsonl` and takes no
+    /// path — so this asserts the shape that lookup depends on, from both ends.
+    #[test]
+    fn move_session_transcript_rehomes_the_conversation_and_its_sidecar() {
+        let root = scratch_dir();
+        let base = root.join("claude");
+        let (from, to) = (root.join("exp-overview"), root.join("overview"));
+        std::fs::create_dir_all(&from).unwrap();
+        std::fs::create_dir_all(&to).unwrap();
+        let id = "acdc250f-a7af-4655-bb87-8ee83731b586";
+        let body = "{\"type\":\"user\",\"cwd\":\"/somewhere\"}\n";
+        let src = seed_transcript(&base, &from, id, body, true);
+
+        let dst = move_session_transcript_in(
+            &base, id, &from.to_string_lossy(), &to.to_string_lossy(),
+        )
+        .expect("the move should succeed");
+
+        // Where `--resume` will look, once the session is relaunched in `to`.
+        let want = project_transcript_dir(&base, &to.to_string_lossy()).join(format!("{id}.jsonl"));
+        assert_eq!(PathBuf::from(&dst), want);
+        assert_eq!(std::fs::read_to_string(&want).unwrap(), body, "content travels intact");
+
+        // A rename, not a copy: one id must not name two conversations. History walks
+        // `projects/*/*.jsonl`, so a leftover would list this session twice, under two
+        // different projects.
+        assert!(!src.exists(), "the source transcript must not be left behind");
+
+        // The sidecar carries the tool results older turns refer to.
+        let side = project_transcript_dir(&base, &to.to_string_lossy())
+            .join(id).join("tool-results").join("artifact.html");
+        assert_eq!(std::fs::read_to_string(&side).unwrap(), "<p>kept</p>");
+        assert!(
+            !project_transcript_dir(&base, &from.to_string_lossy()).join(id).exists(),
+            "the sidecar must move rather than be duplicated",
+        );
+    }
+
+    #[test]
+    fn move_session_transcript_refuses_what_it_cannot_do_safely() {
+        let root = scratch_dir();
+        let base = root.join("claude");
+        let (from, to) = (root.join("a"), root.join("b"));
+        std::fs::create_dir_all(&from).unwrap();
+        std::fs::create_dir_all(&to).unwrap();
+        let id = "acdc250f-a7af-4655-bb87-8ee83731b586";
+        seed_transcript(&base, &from, id, "{}\n", false);
+
+        // Same folder: nothing to do, and the rename would be onto itself.
+        assert!(move_session_transcript_in(
+            &base, id, &from.to_string_lossy(), &from.to_string_lossy(),
+        ).is_err());
+
+        // No such transcript — a session launched but never prompted writes none.
+        assert!(move_session_transcript_in(
+            &base, "11111111-2222-3333-4444-555555555555",
+            &from.to_string_lossy(), &to.to_string_lossy(),
+        ).is_err());
+
+        // An id that is not the uuid shape gets nowhere near a filename: `..` here
+        // would otherwise walk straight out of the projects tree.
+        for bad in ["../../etc/passwd", "a/b", "", "id with space"] {
+            assert!(
+                move_session_transcript_in(
+                    &base, bad, &from.to_string_lossy(), &to.to_string_lossy(),
+                ).is_err(),
+                "must reject session id {bad:?}",
+            );
+        }
+
+        // A different conversation already at the destination is never overwritten.
+        seed_transcript(&base, &to, id, "{\"other\":true}\n", false);
+        assert!(move_session_transcript_in(
+            &base, id, &from.to_string_lossy(), &to.to_string_lossy(),
+        ).is_err());
+        assert_eq!(
+            std::fs::read_to_string(
+                project_transcript_dir(&base, &to.to_string_lossy()).join(format!("{id}.jsonl"))
+            ).unwrap(),
+            "{\"other\":true}\n",
+            "the destination must be left exactly as it was",
+        );
+    }
 
     /// The two-step tail read must never change an answer, only the cost of getting it.
     ///

--- a/src-tauri/src/usage.rs
+++ b/src-tauri/src/usage.rs
@@ -685,9 +685,12 @@ fn read_transcript_in(base: &Path, cwd: &str, session_id: &str, limit: usize) ->
 ///   conversation with the same id (or this move already happened); either way it is
 ///   refused, not overwritten.
 ///
-/// The caller must have stopped the session first. Nothing here can tell whether a
-/// `claude` process still holds the source open, and on a live one the rename would
-/// leave it appending to a path that no longer resolves where anyone will look.
+/// The caller must have stopped the session **and waited for it to actually exit**.
+/// Nothing here can tell whether a `claude` process still holds the source open, and on
+/// a live one the rename would leave it appending to a path that no longer resolves
+/// where anyone will look. Note that killing is not the same as having exited: the
+/// frontend waits for `pty-exit`, which the reaper emits only after `child.wait()`
+/// returns, because `kill_session` merely sends the signal and returns.
 #[tauri::command(async)]
 pub(crate) fn move_session_transcript(
     session_id: String,
@@ -704,9 +707,11 @@ fn move_session_transcript_in(
     from_workdir: &str,
     to_workdir: &str,
 ) -> Result<String, String> {
-    // A session id reaches us from the frontend and is pasted into a filename. Anything
-    // that isn't the uuid shape it should be would let `..` or a separator escape the
-    // projects tree, so it is rejected outright rather than sanitised.
+    // A session id reaches us from the frontend and is pasted into a filename, so it is
+    // restricted to the characters a uuid is made of. That is a character-class test,
+    // not a shape test — `abc` passes — but it is the part that matters here: no dot, no
+    // separator, so no `..` or path fragment can escape the projects tree. Rejected
+    // outright rather than sanitised, because a sanitised id would name the wrong file.
     if session_id.is_empty()
         || !session_id
             .chars()

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -17,9 +17,10 @@ import { refit } from "./terminal";
 import { activeCwd, closeSession, launch } from "./panes";
 import { renderMini, renderSidebar } from "./sidebar";
 import { renderSettings } from "./settings";
+import { queueRosterSave } from "./mirror";
 import {
-  FAVORITES, saveFavorites, sessions, setFavorites, setSortMode, SORT_META,
-  SORT_MODES, sortMode, setWtGroup as setWtGroupState, wtGroup,
+  FAVORITES, markWorkdirStale, saveFavorites, sessions, setFavorites, setSortMode,
+  SORT_META, SORT_MODES, sortMode, setWtGroup as setWtGroupState, wtGroup,
   type SortMode, type WtGroup,
 } from "./state";
 
@@ -105,24 +106,45 @@ export function setTheme(t: "dark" | "light") {
 }
 export function toggleTheme() { setTheme(effectiveTheme() === "dark" ? "light" : "dark"); }
 
-// ---------- moving a session to the checkout its agent moved to ----------
+// ---------- following a session to the checkout its agent moved to ----------
 //
-// The one action in Episko that writes inside `~/.claude`, and the reason it has to:
-// `claude --resume <id>` finds a conversation only under `<enc(cwd)>/<id>.jsonl` and
-// takes no path, so *no sequence of commands a user could type* resumes a session in a
-// folder other than the one it started in. Doing it by hand means exiting, moving a
-// file out of Claude Code's private store, and relaunching with the right flags. This
-// is that, in one click, in the right order.
+// Two drifts, two repairs, and conflating them was the bug this file already shipped
+// once in miniature: what has to happen depends entirely on whether Claude Code moved
+// the session itself or only its writes moved.
 //
-// The order is the safety argument. The session is killed **first**, so nothing is
-// appending to the transcript while it is renamed; the move happens on a dead session,
-// and only then is a new one launched in the new folder against the same conversation.
-// If the move fails, the relaunch still happens — in the original folder, resuming the
-// same id — so a failed move costs a restarted pane and nothing else.
-export async function moveSessionToDrift(id: string) {
+// **via "cwd"** — Claude Code did it (its `EnterWorktree` tool, or a `cd` that stayed
+// inside the project dir). The process is *already* running in the new checkout and
+// Claude has already re-homed the transcript under it. Nothing needs killing, moving or
+// relaunching; Episko is simply behind, and adopting the directory in place is both the
+// complete fix and the one with no cost — the session on screen never even blinks.
+//
+// **via "write"** — the session is still running where it was launched and only its
+// writes moved. Following it therefore means relocating the conversation, and
+// `claude --resume` finds one only under `<enc(cwd)>/<id>.jsonl` and takes no path — so
+// *no sequence of commands a user could type* does this. Kill, move, relaunch: the await
+// on the kill is what makes it a move of a dead session (a live one holds the file open,
+// which Windows refuses to rename outright). A failed move still relaunches, in the
+// original folder, so the cost is a restarted pane and nothing else.
+export async function followSessionDrift(id: string) {
   const s = sessions.get(id);
   if (!s?.drift) return;
-  const { dir, branch } = s.drift;
+  const { dir, branch, via } = s.drift;
+
+  if (via === "cwd") {
+    // No confirm: nothing is destroyed, interrupted or written. This only makes
+    // Episko's idea of the folder agree with the one the session is already in.
+    s.workdir = dir;
+    s.branch = branch;
+    s.worktree = dir === s.colorKey ? null : branch;
+    s.drift = null;
+    s.git = null;                  // the old checkout's working set is not this one's
+    markWorkdirStale(s, "Write");  // re-read the new folder on the next sweep
+    queueRosterSave();             // restore must target the folder the transcript is in
+    renderAll();
+    toast(`Now following ${branch}`);
+    return;
+  }
+
   const ok = await ask(
     `Move this session to ${branch}?\n\n`
     + `Episko will end the session, move its conversation to ${dir}, and resume it there.\n\n`
@@ -134,10 +156,6 @@ export async function moveSessionToDrift(id: string) {
   // Captured before the close, because the fallback path has to be able to rebuild the
   // session exactly as it was — same labels, not the drift's.
   const { project, colorKey, workdir, resumeId, worktree: wasWt, branch: wasBranch } = s;
-  // Kill before close: `closeSession` fires kill_session without awaiting it, and the
-  // rename must not race a process that still has the file open (Windows refuses one
-  // outright; a POSIX rename would succeed and leave the dying session writing into the
-  // moved file). Awaiting the kill is what makes the move a move of a dead session.
   await invoke("kill_session", { sessionId: id }).catch(() => {});
   closeSession(id);
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -9,12 +9,12 @@
 // the repaint are this layer's, exactly as PLAN's `setX`-per-variable decision says.
 
 import { invoke } from "@tauri-apps/api/core";
-import { open } from "@tauri-apps/plugin-dialog";
+import { ask, open } from "@tauri-apps/plugin-dialog";
 import { $, toast } from "./dom";
 import { basename } from "./format";
 import { probeIcon } from "./icons";
 import { refit } from "./terminal";
-import { activeCwd } from "./panes";
+import { activeCwd, closeSession, launch } from "./panes";
 import { renderMini, renderSidebar } from "./sidebar";
 import { renderSettings } from "./settings";
 import {
@@ -104,3 +104,60 @@ export function setTheme(t: "dark" | "light") {
   renderSettings(); // keep the settings picker in sync if it's open
 }
 export function toggleTheme() { setTheme(effectiveTheme() === "dark" ? "light" : "dark"); }
+
+// ---------- moving a session to the checkout its agent moved to ----------
+//
+// The one action in Episko that writes inside `~/.claude`, and the reason it has to:
+// `claude --resume <id>` finds a conversation only under `<enc(cwd)>/<id>.jsonl` and
+// takes no path, so *no sequence of commands a user could type* resumes a session in a
+// folder other than the one it started in. Doing it by hand means exiting, moving a
+// file out of Claude Code's private store, and relaunching with the right flags. This
+// is that, in one click, in the right order.
+//
+// The order is the safety argument. The session is killed **first**, so nothing is
+// appending to the transcript while it is renamed; the move happens on a dead session,
+// and only then is a new one launched in the new folder against the same conversation.
+// If the move fails, the relaunch still happens — in the original folder, resuming the
+// same id — so a failed move costs a restarted pane and nothing else.
+export async function moveSessionToDrift(id: string) {
+  const s = sessions.get(id);
+  if (!s?.drift) return;
+  const { dir, branch } = s.drift;
+  const ok = await ask(
+    `Move this session to ${branch}?\n\n`
+    + `Episko will end the session, move its conversation to ${dir}, and resume it there.\n\n`
+    + `The conversation is kept. Anything the agent is doing right now is interrupted.`,
+    { title: "Move session", kind: "warning", okLabel: "Move & resume", cancelLabel: "Cancel" },
+  );
+  if (!ok) return;
+
+  // Captured before the close, because the fallback path has to be able to rebuild the
+  // session exactly as it was — same labels, not the drift's.
+  const { project, colorKey, workdir, resumeId, worktree: wasWt, branch: wasBranch } = s;
+  // Kill before close: `closeSession` fires kill_session without awaiting it, and the
+  // rename must not race a process that still has the file open (Windows refuses one
+  // outright; a POSIX rename would succeed and leave the dying session writing into the
+  // moved file). Awaiting the kill is what makes the move a move of a dead session.
+  await invoke("kill_session", { sessionId: id }).catch(() => {});
+  closeSession(id);
+
+  let moved = true;
+  try {
+    await invoke("move_session_transcript", { sessionId: resumeId, fromWorkdir: workdir, toWorkdir: dir });
+  } catch (e) {
+    // Nothing was moved — say so and put the session back exactly where it was, rather
+    // than relaunching it in a folder its conversation isn't in.
+    moved = false;
+    toast("Couldn't move the session: " + e);
+  }
+  await launch(project, moved ? dir : workdir, {
+    colorKey,
+    // An agent can drift into the repo's *main* checkout as easily as into a sibling
+    // worktree, and that one is not a worktree — labelling it as one would put a ⑃ on
+    // the repo itself. `colorKey` is the repo root, so the comparison is free.
+    worktree: moved ? (dir === colorKey ? null : branch) : wasWt,
+    branch: moved ? branch : wasBranch,
+    resume: resumeId,
+  });
+  if (moved) toast(`Session moved to ${branch}`);
+}

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -17,6 +17,7 @@ import { refit } from "./terminal";
 import { activeCwd, closeSession, launch } from "./panes";
 import { renderMini, renderSidebar } from "./sidebar";
 import { renderSettings } from "./settings";
+import { waitForExit } from "./tasks";
 import { queueRosterSave } from "./mirror";
 import {
   FAVORITES, markWorkdirStale, saveFavorites, sessions, setFavorites, setSortMode,
@@ -121,10 +122,23 @@ export function toggleTheme() { setTheme(effectiveTheme() === "dark" ? "light" :
 // **via "write"** — the session is still running where it was launched and only its
 // writes moved. Following it therefore means relocating the conversation, and
 // `claude --resume` finds one only under `<enc(cwd)>/<id>.jsonl` and takes no path — so
-// *no sequence of commands a user could type* does this. Kill, move, relaunch: the await
-// on the kill is what makes it a move of a dead session (a live one holds the file open,
-// which Windows refuses to rename outright). A failed move still relaunches, in the
-// original folder, so the cost is a restarted pane and nothing else.
+// *no sequence of commands a user could type* does this. Kill, wait, move, relaunch.
+//
+// The **wait** is load-bearing and is not the `invoke` returning: `kill_session` sends a
+// signal (SIGHUP / TerminateProcess) and returns immediately, so awaiting it proves only
+// that the signal was sent. The process is reaped on a backend thread, which emits
+// `pty-exit` *after* `child.wait()` returns — that event, and only that event, means the
+// transcript handle is closed. Renaming before it lands is the bug the ordering exists
+// to prevent: Windows refuses to rename an open file, and POSIX cheerfully succeeds and
+// leaves the dying session appending into the moved file. Bounded, because a wedged
+// process must not strand the pane forever; past the bound we proceed and the move
+// either works or reports why. A failed move still relaunches, in the original folder,
+// so the cost is a restarted pane and nothing else.
+// How long to give a killed session to actually die before moving its transcript
+// anyway. Generous, because the alternative to waiting is the corruption above, and
+// cheap, because it is only ever reached by a process that ignored its signal.
+const KILL_WAIT_MS = 5000;
+
 export async function followSessionDrift(id: string) {
   const s = sessions.get(id);
   if (!s?.drift) return;
@@ -156,7 +170,12 @@ export async function followSessionDrift(id: string) {
   // Captured before the close, because the fallback path has to be able to rebuild the
   // session exactly as it was — same labels, not the drift's.
   const { project, colorKey, workdir, resumeId, worktree: wasWt, branch: wasBranch } = s;
+  // Register the waiter *before* the kill, or a fast exit resolves into nothing. Note
+  // `closeSession` also settles pending waiters (with -1, so a dependency chain can't
+  // deadlock), which is exactly why this awaits first and closes second.
+  const dead = waitForExit(id);
   await invoke("kill_session", { sessionId: id }).catch(() => {});
+  await Promise.race([dead, new Promise((r) => setTimeout(r, KILL_WAIT_MS))]);
   closeSession(id);
 
   let moved = true;

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -59,6 +59,11 @@ export function dbgSnapshot() {
       id: s.id, project: s.project, phase: s.phase, attention: s.attention, model: s.model,
       ctxPct: s.ctxPct, cost: s.cost, durMs: s.durMs, subagents: s.subagents,
       lastEvent: s.lastEvent, kind: s.kind, external: s.external, branch: s.branch, workdir: s.workdir,
+      // Where the agent's writes are actually landing, when that isn't `workdir`. In
+      // the snapshot because the two disagreeing is precisely the state that needs
+      // explaining from outside the app — the case this was written for looked, from
+      // every log line, like a session sitting quietly in the checkout it had left.
+      drift: s.drift ? `${s.drift.branch} @ ${s.drift.dir}` : null,
     })),
     externals: externals.map((e) => ({ pid: e.pid, session_id: e.session_id, cwd: e.cwd, status: e.status, dirty: folderDirty(e.cwd) })),
     dirtyFolders: [...dirtyByFolder.entries()].map(([f, g]) => ({ folder: f, added: g?.added ?? 0, removed: g?.removed ?? 0, files: g?.files ?? 0, untracked: g?.untracked ?? 0, dirty: isDirty(g) })),

--- a/src/gitwatch.ts
+++ b/src/gitwatch.ts
@@ -1,6 +1,7 @@
-// Deciding, from a shell command an agent just ran, whether Episko should go and
-// re-read git state. Pure logic, in its own module so it can be tested — the DOM and
-// PTY halves of main.ts can't be.
+// What a session's tool activity implies about git: whether Episko should go and
+// re-read state (`gitMutates`), and which checkout the agent's work is actually
+// landing in (`driftTarget`). Pure logic, in its own module so it can be tested —
+// the DOM and PTY halves of main.ts can't be.
 //
 // The contract that makes this safe to keep loose: **this is a trigger, not an
 // authority**. It only decides *when to look*; `git_head` and `worktree_heads` decide
@@ -15,8 +16,10 @@
 //
 // Which is why the list below leans inclusive and doesn't try to be a shell parser.
 
+import type { Drift } from "./types";
+
 /// Verbs that can move HEAD or change the set of checkouts.
-const VERBS = "checkout|switch|worktree|branch|merge|rebase|reset|pull|stash";
+const VERBS ="checkout|switch|worktree|branch|merge|rebase|reset|pull|stash";
 
 // Matched anywhere in the string, because `cd sub && git switch x` is entirely normal.
 // The bounded gap between `git` and the verb lets global flags through
@@ -30,4 +33,86 @@ const GIT_MUTATES = new RegExp(
 /// True when `cmd` might have moved HEAD or changed the set of worktrees.
 export function gitMutates(cmd: unknown): boolean {
   return typeof cmd === "string" && GIT_MUTATES.test(cmd);
+}
+
+// ---------- drift: the agent is working in a checkout it wasn't launched in ----------
+//
+// An agent that runs `git worktree add … -b feat/x` and then works in the new checkout
+// leaves the session pinned to the folder it started in — and Claude Code guarantees we
+// cannot learn the move from `cwd`. Verified against the real CLI (2.1.220): a `cd`
+// *inside* the session's directory persists and the hook's `cwd` follows it, but a `cd`
+// *outside* it is undone ("Shell cwd was reset to …") and `cwd` never moves. The
+// session that prompted this had 42 such resets and 622 records all naming the folder
+// it had already left.
+//
+// What does name the new checkout is the file-writing tools' `file_path`, absolute on
+// every payload. So drift is read off writes — and only writes, because a Read lands
+// anywhere (a sibling repo, ~/.claude, a temp dir) and would make this flap.
+const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
+
+// Path containment, tolerant of the two spellings a path reaches us in: Windows
+// backslashes, and a trailing separator on a directory. Case is left alone — the
+// comparison is between two paths git itself reported, so they already agree.
+function under(dir: string, path: string): boolean {
+  const d = dir.replace(/\\/g, "/").replace(/\/+$/, "");
+  const p = path.replace(/\\/g, "/");
+  return d !== "" && (p === d || p.startsWith(d + "/"));
+}
+
+type Checkout = { path: string; branch: string; exists: boolean };
+
+// Which checkout a path belongs to. The *longest* match wins, and that is the whole
+// subtlety: a worktree may sit inside its own repo (`repo/wt/feature`), where the repo
+// root also contains the path and would otherwise win by appearing first.
+function checkoutOf(path: string, roster: readonly Checkout[]): Checkout | null {
+  let best: Checkout | null = null;
+  for (const w of roster) {
+    if (!w.exists || !under(w.path, path)) continue;
+    if (!best || w.path.length > best.path.length) best = w;
+  }
+  return best;
+}
+
+/// Which checkout an agent's write landed in, when that isn't the session's own.
+///
+/// Deliberately narrow: the target must be a checkout of *this session's repo* that the
+/// worktree roster already knows about. "Any directory outside the workdir" would fire
+/// on a scratch file or an edit to a config in $HOME — a false positive here doesn't
+/// cost a wasted re-read like `gitMutates`, it puts a wrong branch name on screen and
+/// offers to move a live session into it. So an unknown folder reads as no drift, and
+/// the poll that maintains the roster is what makes a genuinely new worktree visible.
+///
+/// Both sides resolve to a checkout before being compared, rather than testing the file
+/// against `workdir` directly. That is what keeps two different launches straight: a
+/// session started in a *subfolder* of a checkout has not drifted when it writes
+/// elsewhere in that same checkout, while one started in a nested worktree has drifted
+/// the moment it writes to the enclosing repo.
+export function driftTarget(
+  workdir: string, tool: string, filePath: unknown, roster: readonly Checkout[],
+): Drift | null {
+  if (!WRITE_TOOLS.has(tool) || typeof filePath !== "string" || !filePath.trim()) return null;
+  const target = checkoutOf(filePath, roster);
+  if (!target) return null;                      // wrote somewhere that isn't a checkout
+  if (target.path === checkoutOf(workdir, roster)?.path) return null;
+  return { dir: target.path, branch: target.branch };
+}
+
+/// The session's drift after one settled tool call — latched, not sampled.
+///
+/// Sampling would be wrong, and visibly so: an agent building in another checkout still
+/// *reads* its original one constantly (that is usually why it moved — to port work
+/// across), so a flag recomputed from each tool call would flicker off on every such
+/// read and take the inspector's card and the sidebar's marker with it. So a drift, once
+/// seen, holds until the agent writes home again — which is the act, and the only act,
+/// that means it came back. Anything else (a read anywhere, a write to a third checkout
+/// that is not this repo's, a Bash call) leaves the answer alone.
+export function driftUpdate(
+  prev: Drift | null, workdir: string, tool: string, filePath: unknown, roster: readonly Checkout[],
+): Drift | null {
+  const target = driftTarget(workdir, tool, filePath, roster);
+  if (target) return target;
+  // Not drift. Was it a write *home*? Only then does an existing drift clear.
+  if (!WRITE_TOOLS.has(tool) || typeof filePath !== "string" || !filePath.trim()) return prev;
+  const wrote = checkoutOf(filePath, roster);
+  return wrote && wrote.path === checkoutOf(workdir, roster)?.path ? null : prev;
 }

--- a/src/gitwatch.ts
+++ b/src/gitwatch.ts
@@ -65,12 +65,25 @@ export function gitMutates(cmd: unknown): boolean {
 //   a flag recomputed per tool call would flicker off on every such read.
 const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
 
-// Path containment, tolerant of the two spellings a path reaches us in: Windows
-// backslashes, and a trailing separator on a directory. Case is left alone — the
-// comparison is between two paths git itself reported, so they already agree.
+// The two sides of every comparison here come from different places and are spelled
+// differently, which is the trap this codebase has already fallen into once (see
+// History's `norm_path`, where skipping it made a repo's own checkout unequal to its own
+// root and 135 of 219 rows read as worktrees). The roster side is resolved and
+// normalised in Rust — `worktree_heads` returns `norm_path(physical_cwd(…))`. The other
+// side is raw: `cwd` and `file_path` as Claude Code reports them, and `Sess.workdir` as
+// the user spelled it when they picked the folder.
+//
+// So separators and a trailing slash are levelled here, and case with them: `norm_path`
+// upper-cases a Windows drive letter that Claude may well send lower-case, and both
+// mainstream desktop filesystems are case-insensitive by default anyway. The cost is
+// that two checkouts differing only in case would read as one — on a case-sensitive
+// volume, and vanishingly unlikely for checkouts of the same repo. Symlinks cannot be
+// resolved from here at all, which is what `checkoutDrift` failing closed is for.
+function norm(p: string): string {
+  return p.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+}
 function under(dir: string, path: string): boolean {
-  const d = dir.replace(/\\/g, "/").replace(/\/+$/, "");
-  const p = path.replace(/\\/g, "/");
+  const d = norm(dir), p = norm(path);
   return d !== "" && (p === d || p.startsWith(d + "/"));
 }
 
@@ -102,11 +115,19 @@ function checkoutOf(path: string, roster: readonly Checkout[]): Checkout | null 
 /// session started in a *subfolder* of a checkout has not drifted when it works
 /// elsewhere in that same checkout (and `cd src/` is not a checkout change), while one
 /// started in a nested worktree has drifted the moment it touches the enclosing repo.
+/// **Fails closed**, and that is the whole of its safety. If the session's *own* folder
+/// cannot be placed in the roster — a spelling git resolved and we cannot (a symlinked
+/// project path), a roster read before the checkout existed — then nothing here is
+/// knowable and the answer is "no drift". Comparing against a missing home instead would
+/// make every write into the session's own checkout read as a move, permanently, which
+/// is worse than saying nothing: the card would offer to relocate a session that never
+/// went anywhere.
 function checkoutDrift(workdir: string, path: unknown, roster: readonly Checkout[]) {
   if (typeof path !== "string" || !path.trim()) return null;
+  const home = checkoutOf(workdir, roster);
+  if (!home) return null;
   const target = checkoutOf(path, roster);
-  if (!target) return null;                      // not in any checkout of this repo
-  if (target.path === checkoutOf(workdir, roster)?.path) return null;
+  if (!target || target.path === home.path) return null;
   return { dir: target.path, branch: target.branch };
 }
 
@@ -145,7 +166,11 @@ export function driftUpdate(
 
   const byWrite = driftTarget(workdir, tool, filePath, roster);
   if (byWrite) return byWrite;
+  // Not drift. Only a write that landed squarely in the session's own checkout retires
+  // one — and, as above, only when we can actually place that checkout. An unplaceable
+  // home clears nothing rather than clearing everything.
   if (!WRITE_TOOLS.has(tool) || typeof filePath !== "string" || !filePath.trim()) return prev;
+  const home = checkoutOf(workdir, roster);
   const wrote = checkoutOf(filePath, roster);
-  return wrote && wrote.path === checkoutOf(workdir, roster)?.path ? null : prev;
+  return home && wrote && wrote.path === home.path ? null : prev;
 }

--- a/src/gitwatch.ts
+++ b/src/gitwatch.ts
@@ -37,17 +37,32 @@ export function gitMutates(cmd: unknown): boolean {
 
 // ---------- drift: the agent is working in a checkout it wasn't launched in ----------
 //
-// An agent that runs `git worktree add … -b feat/x` and then works in the new checkout
-// leaves the session pinned to the folder it started in — and Claude Code guarantees we
-// cannot learn the move from `cwd`. Verified against the real CLI (2.1.220): a `cd`
-// *inside* the session's directory persists and the hook's `cwd` follows it, but a `cd`
-// *outside* it is undone ("Shell cwd was reset to …") and `cwd` never moves. The
-// session that prompted this had 42 such resets and 622 records all naming the folder
-// it had already left.
+// There are **two** ways an agent changes checkout, they behave as opposites, and each
+// is invisible to the signal that catches the other. Both were verified against the real
+// CLI (2.1.220) and against real sessions, because guessing here produced a feature that
+// covered one of them and read as broken in the other.
 //
-// What does name the new checkout is the file-writing tools' `file_path`, absolute on
-// every payload. So drift is read off writes — and only writes, because a Read lands
-// anywhere (a sibling repo, ~/.claude, a temp dir) and would make this flap.
+// **1. Out of the project dir** — `git worktree add ../feature` via Bash, the sibling
+// layout. Claude Code pins the session to its launch directory and actively undoes any
+// `cd` that leaves it ("Shell cwd was reset to …"), so `cwd` never moves; the session
+// that prompted this had 42 such resets and 622 records all naming the folder it had
+// already left. The transcript stays where it was. The only thing that names the new
+// checkout is a write's `file_path`, absolute on every payload.
+//
+// **2. Into the project dir** — Claude Code's own `EnterWorktree` tool, which creates
+// `<repo>/.claude/worktrees/<name>`. Being inside the project dir, there is no reset:
+// `cwd` *follows*, and Claude **re-homes its own transcript** under the new directory.
+// So `cwd` is authoritative here — and `gitMutates` never fires, because no Bash command
+// was run at all.
+//
+// Hence two signals with different standing, and the asymmetry is the whole design:
+//
+// - `cwd` may only ever **set** a drift, never clear a write-derived one. A `cwd` that
+//   says "home" proves nothing about where the writes are going — that is precisely
+//   case 1, where it says "home" for the entire life of the drift.
+// - Writes are the fallback for case 1, and they **latch**: an agent working in another
+//   checkout still reads its original one constantly (that is usually why it moved), so
+//   a flag recomputed per tool call would flicker off on every such read.
 const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
 
 // Path containment, tolerant of the two spellings a path reaches us in: Windows
@@ -73,45 +88,63 @@ function checkoutOf(path: string, roster: readonly Checkout[]): Checkout | null 
   return best;
 }
 
-/// Which checkout an agent's write landed in, when that isn't the session's own.
+/// Which checkout `path` belongs to, when that isn't the session's own.
 ///
 /// Deliberately narrow: the target must be a checkout of *this session's repo* that the
 /// worktree roster already knows about. "Any directory outside the workdir" would fire
 /// on a scratch file or an edit to a config in $HOME — a false positive here doesn't
 /// cost a wasted re-read like `gitMutates`, it puts a wrong branch name on screen and
-/// offers to move a live session into it. So an unknown folder reads as no drift, and
+/// offers to relocate a live session into it. So an unknown folder reads as no drift, and
 /// the poll that maintains the roster is what makes a genuinely new worktree visible.
 ///
-/// Both sides resolve to a checkout before being compared, rather than testing the file
-/// against `workdir` directly. That is what keeps two different launches straight: a
-/// session started in a *subfolder* of a checkout has not drifted when it writes
-/// elsewhere in that same checkout, while one started in a nested worktree has drifted
-/// the moment it writes to the enclosing repo.
-export function driftTarget(
-  workdir: string, tool: string, filePath: unknown, roster: readonly Checkout[],
-): Drift | null {
-  if (!WRITE_TOOLS.has(tool) || typeof filePath !== "string" || !filePath.trim()) return null;
-  const target = checkoutOf(filePath, roster);
-  if (!target) return null;                      // wrote somewhere that isn't a checkout
+/// Both sides resolve to a checkout before being compared, rather than testing `path`
+/// against `workdir` directly. That is what keeps several cases straight at once: a
+/// session started in a *subfolder* of a checkout has not drifted when it works
+/// elsewhere in that same checkout (and `cd src/` is not a checkout change), while one
+/// started in a nested worktree has drifted the moment it touches the enclosing repo.
+function checkoutDrift(workdir: string, path: unknown, roster: readonly Checkout[]) {
+  if (typeof path !== "string" || !path.trim()) return null;
+  const target = checkoutOf(path, roster);
+  if (!target) return null;                      // not in any checkout of this repo
   if (target.path === checkoutOf(workdir, roster)?.path) return null;
   return { dir: target.path, branch: target.branch };
 }
 
-/// The session's drift after one settled tool call — latched, not sampled.
-///
-/// Sampling would be wrong, and visibly so: an agent building in another checkout still
-/// *reads* its original one constantly (that is usually why it moved — to port work
-/// across), so a flag recomputed from each tool call would flicker off on every such
-/// read and take the inspector's card and the sidebar's marker with it. So a drift, once
-/// seen, holds until the agent writes home again — which is the act, and the only act,
-/// that means it came back. Anything else (a read anywhere, a write to a third checkout
-/// that is not this repo's, a Bash call) leaves the answer alone.
-export function driftUpdate(
-  prev: Drift | null, workdir: string, tool: string, filePath: unknown, roster: readonly Checkout[],
+/// Which checkout an agent's *write* landed in, when that isn't the session's own.
+/// The signal for case 1 above — the only one that works when `cwd` is pinned.
+export function driftTarget(
+  workdir: string, tool: string, filePath: unknown, roster: readonly Checkout[],
 ): Drift | null {
-  const target = driftTarget(workdir, tool, filePath, roster);
-  if (target) return target;
-  // Not drift. Was it a write *home*? Only then does an existing drift clear.
+  if (!WRITE_TOOLS.has(tool)) return null;
+  const d = checkoutDrift(workdir, filePath, roster);
+  return d && { ...d, via: "write" };
+}
+
+/// The session's drift after one hook — both signals, in order of standing.
+///
+/// `cwd` first, because when it moves it is Claude Code stating where the session now
+/// lives, which no heuristic can outrank: it also means the transcript has moved, so the
+/// two drifts need different repairs (see `via`). But it is **positive-only**. A `cwd`
+/// reading "home" is the normal, permanent state of a case-1 drift, so letting it clear
+/// one would delete the answer on the very next hook. It may retire only a drift `cwd`
+/// itself reported.
+///
+/// Writes then latch, for case 1. A drift, once seen, holds until the agent writes home
+/// again — the act, and the only act, that means it came back. Anything else (a read
+/// anywhere, a write to a folder that is no checkout of this repo, a Bash call) leaves
+/// the answer alone.
+export function driftUpdate(
+  prev: Drift | null, workdir: string, tool: string, filePath: unknown, cwd: unknown,
+  roster: readonly Checkout[],
+): Drift | null {
+  const byCwd = checkoutDrift(workdir, cwd, roster);
+  if (byCwd) return { ...byCwd, via: "cwd" };
+  // `cwd` resolved to the session's own checkout: authoritative *only* over a drift it
+  // reported. A `cwd` that names no checkout at all (a scratch dir, $HOME) says nothing.
+  if (prev?.via === "cwd" && typeof cwd === "string" && checkoutOf(cwd, roster)) return null;
+
+  const byWrite = driftTarget(workdir, tool, filePath, roster);
+  if (byWrite) return byWrite;
   if (!WRITE_TOOLS.has(tool) || typeof filePath !== "string" || !filePath.trim()) return prev;
   const wrote = checkoutOf(filePath, roster);
   return wrote && wrote.path === checkoutOf(workdir, roster)?.path ? null : prev;

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -22,7 +22,7 @@ import { sessions } from "./state";
 // main.ts; now that they are ./taskrun this module simply imports them.
 import { rerunTask, revealSource, sendOutputToSession } from "./taskrun";
 import {
-  gaugesHtml, planHtml, resHtml, RISK_LABEL, timelineHtml, vitalHtml, wsetHtml,
+  driftHtml, gaugesHtml, planHtml, resHtml, RISK_LABEL, timelineHtml, vitalHtml, wsetHtml,
 } from "./inspectorview";
 
 export function renderInspector(s: Sess | null) {
@@ -51,6 +51,9 @@ export function renderInspector(s: Sess | null) {
       : "The turn ended early — the conversation is intact. Send the prompt again to pick it back up.";
     html.push(`<div class="attn err"><div class="attn-h">⚠ ${esc(apiErrText(s.apiErr))}</div>${s.apiErr.detail ? `<code>${esc(s.apiErr.detail)}</code>` : ""}<div class="attn-note">${note}</div></div>`);
   }
+  // Above the vital, and above the working set it contradicts: everything below reads
+  // the folder the session was launched in, which is not where the work is going.
+  if (s.drift) html.push(driftHtml(s));
   html.push(vitalHtml(s));                                        // state, dwell, current tool
   html.push(gaugesHtml(s));                                       // TRACK — context + cost
   if (s.todos.length) html.push(planHtml(s));                     // the plan it's keeping

--- a/src/inspectorview.ts
+++ b/src/inspectorview.ts
@@ -12,7 +12,7 @@
 // git operation in flight is only ever read to grey them out. main.ts's runGit
 // sets it through setGitBusy — the state.ts convention, a live binding to read.
 
-import { esc, fmtDur, fmtDwell, fmtLatency, fmtMb, fmtRate, sparkline } from "./format";
+import { basename, esc, fmtDur, fmtDwell, fmtLatency, fmtMb, fmtRate, sparkline, tilde } from "./format";
 import type { DiffHunk } from "./diff";
 import { apiErrText, isAgent, statusKey, type DiffStat, type Risk, type Sess } from "./types";
 import { sessions } from "./state";
@@ -117,6 +117,24 @@ export function planHtml(s: Sess): string {
   }).join("");
   const more = total > 5 ? `<div class="todo-more">+${total - 5} more</div>` : "";
   return `<div class="plan"><div class="ph"><span class="lab">Plan</span><span class="frac">${done} / ${total}</span></div><div class="pbar"><i style="width:${pct}%"></i></div>${rows}${more}</div>`;
+}
+// "This agent is writing somewhere else." Sits at the top of the inspector because it
+// reframes every figure below it: the working set, the branch and the fetch/pull/push
+// buttons all read the *launch* folder, and while a drift is showing, that is not where
+// the work is going.
+//
+// The offer is the clean thing a user would otherwise do by hand — except that by hand
+// it does not work: `--resume` finds a conversation only in the directory it was started
+// in, so relocating a session means moving its transcript, which is what the button does
+// and a terminal cannot. Hence the explicit wording; this is not a view toggle.
+export function driftHtml(s: Sess): string {
+  const d = s.drift!;
+  return `<div class="drift">
+    <div class="drift-h"><span class="drift-g">⤳</span>Working in <span class="b">${esc(d.branch)}</span></div>
+    <div class="drift-path" title="${esc(d.dir)}">${esc(tilde(d.dir))}</div>
+    <div class="drift-note">This session was launched in <span class="b">${esc(s.branch || basename(s.workdir))}</span>, so its branch, working set and git buttons still read that checkout.</div>
+    <div class="drift-btns"><button data-driftmove="${esc(s.id)}">Move session here</button></div>
+  </div>`;
 }
 export function wsetHtml(s: Sess): string {
   const g = s.git!;

--- a/src/inspectorview.ts
+++ b/src/inspectorview.ts
@@ -118,22 +118,28 @@ export function planHtml(s: Sess): string {
   const more = total > 5 ? `<div class="todo-more">+${total - 5} more</div>` : "";
   return `<div class="plan"><div class="ph"><span class="lab">Plan</span><span class="frac">${done} / ${total}</span></div><div class="pbar"><i style="width:${pct}%"></i></div>${rows}${more}</div>`;
 }
-// "This agent is writing somewhere else." Sits at the top of the inspector because it
+// "This session is somewhere else." Sits at the top of the inspector because it
 // reframes every figure below it: the working set, the branch and the fetch/pull/push
 // buttons all read the *launch* folder, and while a drift is showing, that is not where
 // the work is going.
 //
-// The offer is the clean thing a user would otherwise do by hand — except that by hand
-// it does not work: `--resume` finds a conversation only in the directory it was started
-// in, so relocating a session means moving its transcript, which is what the button does
-// and a terminal cannot. Hence the explicit wording; this is not a view toggle.
+// The copy and the button differ by `via`, because the two drifts are genuinely
+// different situations rather than one situation with two causes — one is Episko being
+// behind (free to fix), the other is a relocation only Episko can perform. Saying
+// "move" for the first would overstate what happens; saying "follow" for the second
+// would understate it.
 export function driftHtml(s: Sess): string {
   const d = s.drift!;
+  const here = esc(s.branch || basename(s.workdir));
+  const cwdMove = d.via === "cwd";
+  const note = cwdMove
+    ? `Claude moved this session itself, so its conversation is already there. Episko is still showing <span class="b">${here}</span> — following it costs nothing and interrupts nothing.`
+    : `The session is still running in <span class="b">${here}</span>, so its branch, working set and git buttons read that checkout. Moving it takes the conversation along.`;
   return `<div class="drift">
     <div class="drift-h"><span class="drift-g">⤳</span>Working in <span class="b">${esc(d.branch)}</span></div>
     <div class="drift-path" title="${esc(d.dir)}">${esc(tilde(d.dir))}</div>
-    <div class="drift-note">This session was launched in <span class="b">${esc(s.branch || basename(s.workdir))}</span>, so its branch, working set and git buttons still read that checkout.</div>
-    <div class="drift-btns"><button data-driftmove="${esc(s.id)}">Move session here</button></div>
+    <div class="drift-note">${note}</div>
+    <div class="drift-btns"><button data-driftfollow="${esc(s.id)}">${cwdMove ? "Follow it here" : "Move session here"}</button></div>
   </div>`;
 }
 export function wsetHtml(s: Sess): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ import { renderInspector } from "./inspector";
 import { applyFontSize, bumpFont, refit } from "./terminal";
 import {
   addProject, addProjectPath, cycleSort, effectiveTheme, openProjectFolder,
-  moveSessionToDrift, removeFavorite, resolvePermission, revealActiveFolder,
+  followSessionDrift, removeFavorite, resolvePermission, revealActiveFolder,
   setActionsRenderAll,
   setSort, setTheme, setWtGroup, toggleInsp, toggleRail, toggleTheme,
 } from "./actions";
@@ -150,8 +150,8 @@ setOnTurnEnd((s) => { void maybeRunOnStop(s); });
 // changed its checkout — nothing watches the filesystem. Two consequences, both cheap:
 // the folder is queued for a working-set re-read, and a git command that could have
 // moved HEAD or added a worktree pokes the git views straight away.
-setOnSessionTouched((s, tool, input) => {
-  markWorkdirStale(s, tool); noteGitCommand(input?.command); noteDrift(s, tool, input);
+setOnSessionTouched((s, tool, data) => {
+  markWorkdirStale(s, tool); noteGitCommand(data?.tool_input?.command); noteDrift(s, tool, data);
 });
 setTaskLauncher(launchTask);
 setTaskLogger(dlog);
@@ -455,10 +455,10 @@ document.addEventListener("click", (e) => {
   if (dot) { const owner = dot.closest<HTMLElement>("[data-key]"); if (owner?.dataset.key) { openColorPopover(owner.dataset.key, e.clientX, e.clientY + 6); return; } }
   // data-forget and data-resume sit INSIDE a data-past row, so they must be matched
   // (and dispatched) ahead of it or the row's own click would swallow them.
-  const el = t.closest<HTMLElement>("[data-perm],[data-driftmove],[data-git],[data-diff],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-sel],[data-launch],[data-wtlaunch],[data-pal],[data-rail],[data-toast]");
+  const el = t.closest<HTMLElement>("[data-perm],[data-driftfollow],[data-git],[data-diff],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-sel],[data-launch],[data-wtlaunch],[data-pal],[data-rail],[data-toast]");
   if (!el) return;
   if (el.dataset.perm) resolvePermission(el.dataset.permid || "", el.dataset.perm);
-  else if (el.dataset.driftmove) void moveSessionToDrift(el.dataset.driftmove);
+  else if (el.dataset.driftfollow) void followSessionDrift(el.dataset.driftfollow);
   else if (el.dataset.git) runGit(el.dataset.gitsid || "", el.dataset.git);
   else if (el.dataset.diff) openDiff(el.dataset.diff, el.dataset.difftitle || "");
   else if (el.dataset.close) closeSession(el.dataset.close);

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,12 +20,13 @@ import { renderInspector } from "./inspector";
 import { applyFontSize, bumpFont, refit } from "./terminal";
 import {
   addProject, addProjectPath, cycleSort, effectiveTheme, openProjectFolder,
-  removeFavorite, resolvePermission, revealActiveFolder, setActionsRenderAll,
+  moveSessionToDrift, removeFavorite, resolvePermission, revealActiveFolder,
+  setActionsRenderAll,
   setSort, setTheme, setWtGroup, toggleInsp, toggleRail, toggleTheme,
 } from "./actions";
 import {
   activeCwd, activeProjectCtx, closeSession, handToTerminal, launch, launchShell,
-  launchTask, noteGitCommand, openPlainTerminal, refreshGitViews, refreshSessionStats, renderHeader,
+  launchTask, noteDrift, noteGitCommand, openPlainTerminal, refreshGitViews, refreshSessionStats, renderHeader,
   requestLaunch, runGit, scheduleDismiss, setActive, setPanesRenderAll,
   syncStageButtons,
 } from "./panes";
@@ -149,7 +150,9 @@ setOnTurnEnd((s) => { void maybeRunOnStop(s); });
 // changed its checkout — nothing watches the filesystem. Two consequences, both cheap:
 // the folder is queued for a working-set re-read, and a git command that could have
 // moved HEAD or added a worktree pokes the git views straight away.
-setOnSessionTouched((s, tool, cmd) => { markWorkdirStale(s, tool); noteGitCommand(cmd); });
+setOnSessionTouched((s, tool, input) => {
+  markWorkdirStale(s, tool); noteGitCommand(input?.command); noteDrift(s, tool, input);
+});
 setTaskLauncher(launchTask);
 setTaskLogger(dlog);
 setTaskToast(toast);
@@ -452,9 +455,10 @@ document.addEventListener("click", (e) => {
   if (dot) { const owner = dot.closest<HTMLElement>("[data-key]"); if (owner?.dataset.key) { openColorPopover(owner.dataset.key, e.clientX, e.clientY + 6); return; } }
   // data-forget and data-resume sit INSIDE a data-past row, so they must be matched
   // (and dispatched) ahead of it or the row's own click would swallow them.
-  const el = t.closest<HTMLElement>("[data-perm],[data-git],[data-diff],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-sel],[data-launch],[data-wtlaunch],[data-pal],[data-rail],[data-toast]");
+  const el = t.closest<HTMLElement>("[data-perm],[data-driftmove],[data-git],[data-diff],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-sel],[data-launch],[data-wtlaunch],[data-pal],[data-rail],[data-toast]");
   if (!el) return;
   if (el.dataset.perm) resolvePermission(el.dataset.permid || "", el.dataset.perm);
+  else if (el.dataset.driftmove) void moveSessionToDrift(el.dataset.driftmove);
   else if (el.dataset.git) runGit(el.dataset.gitsid || "", el.dataset.git);
   else if (el.dataset.diff) openDiff(el.dataset.diff, el.dataset.difftitle || "");
   else if (el.dataset.close) closeSession(el.dataset.close);

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -400,15 +400,17 @@ export function noteGitCommand(cmd: unknown) {
 // the session's own folder, so a session whose agent moved to a sibling checkout goes on
 // reporting the branch it left, forever and correctly.
 //
-// `driftUpdate` owns the rule (including why it latches); this owns only the repaint.
-export function noteDrift(s: Sess, tool: string, input: any) {
+// `driftUpdate` owns the rule (including which signal outranks which); this owns only
+// the repaint. Both fields it reads come off the same payload — `cwd` catches the moves
+// Claude Code makes itself, `file_path` the ones it doesn't know about.
+export function noteDrift(s: Sess, tool: string, data: any) {
   if (!isAgent(s) || !s.workdir) return;
   const roster = worktreesByRepo.get(s.colorKey);
   if (!roster?.length) return;   // no roster yet — the 4s poll seeds it, then this works
-  const next = driftUpdate(s.drift, s.workdir, tool, input?.file_path, roster);
-  if (next?.dir === s.drift?.dir) return;
+  const next = driftUpdate(s.drift, s.workdir, tool, data?.tool_input?.file_path, data?.cwd, roster);
+  if (next?.dir === s.drift?.dir && next?.via === s.drift?.via) return;
   s.drift = next;
-  dlog("info", next ? `drift ${s.id.slice(0, 8)} → ${next.branch}` : `drift cleared ${s.id.slice(0, 8)}`);
+  dlog("info", next ? `drift ${s.id.slice(0, 8)} → ${next.branch} (via ${next.via})` : `drift cleared ${s.id.slice(0, 8)}`);
   renderAll();
 }
 

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -408,7 +408,9 @@ export function noteDrift(s: Sess, tool: string, data: any) {
   const roster = worktreesByRepo.get(s.colorKey);
   if (!roster?.length) return;   // no roster yet — the 4s poll seeds it, then this works
   const next = driftUpdate(s.drift, s.workdir, tool, data?.tool_input?.file_path, data?.cwd, roster);
-  if (next?.dir === s.drift?.dir && next?.via === s.drift?.via) return;
+  // All three fields, not just the identity of the checkout: the branch on a drifted-into
+  // checkout can be switched underneath us, and it is what every drift surface spells out.
+  if (next?.dir === s.drift?.dir && next?.via === s.drift?.via && next?.branch === s.drift?.branch) return;
   s.drift = next;
   dlog("info", next ? `drift ${s.id.slice(0, 8)} → ${next.branch} (via ${next.via})` : `drift cleared ${s.id.slice(0, 8)}`);
   renderAll();
@@ -429,10 +431,11 @@ export function scheduleDismiss(s: Sess) {
 
 export function renderHeader(s: Sess | null) {
   ($("btnClose") as HTMLButtonElement).hidden = !s;
-  const hb = $("hBranch"); hb.classList.remove("ext-chip");
+  // Reset every attribute a previous session may have left on the shared chip — the
+  // drift branch below sets `title`, and only one of the arms after it would clear it.
+  const hb = $("hBranch"); hb.classList.remove("ext-chip", "drifted"); hb.title = "";
   if (!s) { $("hProj").textContent = "no session"; hb.hidden = true; $("hTitle").textContent = ""; $("hPath").textContent = ""; return; }
   $("hProj").textContent = s.project;
-  hb.classList.remove("drifted");
   if (s.kind !== "claude") { hb.textContent = s.kind === "shell" ? "shell" : "task"; hb.hidden = false; hb.classList.add("ext-chip"); }
   // A drifted session gets BOTH branches, in the order they happened: the chip is the
   // only thing on screen that says which checkout the work is landing in, and showing
@@ -442,7 +445,7 @@ export function renderHeader(s: Sess | null) {
     hb.title = `Launched in ${s.workdir}\nWriting to ${s.drift.dir}`;
     hb.hidden = false; hb.classList.add("drifted");
   }
-  else if (s.branch) { hb.textContent = s.worktree ? "⑃ " + s.branch : s.branch; hb.title = ""; hb.hidden = false; } else hb.hidden = true;
+  else if (s.branch) { hb.textContent = s.worktree ? "⑃ " + s.branch : s.branch; hb.hidden = false; } else hb.hidden = true;
   $("hTitle").textContent = s.kind === "claude" ? (s.title || "") : (s.kind === "task" ? s.run?.label ?? "" : "");
   // The path follows the work for the same reason — it is the answer to "where am I?".
   $("hPath").textContent = tilde(s.drift?.dir ?? s.workdir);

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -27,7 +27,7 @@ import {
   isAgent, type DiffStat, type GitActionResult, type Res, type Runnable, type Sess,
   type WtHead,
 } from "./types";
-import { gitMutates } from "./gitwatch";
+import { driftUpdate, gitMutates } from "./gitwatch";
 import { fmtMb, fmtRate } from "./format";
 import { claudeInput, cleanTitle, fitSession, loadWebgl, macShellKeys, MONO, winClaudePaste } from "./terminal";
 import { gitBusy, setGitBusy } from "./inspectorview";
@@ -82,7 +82,7 @@ export async function launch(project: string, workdir: string, opts: { colorKey?
   const s: Sess = {
     id, project, accent, workdir, colorKey, resumeId: opts.resume ?? id,
     branch: opts.branch ?? "", worktree: opts.worktree ?? null, title: "",
-    phase: "idle", phaseSince: Date.now(), lastActivity: Date.now(), attention: null, pendingCmd: "", pendingPermId: null, pendRisk: null, subagents: 0, apiErr: null,
+    phase: "idle", phaseSince: Date.now(), lastActivity: Date.now(), attention: null, pendingCmd: "", pendingPermId: null, pendRisk: null, subagents: 0, apiErr: null, drift: null,
     model: "", ctxPct: null, ctxTokens: null, cost: null, durMs: null,
     curTool: "", curArg: "", todos: [], ctxHist: [], costHist: [], git: null, res: null,
     lastEvent: "", activity: [], kind: "claude", external, term, fit, pane,
@@ -164,7 +164,7 @@ export async function launchShell(project: string, workdir: string, opts: { colo
     // resumeId is inert for a shell — it has no transcript and saveRoster skips it.
     id, project, accent: accentFor(colorKey), workdir, colorKey, resumeId: id,
     branch: opts.branch ?? "", worktree: opts.worktree ?? null, title: "shell",
-    phase: "idle", phaseSince: Date.now(), lastActivity: Date.now(), attention: null, pendingCmd: "", pendingPermId: null, pendRisk: null, subagents: 0, apiErr: null,
+    phase: "idle", phaseSince: Date.now(), lastActivity: Date.now(), attention: null, pendingCmd: "", pendingPermId: null, pendRisk: null, subagents: 0, apiErr: null, drift: null,
     model: "", ctxPct: null, ctxTokens: null, cost: null, durMs: null,
     curTool: "", curArg: "", todos: [], ctxHist: [], costHist: [], git: null, res: null,
     lastEvent: "", activity: [],
@@ -216,7 +216,7 @@ export async function launchTask(r: Runnable, project: string, opts: TaskLaunchO
     id, project, accent: accentFor(colorKey), workdir: cwd, colorKey,
     branch: opts.branch ?? "", worktree: opts.worktree ?? null, title: r.label,
     phase: "working", phaseSince: Date.now(), lastActivity: Date.now(), attention: null,
-    pendingCmd: "", pendingPermId: null, pendRisk: null, subagents: 0, apiErr: null,
+    pendingCmd: "", pendingPermId: null, pendRisk: null, subagents: 0, apiErr: null, drift: null,
     model: "", ctxPct: null, ctxTokens: null, cost: null, durMs: null,
     curTool: "", curArg: "", todos: [], ctxHist: [], costHist: [], git: null, res: null,
     lastEvent: "", activity: [],
@@ -395,6 +395,23 @@ export function noteGitCommand(cmd: unknown) {
   gitPokeT = window.setTimeout(() => { void refreshGitViews(); }, GIT_POKE_MS);
 }
 
+// The other half of the same hook: a write tells us *where* the agent is working, which
+// is the one thing a branch re-read can never discover — `refreshBranch` reads HEAD in
+// the session's own folder, so a session whose agent moved to a sibling checkout goes on
+// reporting the branch it left, forever and correctly.
+//
+// `driftUpdate` owns the rule (including why it latches); this owns only the repaint.
+export function noteDrift(s: Sess, tool: string, input: any) {
+  if (!isAgent(s) || !s.workdir) return;
+  const roster = worktreesByRepo.get(s.colorKey);
+  if (!roster?.length) return;   // no roster yet — the 4s poll seeds it, then this works
+  const next = driftUpdate(s.drift, s.workdir, tool, input?.file_path, roster);
+  if (next?.dir === s.drift?.dir) return;
+  s.drift = next;
+  dlog("info", next ? `drift ${s.id.slice(0, 8)} → ${next.branch}` : `drift cleared ${s.id.slice(0, 8)}`);
+  renderAll();
+}
+
 // A green run shouldn't linger — tasks are far more numerous and shorter-lived
 // than sessions, and without this the rail silently fills with ticks. A pane you
 // are actually looking at is never yanked away, and a failure never auto-closes.
@@ -413,10 +430,20 @@ export function renderHeader(s: Sess | null) {
   const hb = $("hBranch"); hb.classList.remove("ext-chip");
   if (!s) { $("hProj").textContent = "no session"; hb.hidden = true; $("hTitle").textContent = ""; $("hPath").textContent = ""; return; }
   $("hProj").textContent = s.project;
+  hb.classList.remove("drifted");
   if (s.kind !== "claude") { hb.textContent = s.kind === "shell" ? "shell" : "task"; hb.hidden = false; hb.classList.add("ext-chip"); }
-  else if (s.branch) { hb.textContent = s.worktree ? "⑃ " + s.branch : s.branch; hb.hidden = false; } else hb.hidden = true;
+  // A drifted session gets BOTH branches, in the order they happened: the chip is the
+  // only thing on screen that says which checkout the work is landing in, and showing
+  // just the new one would trade a stale label for a lie about where `--resume` goes.
+  else if (s.drift) {
+    hb.textContent = `${s.branch || basename(s.workdir)} ⤳ ⑃ ${s.drift.branch}`;
+    hb.title = `Launched in ${s.workdir}\nWriting to ${s.drift.dir}`;
+    hb.hidden = false; hb.classList.add("drifted");
+  }
+  else if (s.branch) { hb.textContent = s.worktree ? "⑃ " + s.branch : s.branch; hb.title = ""; hb.hidden = false; } else hb.hidden = true;
   $("hTitle").textContent = s.kind === "claude" ? (s.title || "") : (s.kind === "task" ? s.run?.label ?? "" : "");
-  $("hPath").textContent = tilde(s.workdir);
+  // The path follows the work for the same reason — it is the answer to "where am I?".
+  $("hPath").textContent = tilde(s.drift?.dir ?? s.workdir);
 }
 
 // The active project context is either an Episko session or an external one.

--- a/src/phase.ts
+++ b/src/phase.ts
@@ -24,14 +24,19 @@ let onTurnEnd: (s: Sess) => void = () => {};
 export function setOnTurnEnd(fn: (s: Sess) => void) { onTurnEnd = fn; }
 
 // A tool call settled, or a turn ended: this session may have moved HEAD, added a
-// worktree, or dirtied its working tree — and this is the app's *only* warning that it
-// did. Nothing watches the filesystem, so without a nudge from here the sidebar waits
-// for the next poll to notice a branch switch and never notices a new checkout at all.
+// worktree, dirtied its working tree, or written into a checkout it wasn't launched in
+// — and this is the app's *only* warning that it did. Nothing watches the filesystem,
+// so without a nudge from here the sidebar waits for the next poll to notice a branch
+// switch and never notices a new checkout at all.
+//
+// The whole `tool_input` travels, not just `.command`: the git half reads the command,
+// and the drift half reads `file_path`, which is the only field that can say the agent
+// moved to another checkout (Claude Code's `cwd` provably cannot — see ./gitwatch).
 //
 // A seam rather than a direct call for the same reason as `onTurnEnd`: acting on it
 // means git commands, the roster and a repaint, none of which belong in the phase state
 // machine. main.ts wires it; in a test a settled tool is just a settled tool.
-let onSessionTouched: (s: Sess, tool: string, cmd: unknown) => void = () => {};
+let onSessionTouched: (s: Sess, tool: string, input: any) => void = () => {};
 export function setOnSessionTouched(fn: typeof onSessionTouched) { onSessionTouched = fn; }
 
 // Set the phase and, when it actually changes, stamp phaseSince — the anchor for
@@ -162,7 +167,7 @@ export function applyHook(s: Sess, data: any) {
     case "PostToolUseFailure": {
       const tool = data.tool_name || "";
       closeActivity(s, data.tool_name);
-      onSessionTouched(s, tool, data.tool_input?.command);
+      onSessionTouched(s, tool, data.tool_input);
       if (!bg()) setPhase(s, ev === "PostToolUse" ? "working" : "error");
       break;
     }

--- a/src/phase.ts
+++ b/src/phase.ts
@@ -29,14 +29,15 @@ export function setOnTurnEnd(fn: (s: Sess) => void) { onTurnEnd = fn; }
 // so without a nudge from here the sidebar waits for the next poll to notice a branch
 // switch and never notices a new checkout at all.
 //
-// The whole `tool_input` travels, not just `.command`: the git half reads the command,
-// and the drift half reads `file_path`, which is the only field that can say the agent
-// moved to another checkout (Claude Code's `cwd` provably cannot — see ./gitwatch).
+// The whole payload travels, not a field or two: the git half reads `tool_input.command`,
+// and the drift half needs BOTH `tool_input.file_path` and `cwd` — the two ways an agent
+// changes checkout are invisible to each other's signal (see ./gitwatch). Passing `data`
+// rather than growing the parameter list keeps that from happening a third time.
 //
 // A seam rather than a direct call for the same reason as `onTurnEnd`: acting on it
 // means git commands, the roster and a repaint, none of which belong in the phase state
 // machine. main.ts wires it; in a test a settled tool is just a settled tool.
-let onSessionTouched: (s: Sess, tool: string, input: any) => void = () => {};
+let onSessionTouched: (s: Sess, tool: string, data: any) => void = () => {};
 export function setOnSessionTouched(fn: typeof onSessionTouched) { onSessionTouched = fn; }
 
 // Set the phase and, when it actually changes, stamp phaseSince — the anchor for
@@ -167,7 +168,7 @@ export function applyHook(s: Sess, data: any) {
     case "PostToolUseFailure": {
       const tool = data.tool_name || "";
       closeActivity(s, data.tool_name);
-      onSessionTouched(s, tool, data.tool_input);
+      onSessionTouched(s, tool, data);
       if (!bg()) setPhase(s, ev === "PostToolUse" ? "working" : "error");
       break;
     }
@@ -176,7 +177,7 @@ export function applyHook(s: Sess, data: any) {
     case "Stop": endTurn(s); clearPending(s); s.curTool = ""; s.curArg = "";
       // Reconcile the working set even if the last tool looked read-only, so the state
       // you come back to read is the state after the whole turn.
-      onSessionTouched(s, "Stop", undefined);
+      onSessionTouched(s, "Stop", data);
       // Only a turn that really ended gets its work checked: an unattended run
       // against a turn the API cut short would be verifying half-written files.
       if (!s.apiErr) onTurnEnd(s);

--- a/src/sidebarview.ts
+++ b/src/sidebarview.ts
@@ -46,10 +46,22 @@ function sessionRow(s: Sess, chip?: WtCluster): string {
     : "";
   // A red ✕ says the turn broke; the row's tooltip says why, because "API overloaded"
   // and "auth failed" are the same glyph and completely different problems.
-  const tip = s.phase === "error" && s.apiErr ? `${label} — ${apiErrText(s.apiErr)}` : label;
-  return `<div class="srow${chip ? " o3" : ""} ${s.id === activeId ? "active" : ""}" data-sel="${s.id}">
+  const tip = s.phase === "error" && s.apiErr
+    ? `${label} — ${apiErrText(s.apiErr)}`
+    : s.drift ? `${label} — writing to ${s.drift.branch}, not ${s.branch || "this checkout"}` : label;
+  // The row stays under the checkout the session was *launched* in — that is its
+  // identity, and where `--resume` goes. This is what says the agent's writes have
+  // moved elsewhere, without moving the row out from under you.
+  const drift = s.drift
+    ? `<span class="sdrift" title="${esc(`Writing to ${s.drift.dir}`)}">⤳ ${esc(s.drift.branch)}</span>`
+    : "";
+  // Both tags share one grid cell. `.srow`'s column count is fixed by CSS (`.o3` adds
+  // the fourth for a chip), so a second in-flow child would wrap the row instead of
+  // sitting beside it — wrapping them keeps the existing grid math untouched.
+  const tags = drift + chipHtml;
+  return `<div class="srow${tags ? " o3" : ""}${s.drift ? " drifted" : ""} ${s.id === activeId ? "active" : ""}" data-sel="${s.id}">
     <span class="sglyph ${gcls}">${glyph}</span>
-    <span class="sbranch" title="${esc(tip)}">${esc(label)}</span>${chipHtml}
+    <span class="sbranch" title="${esc(tip)}">${esc(label)}</span>${tags ? `<span class="stags">${tags}</span>` : ""}
     <span class="sctx">${s.kind === "task" ? esc(taskStateText(s)) : s.ctxPct != null ? Math.round(s.ctxPct) + "%" : ""}</span>
     <span class="sclose" data-close="${s.id}" title="Close session">✕</span></div>`;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -246,6 +246,13 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .srow.o3 { grid-template-columns: 14px minmax(0,1fr) auto auto; }
 .srow.extrow.o3e { grid-template-columns: 14px minmax(0,1fr) auto auto auto; }
 .chip { display: inline-flex; align-items: center; overflow: hidden; font: 600 10px var(--font-mono); color: var(--wtc, var(--muted-2)); }
+/* Both row tags (drift marker, worktree chip) share one grid cell — see sessionRow. */
+.stags { display: inline-flex; align-items: center; gap: 5px; min-width: 0; overflow: hidden; }
+/* The agent is writing in a different checkout than the one this session was launched
+   in. Deliberately quiet: it is information, not an alert — the row is still healthy,
+   it is only pointing somewhere else. The inspector card is where the fix lives. */
+.sdrift { flex: none; white-space: nowrap; font: 600 9.5px var(--font-mono); color: var(--st-working); opacity: .85; }
+.srow.drifted .sbranch { color: color-mix(in srgb, var(--st-working) 55%, var(--muted)); }
 .chip .fork { flex: none; }
 .chip .lbl { max-width: 0; opacity: 0; white-space: nowrap; transform: translateX(-3px); transition: max-width .22s ease, opacity .18s ease, transform .22s ease, margin-left .22s ease; }
 .srow.o3:hover .chip .lbl, .srow.o3e:hover .chip .lbl { max-width: 130px; opacity: 1; transform: none; margin-left: 4px; }
@@ -327,6 +334,25 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .attn-btns { display: flex; gap: 6px; }
 .attn-btns button { flex: 1; height: 28px; border-radius: 7px; cursor: pointer; font: 700 11px var(--font-ui); border: 1px solid var(--hair-strong); background: var(--surface); color: var(--text); }
 .attn-btns .allow { background: linear-gradient(180deg, color-mix(in srgb, var(--st-done) 86%, white), var(--st-done)); color: #07281a; border-color: transparent; }
+
+/* ---- drift card ---- */
+/* Same card grammar as .attn, in the working colour rather than the attention one: an
+   agent that moved checkout is doing exactly what it meant to. Nothing is wrong, so it
+   must not read as an alarm — but it sits at the top of the inspector, because every
+   figure below it (branch, working set, fetch/pull/push) reads the *launch* folder. */
+.drift { border-radius: var(--radius); padding: 11px; display: flex; flex-direction: column; gap: 8px; background: linear-gradient(180deg, color-mix(in srgb, var(--st-working) 13%, transparent), color-mix(in srgb, var(--st-working) 5%, transparent)); border: 1px solid color-mix(in srgb, var(--st-working) 30%, transparent); }
+.drift-h { display: flex; align-items: center; gap: 7px; font-weight: 700; font-size: 12px; color: var(--st-working); }
+.drift-h .b { font-family: var(--font-mono); font-size: 11px; }
+.drift-g { font-size: 13px; line-height: 1; }
+.drift-path { font: 10.5px var(--font-mono); color: var(--muted); word-break: break-all; }
+.drift-note { font-size: 11px; line-height: 1.45; color: var(--muted); }
+.drift-note .b { font-family: var(--font-mono); color: var(--muted); }
+.drift-btns { display: flex; }
+.drift-btns button { flex: 1; height: 28px; border-radius: 7px; cursor: pointer; font: 700 11px var(--font-ui); color: var(--text); background: var(--surface); border: 1px solid color-mix(in srgb, var(--st-working) 40%, var(--hair-strong)); }
+.drift-btns button:hover { background: color-mix(in srgb, var(--st-working) 14%, var(--surface)); border-color: var(--st-working); }
+
+/* The stage header's branch chip, when the two branches disagree. */
+#hBranch.drifted { color: var(--st-working); border-color: color-mix(in srgb, var(--st-working) 34%, transparent); background: color-mix(in srgb, var(--st-working) 10%, transparent); }
 .attn-btns button:hover { filter: brightness(1.06); }
 
 /* ============ redesigned inspector modules ============ */

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,9 +32,19 @@ export interface DiffStat {
 // `git worktree list`, so it is cheap enough to poll; see the Rust side for why.
 export interface WtHead { path: string; branch: string; is_main: boolean; exists: boolean }
 // A checkout of a session's own repo that isn't the one it was launched in, as
-// `driftTarget` (./gitwatch) reads it off the agent's writes. What the inspector's
-// "working in" card offers to move the session to.
-export interface Drift { dir: string; branch: string }
+// ./gitwatch reads it off the hook stream. What the inspector's "working in" card
+// offers to point the session at.
+//
+// `via` is not decoration — it decides the repair, because the two ways an agent
+// changes checkout leave the conversation in different places:
+//   "cwd"   — Claude Code moved the session itself (its `EnterWorktree` tool, or any
+//             `cd` staying inside the project dir). It has already re-homed the
+//             transcript, so Episko only has to catch up: adopt the directory, no
+//             restart, no file move.
+//   "write" — the session is still running where it was launched and only its *writes*
+//             moved. Nothing has re-homed anything, so following it means moving the
+//             transcript and relaunching.
+export interface Drift { dir: string; branch: string; via: "cwd" | "write" }
 // Disk I/O for one session's `claude` process: rates over the gap since the previous
 // sample, plus lifetime totals. `primed` is false on the first reading, when there is
 // nothing to difference against and the rates are 0 by default rather than measured.

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,10 +123,13 @@ export interface Sess {
   // is set the turn is known-failed, which is what stops the 60s idle Notification
   // from relabelling a dead turn "your turn" — see endTurn in phase.ts.
   apiErr: ApiErr | null;
-  // Set when the agent's writes land in a *different* checkout of this repo than the
-  // one the session was launched in — see driftTarget in ./gitwatch for why writes are
-  // the only signal that can say so. Display-only: `workdir` stays the folder Claude
-  // actually runs in (and that `--resume` needs) until the user moves the session.
+  // Set when the agent's work has moved to a *different* checkout of this repo than the
+  // one the session was launched in — by either route, see `Drift.via` above and
+  // ./gitwatch for the two signals. Display-only either way: nothing here changes
+  // `workdir`, so the pane keeps acting on its launch folder until the user follows the
+  // drift. Which of the two it is decides what "following" means, and note that for
+  // `via: "cwd"` the process has *already* left `workdir` — that is the gap the
+  // inspector's button closes, not one Episko opened.
   drift: Drift | null;
   model: string; ctxPct: number | null; ctxTokens: number | null; cost: number | null; durMs: number | null;
   curTool: string; curArg: string; todos: Todo[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,10 @@ export interface DiffStat {
 // HEAD, and whether the directory is still on disk. Read from files rather than from
 // `git worktree list`, so it is cheap enough to poll; see the Rust side for why.
 export interface WtHead { path: string; branch: string; is_main: boolean; exists: boolean }
+// A checkout of a session's own repo that isn't the one it was launched in, as
+// `driftTarget` (./gitwatch) reads it off the agent's writes. What the inspector's
+// "working in" card offers to move the session to.
+export interface Drift { dir: string; branch: string }
 // Disk I/O for one session's `claude` process: rates over the gap since the previous
 // sample, plus lifetime totals. `primed` is false on the first reading, when there is
 // nothing to difference against and the rates are 0 by default rather than measured.
@@ -109,6 +113,11 @@ export interface Sess {
   // is set the turn is known-failed, which is what stops the 60s idle Notification
   // from relabelling a dead turn "your turn" — see endTurn in phase.ts.
   apiErr: ApiErr | null;
+  // Set when the agent's writes land in a *different* checkout of this repo than the
+  // one the session was launched in — see driftTarget in ./gitwatch for why writes are
+  // the only signal that can say so. Display-only: `workdir` stays the folder Claude
+  // actually runs in (and that `--resume` needs) until the user moves the session.
+  drift: Drift | null;
   model: string; ctxPct: number | null; ctxTokens: number | null; cost: number | null; durMs: number | null;
   curTool: string; curArg: string; todos: Todo[];
   ctxHist: number[]; costHist: number[]; git: DiffStat | null; res: Res | null;

--- a/test/gitwatch.test.ts
+++ b/test/gitwatch.test.ts
@@ -71,8 +71,9 @@ describe("driftTarget", () => {
   // The shape the roster reports, and the shape of the real case this was written for:
   // a session launched in exp-overview whose agent created ../overview and moved there.
   const WT = "/Users/t/w/cc-launcher-spike";
+  const REPO = "/Users/t/repos/cc-launcher-spike";
   const roster = [
-    { path: "/Users/t/repos/cc-launcher-spike", branch: "main", exists: true, is_main: true },
+    { path: REPO, branch: "main", exists: true, is_main: true },
     { path: `${WT}/exp-overview`, branch: "exp/overview", exists: true, is_main: false },
     { path: `${WT}/overview`, branch: "feat/overview", exists: true, is_main: false },
     { path: `${WT}/gone`, branch: "dead/branch", exists: false, is_main: false },
@@ -81,12 +82,12 @@ describe("driftTarget", () => {
 
   it("names the checkout a write landed in when it isn't the session's own", () => {
     expect(driftTarget(launched, "Write", `${WT}/overview/src/usage.ts`, roster))
-      .toEqual({ dir: `${WT}/overview`, branch: "feat/overview" });
+      .toEqual({ dir: `${WT}/overview`, branch: "feat/overview", via: "write" });
     expect(driftTarget(launched, "Edit", `${WT}/overview/src-tauri/src/usage.rs`, roster))
-      .toEqual({ dir: `${WT}/overview`, branch: "feat/overview" });
+      .toEqual({ dir: `${WT}/overview`, branch: "feat/overview", via: "write" });
     // Drifting into the repo's own main checkout counts exactly the same.
-    expect(driftTarget(launched, "Write", "/Users/t/repos/cc-launcher-spike/README.md", roster))
-      .toEqual({ dir: "/Users/t/repos/cc-launcher-spike", branch: "main" });
+    expect(driftTarget(launched, "Write", `${REPO}/README.md`, roster))
+      .toEqual({ dir: REPO, branch: "main", via: "write" });
   });
 
   it("stays silent while the agent works where it was launched", () => {
@@ -114,17 +115,18 @@ describe("driftTarget", () => {
   });
 
   it("picks the innermost checkout when one worktree sits inside another", () => {
-    // A worktree created *inside* its own repo: the repo root contains it, so a
-    // longest-match is the only thing that names the right branch.
+    // Claude Code's own worktrees live at `<repo>/.claude/worktrees/<name>`, so the repo
+    // root also contains them and a longest-match is the only thing that names the right
+    // branch. This is not hypothetical — it is where `EnterWorktree` puts them.
     const nested = [
       { path: "/r", branch: "main", exists: true, is_main: true },
-      { path: "/r/wt/feature", branch: "feat/x", exists: true, is_main: false },
+      { path: "/r/.claude/worktrees/feature", branch: "feat/x", exists: true, is_main: false },
     ];
-    expect(driftTarget("/r", "Write", "/r/wt/feature/a.ts", nested))
-      .toEqual({ dir: "/r/wt/feature", branch: "feat/x" });
+    expect(driftTarget("/r", "Write", "/r/.claude/worktrees/feature/a.ts", nested))
+      .toEqual({ dir: "/r/.claude/worktrees/feature", branch: "feat/x", via: "write" });
     // …and from inside that worktree, writing back up into the repo is drift too.
-    expect(driftTarget("/r/wt/feature", "Write", "/r/src/a.ts", nested))
-      .toEqual({ dir: "/r", branch: "main" });
+    expect(driftTarget("/r/.claude/worktrees/feature", "Write", "/r/src/a.ts", nested))
+      .toEqual({ dir: "/r", branch: "main", via: "write" });
   });
 
   it("does not mistake a sibling with a shared name prefix for a match", () => {
@@ -135,7 +137,7 @@ describe("driftTarget", () => {
       { path: `${WT}/overview-old`, branch: "old/overview", exists: true, is_main: false },
     ];
     expect(driftTarget(launched, "Write", `${WT}/overview-old/a.ts`, sib))
-      .toEqual({ dir: `${WT}/overview-old`, branch: "old/overview" });
+      .toEqual({ dir: `${WT}/overview-old`, branch: "old/overview", via: "write" });
   });
 
   it("treats a session launched in a subfolder of a checkout as being in it", () => {
@@ -147,7 +149,7 @@ describe("driftTarget", () => {
     const win = [{ path: "C:\\r\\main\\", branch: "main", exists: true, is_main: true },
                  { path: "C:\\r\\feat", branch: "feat/x", exists: true, is_main: false }];
     expect(driftTarget("C:\\r\\main", "Edit", "C:\\r\\feat\\src\\a.ts", win))
-      .toEqual({ dir: "C:\\r\\feat", branch: "feat/x" });
+      .toEqual({ dir: "C:\\r\\feat", branch: "feat/x", via: "write" });
     expect(driftTarget("C:\\r\\main", "Edit", "C:\\r\\main\\src\\a.ts", win)).toBeNull();
   });
 
@@ -159,10 +161,11 @@ describe("driftTarget", () => {
     expect(driftTarget(launched, "Write", `${WT}/overview/a.ts`, [])).toBeNull();
   });
 
-  describe("driftUpdate — the latch", () => {
-    const moved = { dir: `${WT}/overview`, branch: "feat/overview" };
-    const upd = (prev: Drift | null, tool: string, fp: unknown) =>
-      driftUpdate(prev, launched, tool, fp, roster);
+  describe("driftUpdate — two signals, one answer", () => {
+    const moved = { dir: `${WT}/overview`, branch: "feat/overview", via: "write" as const };
+    // Case 1: cwd is pinned to the launch dir for the whole life of the drift.
+    const upd = (prev: Drift | null, tool: string, fp: unknown, cwd: unknown = launched) =>
+      driftUpdate(prev, launched, tool, fp, cwd, roster);
 
     it("latches on the first write into another checkout", () => {
       expect(upd(null, "Write", `${WT}/overview/src/a.ts`)).toEqual(moved);
@@ -185,14 +188,65 @@ describe("driftTarget", () => {
     });
 
     it("re-targets straight from one drifted checkout to another", () => {
-      expect(upd(moved, "Write", "/Users/t/repos/cc-launcher-spike/README.md"))
-        .toEqual({ dir: "/Users/t/repos/cc-launcher-spike", branch: "main" });
+      expect(upd(moved, "Write", `${REPO}/README.md`))
+        .toEqual({ dir: REPO, branch: "main", via: "write" });
     });
 
     it("is a no-op on a session that never drifted", () => {
       expect(upd(null, "Read", `${WT}/overview/src/a.ts`)).toBeNull();
       expect(upd(null, "Write", `${launched}/src/a.ts`)).toBeNull();
       expect(upd(null, "Bash", undefined)).toBeNull();
+    });
+
+    // --- the cwd signal: Claude Code moving the session itself ---
+
+    it("reads a moved cwd as drift with no write at all", () => {
+      // The EnterWorktree case, exactly: three Bash calls, zero writes, and the only
+      // thing that changed is the cwd riding along on every hook. The write signal is
+      // blind here, which is why this half exists.
+      expect(driftUpdate(null, launched, "Bash", undefined, `${WT}/overview`, roster))
+        .toEqual({ dir: `${WT}/overview`, branch: "feat/overview", via: "cwd" });
+      expect(driftUpdate(null, launched, "Bash", undefined, `${WT}/overview/src`, roster))
+        .toEqual({ dir: `${WT}/overview`, branch: "feat/overview", via: "cwd" });
+    });
+
+    it("does not read a cd within the same checkout as a move", () => {
+      // `cd src && …` moves the cwd and changes no checkout. Without resolving both
+      // sides to a checkout first, every such call would read as a relocation.
+      expect(driftUpdate(null, launched, "Bash", undefined, `${launched}/src`, roster)).toBeNull();
+      expect(driftUpdate(null, launched, "Bash", undefined, launched, roster)).toBeNull();
+    });
+
+    it("lets cwd outrank a write, since it also moves the conversation", () => {
+      // Both signals firing at once: cwd wins, and the `via` it carries is what tells
+      // the repair that the transcript has already been re-homed by Claude.
+      expect(driftUpdate(null, launched, "Write", `${REPO}/a.ts`, `${WT}/overview`, roster))
+        .toEqual({ dir: `${WT}/overview`, branch: "feat/overview", via: "cwd" });
+    });
+
+    it("retires a cwd drift when cwd comes home", () => {
+      const byCwd = { dir: `${WT}/overview`, branch: "feat/overview", via: "cwd" as const };
+      expect(driftUpdate(byCwd, launched, "Bash", undefined, launched, roster)).toBeNull();
+    });
+
+    // The regression guard for the bug this whole feature exists to fix.
+    it("NEVER lets a home cwd clear a write drift", () => {
+      // In case 1 the cwd reads "home" on every single hook for the entire life of the
+      // drift — Claude Code resets it. If that were allowed to clear the flag, the
+      // feature would work for exactly one tool call and then delete its own answer.
+      expect(upd(moved, "Bash", undefined, launched)).toEqual(moved);
+      expect(upd(moved, "Read", `${WT}/overview/a.ts`, launched)).toEqual(moved);
+      expect(upd(moved, "Read", `${launched}/a.ts`, `${launched}/src`)).toEqual(moved);
+    });
+
+    it("says nothing when cwd names no checkout of this repo", () => {
+      // A session whose cwd is a scratch dir tells us nothing about checkouts, so it
+      // must neither set a drift nor retire one.
+      expect(driftUpdate(null, launched, "Bash", undefined, "/tmp/whatever", roster)).toBeNull();
+      expect(driftUpdate(moved, launched, "Bash", undefined, "/tmp/whatever", roster)).toEqual(moved);
+      const byCwd = { dir: `${WT}/overview`, branch: "feat/overview", via: "cwd" as const };
+      expect(driftUpdate(byCwd, launched, "Bash", undefined, "/tmp/whatever", roster)).toEqual(byCwd);
+      expect(driftUpdate(byCwd, launched, "Bash", undefined, undefined, roster)).toEqual(byCwd);
     });
   });
 });

--- a/test/gitwatch.test.ts
+++ b/test/gitwatch.test.ts
@@ -131,13 +131,46 @@ describe("driftTarget", () => {
 
   it("does not mistake a sibling with a shared name prefix for a match", () => {
     // `/w/overview-old` starts with `/w/overview` as a *string*; only a path-boundary
-    // test keeps them apart.
+    // test keeps them apart. The roster must include the session's own checkout, as a
+    // real one from `worktree_heads` always does — without it there is no home to
+    // compare against and the answer is (correctly) nothing at all.
     const sib = [
+      { path: launched, branch: "exp/overview", exists: true, is_main: false },
       { path: `${WT}/overview`, branch: "feat/overview", exists: true, is_main: false },
       { path: `${WT}/overview-old`, branch: "old/overview", exists: true, is_main: false },
     ];
     expect(driftTarget(launched, "Write", `${WT}/overview-old/a.ts`, sib))
       .toEqual({ dir: `${WT}/overview-old`, branch: "old/overview", via: "write" });
+    expect(driftTarget(launched, "Write", `${WT}/overview/a.ts`, sib))
+      .toEqual({ dir: `${WT}/overview`, branch: "feat/overview", via: "write" });
+  });
+
+  // The regression guard for the review finding: the roster is resolved and normalised
+  // in Rust, while `workdir` is however the user spelled the folder they picked. When
+  // the two cannot be reconciled, the old code compared the target against `undefined`
+  // and every write into the session's OWN checkout read as a move — permanently.
+  it("says nothing at all when the session's own folder isn't in the roster", () => {
+    const elsewhere = [
+      { path: `${WT}/overview`, branch: "feat/overview", exists: true, is_main: false },
+    ];
+    expect(driftTarget("/some/symlinked/spelling", "Write", `${WT}/overview/a.ts`, elsewhere)).toBeNull();
+    expect(driftUpdate(null, "/some/symlinked/spelling", "Write", `${WT}/overview/a.ts`, `${WT}/overview`, elsewhere)).toBeNull();
+    // …and an unplaceable home must not retire a drift either, in the other direction.
+    const held = { dir: `${WT}/overview`, branch: "feat/overview", via: "write" as const };
+    expect(driftUpdate(held, "/some/symlinked/spelling", "Write", "/some/symlinked/spelling/a.ts", undefined, elsewhere))
+      .toEqual(held);
+  });
+
+  it("compares paths case-insensitively, as norm_path and the filesystem both do", () => {
+    // `worktree_heads` upper-cases a Windows drive letter; Claude Code may report it
+    // lower-case. Left case-sensitive, the whole feature goes dark on Windows.
+    const win = [
+      { path: "C:/r/main", branch: "main", exists: true, is_main: true },
+      { path: "C:/r/feat", branch: "feat/x", exists: true, is_main: false },
+    ];
+    expect(driftTarget("c:/r/main", "Write", "c:/r/feat/src/a.ts", win))
+      .toEqual({ dir: "C:/r/feat", branch: "feat/x", via: "write" });
+    expect(driftTarget("c:/r/main", "Write", "c:/R/MAIN/src/a.ts", win)).toBeNull();
   });
 
   it("treats a session launched in a subfolder of a checkout as being in it", () => {

--- a/test/gitwatch.test.ts
+++ b/test/gitwatch.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { gitMutates } from "../src/gitwatch";
+import { driftTarget, driftUpdate, gitMutates } from "../src/gitwatch";
+import type { Drift } from "../src/types";
 
 describe("gitMutates", () => {
   it("catches every ordinary way an agent moves HEAD", () => {
@@ -63,5 +64,135 @@ describe("gitMutates", () => {
     // what stops this reading as a branch change.
     const far = "git status && " + "echo padding ".repeat(20) + "&& npm run reset";
     expect(gitMutates(far)).toBe(false);
+  });
+});
+
+describe("driftTarget", () => {
+  // The shape the roster reports, and the shape of the real case this was written for:
+  // a session launched in exp-overview whose agent created ../overview and moved there.
+  const WT = "/Users/t/w/cc-launcher-spike";
+  const roster = [
+    { path: "/Users/t/repos/cc-launcher-spike", branch: "main", exists: true, is_main: true },
+    { path: `${WT}/exp-overview`, branch: "exp/overview", exists: true, is_main: false },
+    { path: `${WT}/overview`, branch: "feat/overview", exists: true, is_main: false },
+    { path: `${WT}/gone`, branch: "dead/branch", exists: false, is_main: false },
+  ];
+  const launched = `${WT}/exp-overview`;
+
+  it("names the checkout a write landed in when it isn't the session's own", () => {
+    expect(driftTarget(launched, "Write", `${WT}/overview/src/usage.ts`, roster))
+      .toEqual({ dir: `${WT}/overview`, branch: "feat/overview" });
+    expect(driftTarget(launched, "Edit", `${WT}/overview/src-tauri/src/usage.rs`, roster))
+      .toEqual({ dir: `${WT}/overview`, branch: "feat/overview" });
+    // Drifting into the repo's own main checkout counts exactly the same.
+    expect(driftTarget(launched, "Write", "/Users/t/repos/cc-launcher-spike/README.md", roster))
+      .toEqual({ dir: "/Users/t/repos/cc-launcher-spike", branch: "main" });
+  });
+
+  it("stays silent while the agent works where it was launched", () => {
+    expect(driftTarget(launched, "Write", `${launched}/src/phase.ts`, roster)).toBeNull();
+    expect(driftTarget(launched, "Edit", `${launched}/deep/nested/file.ts`, roster)).toBeNull();
+  });
+
+  it("only writes count — a read lands anywhere and would make this flap", () => {
+    // Every one of these is an ordinary thing for an agent to do from exp-overview.
+    expect(driftTarget(launched, "Read", `${WT}/overview/src/usage.ts`, roster)).toBeNull();
+    expect(driftTarget(launched, "Bash", `${WT}/overview/src/usage.ts`, roster)).toBeNull();
+    expect(driftTarget(launched, "Grep", `${WT}/overview/src/usage.ts`, roster)).toBeNull();
+  });
+
+  it("ignores writes outside the repo entirely", () => {
+    // A scratch file, a global config, another project: none of these are a move, and
+    // treating them as one would offer to relocate a live session into $TMPDIR.
+    expect(driftTarget(launched, "Write", "/tmp/scratch/notes.md", roster)).toBeNull();
+    expect(driftTarget(launched, "Write", "/Users/t/.claude/settings.json", roster)).toBeNull();
+    expect(driftTarget(launched, "Write", "/Users/t/repos/other-project/src/a.ts", roster)).toBeNull();
+  });
+
+  it("ignores a checkout git still lists but that is gone from disk", () => {
+    expect(driftTarget(launched, "Write", `${WT}/gone/src/a.ts`, roster)).toBeNull();
+  });
+
+  it("picks the innermost checkout when one worktree sits inside another", () => {
+    // A worktree created *inside* its own repo: the repo root contains it, so a
+    // longest-match is the only thing that names the right branch.
+    const nested = [
+      { path: "/r", branch: "main", exists: true, is_main: true },
+      { path: "/r/wt/feature", branch: "feat/x", exists: true, is_main: false },
+    ];
+    expect(driftTarget("/r", "Write", "/r/wt/feature/a.ts", nested))
+      .toEqual({ dir: "/r/wt/feature", branch: "feat/x" });
+    // …and from inside that worktree, writing back up into the repo is drift too.
+    expect(driftTarget("/r/wt/feature", "Write", "/r/src/a.ts", nested))
+      .toEqual({ dir: "/r", branch: "main" });
+  });
+
+  it("does not mistake a sibling with a shared name prefix for a match", () => {
+    // `/w/overview-old` starts with `/w/overview` as a *string*; only a path-boundary
+    // test keeps them apart.
+    const sib = [
+      { path: `${WT}/overview`, branch: "feat/overview", exists: true, is_main: false },
+      { path: `${WT}/overview-old`, branch: "old/overview", exists: true, is_main: false },
+    ];
+    expect(driftTarget(launched, "Write", `${WT}/overview-old/a.ts`, sib))
+      .toEqual({ dir: `${WT}/overview-old`, branch: "old/overview" });
+  });
+
+  it("treats a session launched in a subfolder of a checkout as being in it", () => {
+    // Launching in `overview/src-tauri` and writing to `overview/src` is not a move.
+    expect(driftTarget(`${WT}/overview/src-tauri`, "Write", `${WT}/overview/src/a.ts`, roster)).toBeNull();
+  });
+
+  it("handles Windows separators and a trailing slash on the roster path", () => {
+    const win = [{ path: "C:\\r\\main\\", branch: "main", exists: true, is_main: true },
+                 { path: "C:\\r\\feat", branch: "feat/x", exists: true, is_main: false }];
+    expect(driftTarget("C:\\r\\main", "Edit", "C:\\r\\feat\\src\\a.ts", win))
+      .toEqual({ dir: "C:\\r\\feat", branch: "feat/x" });
+    expect(driftTarget("C:\\r\\main", "Edit", "C:\\r\\main\\src\\a.ts", win)).toBeNull();
+  });
+
+  it("rejects a payload with no usable file_path", () => {
+    expect(driftTarget(launched, "Write", undefined, roster)).toBeNull();
+    expect(driftTarget(launched, "Write", "", roster)).toBeNull();
+    expect(driftTarget(launched, "Write", "   ", roster)).toBeNull();
+    expect(driftTarget(launched, "Write", 42, roster)).toBeNull();
+    expect(driftTarget(launched, "Write", `${WT}/overview/a.ts`, [])).toBeNull();
+  });
+
+  describe("driftUpdate — the latch", () => {
+    const moved = { dir: `${WT}/overview`, branch: "feat/overview" };
+    const upd = (prev: Drift | null, tool: string, fp: unknown) =>
+      driftUpdate(prev, launched, tool, fp, roster);
+
+    it("latches on the first write into another checkout", () => {
+      expect(upd(null, "Write", `${WT}/overview/src/a.ts`)).toEqual(moved);
+    });
+
+    it("holds through everything that isn't a write home", () => {
+      // This is the whole point of latching, and it is the common case: an agent that
+      // moved to a new checkout goes on reading the one it came from, constantly.
+      expect(upd(moved, "Read", `${launched}/src/phase.ts`)).toEqual(moved);
+      expect(upd(moved, "Grep", `${launched}/src`)).toEqual(moved);
+      expect(upd(moved, "Bash", undefined)).toEqual(moved);
+      // A write to somewhere that is no checkout of this repo says nothing either way.
+      expect(upd(moved, "Write", "/tmp/scratch/notes.md")).toEqual(moved);
+      expect(upd(moved, "Write", undefined)).toEqual(moved);
+    });
+
+    it("clears only when the agent writes home again", () => {
+      expect(upd(moved, "Write", `${launched}/src/phase.ts`)).toBeNull();
+      expect(upd(moved, "Edit", `${launched}/deep/a.ts`)).toBeNull();
+    });
+
+    it("re-targets straight from one drifted checkout to another", () => {
+      expect(upd(moved, "Write", "/Users/t/repos/cc-launcher-spike/README.md"))
+        .toEqual({ dir: "/Users/t/repos/cc-launcher-spike", branch: "main" });
+    });
+
+    it("is a no-op on a session that never drifted", () => {
+      expect(upd(null, "Read", `${WT}/overview/src/a.ts`)).toBeNull();
+      expect(upd(null, "Write", `${launched}/src/a.ts`)).toBeNull();
+      expect(upd(null, "Bash", undefined)).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
A session launched in one worktree whose agent then creates another and works there kept reporting the branch it left. In the reported case every Write/Edit after the `git worktree add` — 7 of 7 — landed in a different checkout while the sidebar, header and inspector all named the old one.

`Sess.workdir` is frozen at launch, and correctly so: resume, transcript path, diffstat and task discovery all key off it. So `refreshBranch` kept re-reading `git_head` in a folder the work had left. The worktree roster noticed the new checkout fine (the toast fired, the row appeared) — only the **session → checkout** link went stale.

## Why `cwd` can't fix it

Verified against the real CLI (2.1.220), not assumed:

| agent does | shell cwd | hook `cwd` |
|---|---|---|
| `cd` **inside** the session dir | persists | follows it ✓ |
| `cd` **outside** it (→ sibling worktree) | **reset back** | never moves ✗ |

The reporting session's transcript has 42 `Shell cwd was reset to …` and 622 records all naming the folder it had already left. Any design watching `cwd`, `workspace.current_dir` or the transcript watches a field pinned by construction for exactly the case that matters.

What *does* name the new checkout is `tool_input.file_path`, absolute on every write — already arriving on every `PostToolUse` and previously discarded.

## Detection (`gitwatch.ts`, pure + tested)

- **Only writes count.** A Read lands anywhere, and reading the old checkout is *why* an agent moved.
- **Both sides resolve to a checkout before comparing** — keeps a session launched in a *subfolder* (not drift) apart from one in a *nested worktree* (drift). Longest match wins.
- **Target must be a checkout the roster knows.** Unlike `gitMutates`, a false positive here isn't a wasted re-read — it puts a wrong branch on screen and offers to relocate a live session into `$TMPDIR`.
- **Latched, not sampled** — holds until the agent *writes home*, the only act meaning it came back.

## Display — the row does not move

It stays under the checkout that owns its identity (and where `--resume` goes), carrying a `⤳ branch` marker. The header chip reads `old ⤳ ⑃ new`; the inspector gets a card **above** the working set and git buttons it contradicts.

## The move action

`moveSessionToDrift` is the one action that writes inside `~/.claude`, and it has to be an action rather than something a user could type: `claude --resume` takes a session id and **no path**, looking the conversation up under `<enc(cwd)>/<id>.jsonl`. So no sequence of commands resumes a session in another folder.

**Kill → move → relaunch.** The await on the kill is what makes it a move of a *dead* session (`closeSession` fires `kill_session` without awaiting; a live process holding the file open makes Windows refuse the rename outright). The rename carries the `<id>/tool-results` sidecar, never overwrites, and rejects a non-uuid id before it reaches a filename. A failed move still relaunches — in the original folder — so the cost is a restarted pane.

Known wart, documented: the moved transcript's first record still names the old cwd, so its History row grafts onto the old project. Defensible — the conversation did start there.

## Verification

- `tsc` clean · **423 vitest** (was 408) · **91 cargo** (was 89) · clippy clean under `-D warnings` · no import cycles · builds
- The `--ignored` CLI contract test now pins `file_path` being absolute, and **was run against the real binary** (passes)
- The **cfg flip** was run post-commit: only the documented macOS-edge `E0433`s (`windows_sys`, `std::os::windows`), no findings — this change adds no cfg arms
- CLAUDE.md and RELEASE.md updated in the same commit

**Not done: the live click-through.** Every display surface here is DOM, which is untested by design in this repo. `RELEASE.md` gained a *Drift* section covering it; worth walking before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)