### PR TITLE
feat: the ＋ Session picker offers branches that only exist on a remote

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,7 +247,7 @@ Four smaller P4 affordances, all in the frontend:
 | --- | --- | --- |
 | `lib.rs` | 456 | `run()`, `AppState`/`Session`, the tray mirror, the panic hook, `write_debug_file`/`log_frontend`, `confirm_quit`, and the `invoke_handler!` list |
 | `tasks.rs` | 2,399 | runnable discovery — see Runnables above |
-| `git.rs` | 1,877 | worktrees, branches, the working-set diff, the toolbar's fetch/pull/push, commit info |
+| `git.rs` | 1,903 | worktrees, branches (local **and** remote-only), the working-set diff, the toolbar's fetch/pull/push, commit info |
 | `usage.rs` | 1,286 | transcripts (incl. History's whole-machine scan) + the token ledger — everything read out of `~/.claude` |
 | `telemetry.rs` | 857 | `write_instrument_settings`, `run_telemetry_server`, `resolve_permission` |
 | `platform.rs` | 743 | OS leaves (top half, incl. `norm_path`/`physical_cwd`) + OS integrations (bottom half) |
@@ -295,7 +295,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 
 **Markup-only views**, untested by design: `usageview`, `inspectorview`, `sidebarview`.
 
-**DOM-owning / render**, untested by design: `sidebar`, `footer`, `tray`, `inspector`, `debug`, `worktree` (the new-session dialog, the biggest single module at 932 lines), `settings`, `taskui`, `palui`, `projmenu`, `caffeinate`, `diffview`, `mirror`, `historyui`, `update`.
+**DOM-owning / render**, untested by design: `sidebar`, `footer`, `tray`, `inspector`, `debug`, `worktree` (the new-session dialog, the biggest single module at 953 lines), `settings`, `taskui`, `palui`, `projmenu`, `caffeinate`, `diffview`, `mirror`, `historyui`, `update`.
 
 **Behaviour** — IPC and DOM all the way down, so untested too, and therefore the thinnest ice in the app: `panes` (the three spawners + a pane's lifecycle), `terminal` (the xterm plumbing), `taskrun` (run on stop), `actions` (the app-level verbs), `icons` (the per-project glyph store).
 

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -80,10 +80,29 @@ pub(crate) fn create_worktree(repo_dir: String, branch: String, base: Option<Str
         }
     }
 
+    // A start-point that IS a remote-tracking ref means "check out what's on the remote",
+    // so the branch we cut must follow it: without an upstream, `git push`/`git pull` in
+    // the new worktree need arguments, and the picker's ahead/behind for it reads empty
+    // forever. Git already does this when `branch.autoSetupMerge` is at its default —
+    // which is exactly why it must be said outright, since a user who turned that off
+    // would otherwise get a silently untracked branch. Detected rather than passed as a
+    // flag so the rule holds for any caller, and so `base` keeps its one meaning.
+    let track = !branch_exists
+        && base.as_deref().is_some_and(|b| {
+            git(&["-C", &root, "rev-parse", "--verify", "--quiet", &format!("refs/remotes/{b}")])
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        });
+
     let add = if branch_exists {
         git(&["-C", &root, "worktree", "add", &wt_str, &safe])
     } else if let Some(b) = base.as_deref() {
-        git(&["-C", &root, "worktree", "add", "-b", &safe, &wt_str, b])
+        let mut args = vec!["-C", &root, "worktree", "add"];
+        if track {
+            args.push("--track");
+        }
+        args.extend_from_slice(&["-b", &safe, &wt_str, b]);
+        git(&args)
     } else {
         git(&["-C", &root, "worktree", "add", "-b", &safe, &wt_str])
     }.map_err(|e| e.to_string())?;
@@ -597,18 +616,31 @@ pub(crate) struct BranchInfo {
     /// An upstream is configured but no longer exists on the remote (branch deleted
     /// after a merge, typically). `upstream` still names it.
     gone: bool,
+    /// This row is a remote-tracking ref with no local branch of the same name —
+    /// someone else pushed it and nothing here points at it yet. The fields are then
+    /// read one level over: `name` is the local branch a checkout would CREATE and
+    /// `upstream` the ref it would track, which is exactly the pair the row will hold
+    /// a second after it is picked. `current`/`checked_out` are always false (there is
+    /// no local ref to be either) and so are `ahead`/`behind`/`gone` — the branch has
+    /// nothing to be ahead of yet.
+    remote: bool,
     rel: String,
     unix: i64,
 }
 
-/// Local branches for the worktree picker, most-recently-committed first, each with
+/// Branches for the worktree picker, most-recently-committed first, each with
 /// staleness + upstream context (see `BranchInfo`). Nothing is filtered here — the
 /// frontend hides `current` and `checked_out` from the pickable list; returning them
 /// with flags keeps the command honest and testable. Capped at BRANCH_LIST_CAP so a
 /// repo with hundreds of refs can't blow the list up.
 ///
-/// Everything comes out of ONE `for-each-ref`: `%(upstream:track)` makes git do the
+/// Local branches come out of ONE `for-each-ref`: `%(upstream:track)` makes git do the
 /// ahead/behind arithmetic itself, so this no longer spawns a `rev-list` per branch.
+/// A second pass adds **remote-only** branches (`remote: true`) — a colleague's branch
+/// that exists on a remote and nowhere locally is a destination you'd want, and before
+/// this it wasn't merely hidden: typing its name fell through to the create path and
+/// made a *new, unrelated* branch off HEAD under the same name. Remote rows are capped
+/// separately so a fork with hundreds of them can't crowd out the local list.
 #[tauri::command(async)]
 pub(crate) fn git_branch_list(repo_dir: String) -> Vec<BranchInfo> {
     const BRANCH_LIST_CAP: usize = 80;
@@ -647,6 +679,16 @@ pub(crate) fn git_branch_list(repo_dir: String) -> Vec<BranchInfo> {
     };
     let text = String::from_utf8_lossy(&out.stdout);
 
+    // Every local branch name, uncapped. The remote pass below asks "is there already a
+    // local branch called this?", and `res` stops being able to answer that the moment
+    // BRANCH_LIST_CAP truncates it — which would resurrect a checked-out branch as a
+    // remote-only row in exactly the repos big enough to hit the cap.
+    let local_names: std::collections::HashSet<&str> = text
+        .lines()
+        .filter_map(|l| l.split('\t').next())
+        .filter(|n| !n.is_empty())
+        .collect();
+
     let mut res = Vec::new();
     for line in text.lines().take(BRANCH_LIST_CAP) {
         let mut parts = line.split('\t');
@@ -678,7 +720,83 @@ pub(crate) fn git_branch_list(repo_dir: String) -> Vec<BranchInfo> {
         res.push(BranchInfo {
             checked_out: taken.contains(&name),
             current: current.as_deref() == Some(name.as_str()),
+            remote: false,
             name, upstream, ahead, behind, gone, rel, unix,
+        });
+    }
+
+    // ---- remote-only branches ------------------------------------------------------
+    // The remote names are read rather than assumed, because the short ref is the only
+    // thing `for-each-ref` gives us and "origin/feature/x" has to be split back into
+    // remote + branch. Nothing here can guess where that boundary is.
+    let remotes: Vec<String> = match git(&["-C", &repo_dir, "remote"]) {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            .map(str::to_string)
+            .collect(),
+        _ => Vec::new(),
+    };
+    if remotes.is_empty() {
+        return res;
+    }
+    let rout = match git(&[
+        "-C", &repo_dir,
+        "for-each-ref",
+        "--sort=-committerdate",
+        "--format=%(refname:short)\t%(committerdate:unix)\t%(committerdate:relative)",
+        "refs/remotes",
+    ]) {
+        Ok(o) if o.status.success() => o,
+        _ => return res,
+    };
+    let rtext = String::from_utf8_lossy(&rout.stdout);
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for line in rtext.lines() {
+        if seen.len() >= BRANCH_LIST_CAP {
+            break;
+        }
+        let mut parts = line.split('\t');
+        let short = match parts.next() {
+            Some(s) if !s.is_empty() => s,
+            _ => continue,
+        };
+        // Longest matching prefix wins: git permits a remote named `a` alongside one
+        // named `a/b`, and only the longer one splits `a/b/topic` where it really joins.
+        // The empty remainder is what drops `refs/remotes/<remote>/HEAD` — the symbolic
+        // pointer at the remote's default branch, which would otherwise duplicate
+        // whatever it points at. Worth spelling out because it does NOT shorten to
+        // `origin/HEAD` as you'd expect: git renders it as a bare `origin`, so no test
+        // on the name would have caught it. (The `HEAD` check below is a belt for any
+        // git that does spell it out.)
+        let local = match remotes
+            .iter()
+            .filter_map(|r| short.strip_prefix(r.as_str()).and_then(|s| s.strip_prefix('/')))
+            .filter(|s| !s.is_empty())
+            .min_by_key(|s| s.len())
+        {
+            Some(l) => l,
+            None => continue,
+        };
+        // A name that already exists locally isn't remote-*only*, and two remotes
+        // carrying the same branch is one destination, not two.
+        if local == "HEAD" || local_names.contains(local) || !seen.insert(local.to_string()) {
+            continue;
+        }
+        let unix = parts.next().and_then(|s| s.trim().parse().ok()).unwrap_or(0);
+        let rel = parts.next().unwrap_or("").to_string();
+        res.push(BranchInfo {
+            name: local.to_string(),
+            current: false,
+            checked_out: false,
+            upstream: short.to_string(),
+            ahead: 0,
+            behind: 0,
+            gone: false,
+            remote: true,
+            rel,
+            unix,
         });
     }
     res
@@ -1645,6 +1763,78 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(wt_root(&dir));
         let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_dir_all(&remote);
+    }
+
+    /// A branch that exists on a remote and nowhere locally is a destination too. Both
+    /// halves matter and the second is the one with teeth: picking such a row must cut a
+    /// branch from the remote's tip and TRACK it, not mint a same-named stranger off
+    /// HEAD — which is precisely what the create path did before these rows existed.
+    #[test]
+    fn git_branch_list_offers_remote_only_branches_and_their_worktrees_track() {
+        let dir = scratch_dir();
+        let remote = scratch_dir();
+        let theirs = scratch_dir();
+        git(&remote, &["init", "-q", "--bare", "-b", "dev"]);
+        git(&dir, &["init", "-q", "-b", "dev"]);
+        let commit = |dir: &Path, msg: &str| git(dir, &["-c", "user.email=t@example.com", "-c", "user.name=T", "-c", "commit.gpgsign=false", "commit", "-q", "--allow-empty", "-m", msg]);
+        commit(&dir, "base");
+        git(&dir, &["remote", "add", "origin", remote.to_str().unwrap()]);
+        git(&dir, &["push", "-q", "-u", "origin", "dev"]);
+
+        // A colleague pushes from their own clone; ours only ever fetches, so these two
+        // branches exist under refs/remotes and nowhere else.
+        git(&theirs, &["clone", "-q", remote.to_str().unwrap(), "."]);
+        git(&theirs, &["checkout", "-q", "-b", "their-feature"]);
+        commit(&theirs, "their work");
+        git(&theirs, &["push", "-q", "-u", "origin", "their-feature"]);
+        git(&theirs, &["checkout", "-q", "-b", "nested/topic"]);
+        commit(&theirs, "nested work");
+        git(&theirs, &["push", "-q", "-u", "origin", "nested/topic"]);
+        git(&dir, &["fetch", "-q", "origin"]);
+        git(&dir, &["remote", "set-head", "origin", "dev"]);   // creates origin/HEAD
+
+        let bs = git_branch_list(dir.to_str().unwrap().to_string());
+        let by = |n: &str| bs.iter().find(|b| b.name == n).unwrap_or_else(|| panic!("{n} missing from {bs:?}"));
+
+        let f = by("their-feature");
+        assert!(f.remote, "their-feature exists only on the remote: {bs:?}");
+        assert_eq!(f.upstream, "origin/their-feature", "name is the local branch to create, upstream the ref it tracks: {bs:?}");
+        assert!(!f.current && !f.checked_out, "a remote-only branch has no local checkout: {bs:?}");
+        assert!(!f.gone && (f.ahead, f.behind) == (0, 0), "nothing to be ahead of yet: {bs:?}");
+
+        // The short ref has to be split back into remote + branch, and a branch name
+        // containing a slash must not be split at the first one it happens to hold.
+        assert_eq!(by("nested/topic").upstream, "origin/nested/topic", "{bs:?}");
+
+        // dev has a local branch, so it is not remote-*only*; origin/HEAD is a symbolic
+        // pointer at the default branch rather than a branch. Neither may appear. Both
+        // spellings are asserted because git shortens that ref to a bare `origin`, so a
+        // filter that only looked for "HEAD" would let it through as a phantom row.
+        assert!(!by("dev").remote, "dev has a local branch: {bs:?}");
+        assert!(!bs.iter().any(|b| b.name == "HEAD" || b.name == "origin"),
+            "the remote's HEAD pointer is not a branch: {bs:?}");
+
+        // Picking the row is `create_worktree(name, base = upstream)`.
+        let path = create_worktree(dir.to_str().unwrap().to_string(), "their-feature".into(), Some("origin/their-feature".into()))
+            .expect("worktree on a remote-only branch");
+        let out = |args: &[&str]| String::from_utf8_lossy(
+            &Command::new("git").current_dir(&path).args(args).output().unwrap().stdout
+        ).trim().to_string();
+        assert_eq!(out(&["rev-parse", "--abbrev-ref", "HEAD"]), "their-feature");
+        assert_eq!(out(&["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]), "origin/their-feature",
+            "the new branch must track the remote ref it was cut from");
+        assert_eq!(out(&["log", "-1", "--format=%s"]), "their work",
+            "it must hold THEIR commit, not a fresh branch off our HEAD");
+
+        // And having become local, it must stop being offered as remote-only.
+        let bs2 = git_branch_list(dir.to_str().unwrap().to_string());
+        let f2 = bs2.iter().find(|b| b.name == "their-feature").expect("still listed");
+        assert!(!f2.remote && f2.checked_out, "it is a local, checked-out branch now: {bs2:?}");
+
+        let _ = std::fs::remove_dir_all(wt_root(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_dir_all(&theirs);
         let _ = std::fs::remove_dir_all(&remote);
     }
     /// Without a start-point, `worktree add -b` cuts from HEAD — which makes whatever

--- a/src/styles.css
+++ b/src/styles.css
@@ -721,6 +721,9 @@ select.in-ctl { cursor: pointer; }
 .wt-tag.moved { color: var(--st-working); border-color: color-mix(in srgb, var(--st-working) 42%, transparent); }
 .wt-tag.missing { color: var(--st-error); border-color: color-mix(in srgb, var(--st-error) 42%, transparent); }
 .wt-tag.det, .wt-tag.locked, .wt-tag.ext { color: var(--st-idle); }
+/* `rem` names the remote a branch lives on and is pure orientation — the row is a
+   perfectly good destination, so it must not borrow any of the warning colours. */
+.wt-tag.rem { color: var(--st-idle); }
 /* `gone` is INFORMATION, not a fault: the remote branch was deleted, which usually
    follows a merged PR but just as often precedes picking the work back up. It must
    not share .missing's error red — that reads as "broken, delete me" and argues

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -44,11 +44,14 @@ export function setWtHandToTerminal(fn: typeof handToTerminal) { handToTerminal 
 // panel each led to a dialog that couldn't start a session in the project itself.
 // ahead/behind are versus this branch's OWN remote upstream (empty when it has none),
 // not versus whatever HEAD is on — see the BranchInfo doc comment in lib.rs.
-type BranchInfo = { name: string; current: boolean; checked_out: boolean; upstream: string; ahead: number; behind: number; gone: boolean; rel: string; unix: number };
+// `remote: true` inverts how the row is read: it has no local branch at all, so `name`
+// is the local branch a checkout WOULD create and `upstream` the ref it would track.
+// See the BranchInfo doc comment in git.rs.
+type BranchInfo = { name: string; current: boolean; checked_out: boolean; upstream: string; ahead: number; behind: number; gone: boolean; remote: boolean; rel: string; unix: number };
 type WtInfo = { path: string; branch: string; is_main: boolean; dirty: boolean; merged: boolean; locked: boolean; exists: boolean };
 type CommitInfo = { short: string; subject: string; author: string; rel: string };
 
-type DestKind = "repo" | "wt" | "branch" | "create";
+type DestKind = "repo" | "wt" | "branch" | "remote" | "create";
 interface Dest {
   kind: DestKind;
   group: string;          // "" pins the row above every group (the create row)
@@ -68,7 +71,12 @@ interface Dest {
 
 let wtCtx: { project: string; repoDir: string } | null = null;
 let wtWts: WtInfo[] = [];
+// Kept apart rather than filtered at each use: `wtBranches` means "branches this repo
+// has", and every existing reader (the base chooser, the switch chooser, delete) is only
+// ever correct for those. A remote-only row is not a branch you can base, switch to or
+// delete — it doesn't exist yet.
 let wtBranches: BranchInfo[] = [];
+let wtRemotes: BranchInfo[] = [];
 let wtRepoBranch = "";
 let wtLoading = true;          // git hasn't answered yet — draw skeleton rows
 let wtRows: Dest[] = [];
@@ -165,7 +173,9 @@ export async function openWt(project: string, repoDir: string, knownBranch?: str
 //   wtReadLocal — pure local git, instant, safe to run whenever.
 //   wtMaybeFetch — network. ahead/behind and `gone` come from %(upstream:track), which
 //     compares against refs/remotes/*, a cache only `git fetch` moves. Without this the
-//     panel's most useful signal would silently reflect whenever you last fetched.
+//     panel's most useful signal would silently reflect whenever you last fetched — and
+//     the Remote branches group is read straight out of refs/remotes, so a colleague's
+//     branch pushed five minutes ago would not be a destination at all.
 async function wtLoad(quiet = false) {
   await wtReadLocal(quiet);
   void wtMaybeFetch();
@@ -219,7 +229,9 @@ async function wtReadLocal(quiet = false) {
     invoke<string | null>("git_branch", { workdir: repoDir }).catch(() => null),
   ]);
   if (gen !== wtGen || !wtCtx || wtCtx.repoDir !== repoDir) return; // dialog moved on
-  wtWts = wts; wtBranches = branches; wtRepoBranch = head || wtRepoBranch;
+  wtWts = wts; wtRepoBranch = head || wtRepoBranch;
+  wtBranches = branches.filter((b) => !b.remote);
+  wtRemotes = branches.filter((b) => b.remote);
   wtLoading = false;
   wtLoadedAt = Date.now();
   if (!wts.length && !quiet) toast(`${basename(repoDir)} isn't a git repository`);
@@ -242,7 +254,10 @@ function wtBuild(): Dest[] {
   const hit = (s: string) => !q || s.toLowerCase().includes(q);
   const out: Dest[] = [];
 
-  const known = [...wtWts.map((w) => w.branch), ...wtBranches.map((b) => b.name), wtRepoBranch];
+  // Remote-only names count as known: typing one must land on its row, not fall through
+  // to "create", which would cut an unrelated branch off HEAD under the very same name.
+  const known = [...wtWts.map((w) => w.branch), ...wtBranches.map((b) => b.name),
+    ...wtRemotes.map((b) => b.name), wtRepoBranch];
   const exact = known.some((n) => n && n.toLowerCase() === q);
 
   // The typed query, promoted to an action. This is what lets the branch field, its
@@ -314,7 +329,29 @@ function wtBuild(): Dest[] {
       verb: clash ? "blocked — that folder exists" : "create a worktree on this branch & start",
     });
   }
+
+  // Branches that exist on a remote and nowhere here — a colleague's work, or your own
+  // from another machine. Last, because they're the least likely destination and the
+  // only ones that touch a name the repo doesn't have yet.
+  for (const b of wtRemotes) {
+    if (!hit(`${b.name} ${b.upstream}`)) continue;
+    const clash = wtWts.find((w) => !w.is_main && basename(w.path) === wtSlug(b.name));
+    out.push({
+      kind: "remote", group: "Remote branches", ic: "⇣", br: b, clash,
+      label: b.name, sub: "", dir: wtTargetDir(repoDir, b.name), branch: b.name,
+      tags: [], stale: b.unix > 0 && now - b.unix > STALE,
+      meta: `<span class="wt-tag rem" title="Only on ${esc(b.upstream)} — no local branch yet">${esc(wtRemoteOf(b))}</span>`
+        + `<span class="wt-when">${esc(b.rel || "")}</span>`,
+      verb: clash ? "blocked — that folder exists" : `check ${b.upstream} out into a worktree & start`,
+    });
+  }
   return out;
+}
+
+/** The remote a remote-only row came from. `upstream` is exactly `<remote>/<name>`, so
+ *  this is a slice rather than a split — the branch name may itself contain slashes. */
+function wtRemoteOf(b: BranchInfo) {
+  return b.upstream.slice(0, Math.max(0, b.upstream.length - b.name.length - 1));
 }
 
 function wtRender() {
@@ -387,6 +424,8 @@ function wtCommitKey(d: Dest): string {
   if (d.kind === "repo") return `${d.dir}\n`;
   if (d.kind === "wt") return d.wt!.exists ? `${d.dir}\n` : "";
   if (d.kind === "branch") return `${wtCtx.repoDir}\n${d.branch}`;
+  // A remote-only row has no local ref to name, so ask about the remote-tracking one.
+  if (d.kind === "remote") return `${wtCtx.repoDir}\n${d.br!.upstream}`;
   return "";
 }
 
@@ -510,6 +549,27 @@ function wtDetailHtml(d: Dest | undefined): string {
       + `<button class="wt-rm" type="button" data-wtact="arm">Delete branch…</button>`
       + `</div>`;
   }
+
+  // A remote-only branch. Nothing here can be deleted or switched to — there is no local
+  // ref yet — so the pane is entirely about what picking it would bring into existence.
+  if (d.kind === "remote") {
+    const b = d.br!;
+    return `<div class="wt-dhead"><span class="wt-dkind">Remote branch — no local copy</span><span class="wt-dname">${esc(b.upstream)}</span></div>`
+      + clashWarn
+      + (clash ? "" : `<div class="wt-warn note"><span class="t">Not checked out anywhere yet</span>`
+        + `This exists on <b>${esc(wtRemoteOf(b))}</b> and nowhere in this repo. Starting here cuts <b>${esc(b.name)}</b> `
+        + `from it and sets it to track <b>${esc(b.upstream)}</b>, so <b>git push</b> and <b>git pull</b> in the new worktree take no arguments.</div>`)
+      + wtFacts([
+        ["Last commit", wtCommitHtml(d)],
+        ["Will track", `<span class="em">${esc(b.upstream)}</span>`],
+        ["Local branch", `<span class="em">${esc(b.name)}</span> <span class="dim">— created now</span>`],
+        [clash ? "Would be" : "Will create", wtPathHtml(d.dir)],
+      ])
+      + `<div class="wt-acts"><button class="wt-go" type="button" data-wtact="go"${clash ? " disabled" : ""}>Create worktree &amp; start</button>`
+      + (clash ? `<button class="wt-alt" type="button" data-wtact="openclash">Open that checkout instead</button>` : "")
+      + `</div>`;
+  }
+
   return `<div class="wt-dhead"><span class="wt-dkind">New worktree</span><span class="wt-dname">${esc(d.label)}</span></div>`
     + clashWarn
     + wtFacts([
@@ -797,7 +857,9 @@ function wtRun(d: Dest | undefined) {
     return;
   }
   if (d.clash) { toast(`${basename(d.clash.path)}/ already exists`); return; }
-  void wtCreate(d.branch, d.kind === "create" ? wtBase : "");
+  // A remote-only row starts from its remote ref, which is also what makes the new
+  // branch track it — `create_worktree` reads that off the start-point.
+  void wtCreate(d.branch, d.kind === "create" ? wtBase : d.kind === "remote" ? d.br!.upstream : "");
 }
 
 async function wtCreate(branch: string, base = "") {


### PR DESCRIPTION
## What

A branch that exists on a remote and nowhere locally — a colleague's, or your own from another machine — is now a destination in the new-session dialog, in its own **Remote branches** group.

It wasn't merely hidden before. Typing such a branch's name fell through to the create path and cut a **new, unrelated branch off HEAD under the very same name**, which is a quietly wrong outcome rather than a missing feature.

## Backend — `git.rs`

- `BranchInfo` gains `remote: bool`. On such a row the fields are read one level over: `name` is the local branch a checkout would *create*, `upstream` the ref it would track. That is exactly the pair the row holds a second after it's picked, so every existing renderer fits unchanged.
- `git_branch_list` adds a second `for-each-ref refs/remotes` pass — drops anything with a local branch of the same name, dedupes across remotes, capped separately so a fork with hundreds of refs can't crowd out the local list.
- `create_worktree` passes `--track` when the start-point is a remote-tracking ref. Detected via `rev-parse refs/remotes/<base>` rather than added as a parameter, so `base` keeps its one meaning and the rule holds for any caller. Git already does this under the default `branch.autoSetupMerge` — which is the reason to say it outright, since anyone who turned that off would otherwise get a silently untracked branch.

## Two traps worth reviewing

- **The local-name set is built uncapped.** Building it from the already-capped result would resurrect a checked-out branch as a remote-only row in precisely the repos big enough to hit `BRANCH_LIST_CAP`.
- **`refs/remotes/origin/HEAD` shortens to a bare `origin`, not `origin/HEAD`.** Found by checking real output, not by assuming. It's the empty-remainder filter that drops it; a test on the name would never have fired. My first pass's comment credited the wrong filter. Both spellings are now asserted.

## Frontend — `worktree.ts`, `styles.css`

- `wtRemotes` is kept **separate** from `wtBranches` rather than filtered per use: the base chooser, the switch chooser and delete are only ever correct for branches that exist, and a remote-only row can be none of those.
- Rows carry a `⇣` glyph, the remote name as a chip, and the commit age. The detail pane spells out that picking one cuts `<name>` from the remote and tracks it. `wtCommitKey` reads the remote ref so "Last commit" resolves.
- Remote names **do** join the `known` set — that's what stops the wrong-branch-off-HEAD fall-through above.

## Testing

Gates all green: **408** vitest, **87** cargo, clippy `-D warnings` clean, `tsc` clean.

One new Rust test drives real git — pushes from a second clone, asserts the rows (including the slash-in-branch-name split and the `origin/HEAD` exclusion), then checks the resulting worktree holds *their* commit and tracks the ref it came from.

**Not covered:** the rendering half is the untested-by-design layer, so the group's appearance and keyboard flow want a click-through in a running app. I have not done that. Against this repo the change surfaces 6 new rows (`feat/session-drift`, `fix/run-window`, `feat/permission-mode`, `feat/commit-graph`, `feat/reveal-folder-hotkey`, `fix/worktree-branch-sidebar`).

## Deliberately out of scope

The **Branch from** base chooser stays local-only. Basing a new branch on `origin/main` is a reasonable follow-up and the backend would already track it correctly, but it's a separate decision.

## Note

Two line counts in `CLAUDE.md` were already stale by ~150 lines before this branch; corrected for the two files touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)