### PR TITLE
sidebar: idle checkouts wait until you rest on the project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ pnpm coverage           # the same suites with v8 coverage
 ```
 
 Coverage is a **yardstick, not a target** — there is deliberately no gate, because the
-render and DOM-owning modules are untested by design. Current: **88.0%** statements
-over the modules the suites load, **19.4%** over all of `src/`, and **71.0%** Rust
+render and DOM-owning modules are untested by design. Current: **88.4%** statements
+over the modules the suites load, **19.3%** over all of `src/`, and **71.0%** Rust
 lines (`cargo llvm-cov --summary-only` from `src-tauri/`). Both gaps are the OS edge,
 which `RELEASE.md` covers by hand. Note vitest's `text` reporter **hides any file at
 100% in all four columns**, so a fully-covered module looks absent; use
@@ -52,9 +52,9 @@ Mac has the same symlink — but it is one both legs will find at once.
 
 **Package manager: `pnpm`** for this repo (there's a `pnpm-lock.yaml`; both CI workflows use `pnpm install --frozen-lockfile`, and `packageManager` in `package.json` pins the version for corepack/CI). Use pnpm here, not npm. Windows code-signing / release-signing setup lives in `src-tauri/SIGNING.md`.
 
-Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **468 vitest + cargo (100 on macOS, 97 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
+Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **490 vitest + cargo (100 on macOS, 97 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
 
-**vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which twelve those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
+**vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which thirteen those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
 
 What is **untested by design**: the render, view and DOM-owning modules on both sides of the app — snapshotting template literals mostly re-asserts itself. Anything touching the DOM, PTYs, or live telemetry is still verified by **running the app and exercising it** — the statusLine half of telemetry only fires in interactive mode, so it cannot be checked end to end with `claude -p`. Split that one carefully, because the split is not where it looks: whether the generated statusLine command *works* is checked headlessly and in CI (the shell runs it for real — see the constraint above). What needs a live REPL is only whether **Claude still picks the shell and payload we expect**. That costs a TTY, not tokens: a session you launch and never prompt makes no API call, and the statusLine fires on start and every `refreshInterval` seconds regardless. It's a `RELEASE.md` click-through, and a cheap one. `tsc` (strict) is the real linter. Requires `claude` on PATH, the Node in `.nvmrc` (`nvm use`; `engines` floors it at 24), and Rust stable + Tauri system deps.
 
@@ -192,6 +192,14 @@ couldn't express: **`toggle`** (a single switch) and **`multi`** (independently
 toggled values, for "which providers to scan" and the revocable trust list). New
 task settings belong in that tab as control descriptors; `applySetting` dispatches
 them.
+
+Two later kinds are worth knowing about because they set the precedent for anything
+with a *feel* rather than a value: **`wtpreview`** (a pick shown as live mini-sidebars)
+and **`peek`** (steppers over a preview you hover). Both build their preview from the
+app's own CSS and, in `peek`'s case, its own reducer — the rule being that a preview
+which restates the thing it previews will drift from it, and then reassure you about
+behaviour the app no longer has. A setting whose right value can only be *felt* should
+ship with something to feel it on rather than a number in a box.
 
 Task preferences live in `cc-task-prefs`, pins in `cc-task-pins`, hidden tasks in
 `cc-task-hidden`, run-on-stop rules in `cc-task-onstop`, trust in `cc-trusted`. The split is deliberate and worth
@@ -391,13 +399,13 @@ Four conventions hold across them:
 - **Telemetry server** (`run_telemetry_server`) forwards `/hook` and `/statusline` POSTs as one `telemetry` event each; `/permission` is the blocking path described above.
 - Commands are registered in the `invoke_handler![...]` list at the bottom of `run()` — add new `#[tauri::command]` fns there.
 
-## Frontend (`src/`, `index.html`, `src/styles.css`) — 39 modules
+## Frontend (`src/`, `index.html`, `src/styles.css`) — 40 modules
 
-**No framework, and no longer one file.** ~9,885 lines across 39 modules; `main.ts` is 731 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
+**No framework, and no longer one file.** ~10,300 lines across 40 modules; `main.ts` is 735 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (~70 lines — it is the seam map, and belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, the window controls (see One title bar), and the seven `setInterval`s.
 
-**Tested logic modules** (twelve — no DOM, no Tauri, no render imports; these are what the 468 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
+**Tested logic modules** (thirteen — no DOM, no Tauri, no render imports; these are what the 490 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
 
 | Module | What |
 | --- | --- |
@@ -413,6 +421,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 | `history.ts` | History's rules: `histProject` (regrafting a row onto a project), `histBusy`, the scope/search predicates, day buckets |
 | `gitwatch.ts` | `gitMutates` — whether a shell command an agent ran is worth re-reading git for; `driftTarget`/`driftUpdate` — which checkout its work has moved to, from writes *and* `cwd` |
 | `graph.ts` | the commit graph: `layoutGraph`'s lanes, what names a lane (`lineRef`, `lineTip`), `parseRefs`, the geometry and `rowSvg` |
+| `peek.ts` | the sidebar's hover-to-reveal: what arms, what cancels, what the next deadline is |
 
 **Shared**: `state.ts` (the session map, the stage pointer, every persisted preference) and `dom.ts` (`$`, `toast`, the shared scrim, `IS_MAC`/`MOD`/`chord`).
 
@@ -422,7 +431,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 
 **Behaviour** — IPC and DOM all the way down, so untested too, and therefore the thinnest ice in the app: `panes` (the three spawners + a pane's lifecycle), `terminal` (the xterm plumbing), `taskrun` (run on stop), `actions` (the app-level verbs), `icons` (the per-project glyph store).
 
-Four rules keep that graph honest. **There are no import cycles across the 39 modules; re-run a cycle check after any change that adds an import.**
+Four rules keep that graph honest. **There are no import cycles across the 40 modules; re-run a cycle check after any change that adds an import.**
 
 - **Dependency direction is state ← render ← wiring.** A logic module must not import render code or `main.ts`.
 - **When an extracted function needs something that lives further up**, resolve it in this order: (1) **move the callee down too** if it is itself leaf-shaped — that is why `icons.ts` sits below `sidebar.ts` and `usage.ts` below `phase.ts`; (2) **a settable hook defaulting to a no-op** (`setRlLogger`, `setPanesRenderAll`) when the callee genuinely belongs to the render layer; (3) **an extra parameter** only as a last resort, since it changes a signature the move was supposed to leave alone. A control panel touching many things it doesn't own may take **one host object** instead of N setters (`settings`, `palui`, `projmenu`); prefer per-callee setters below ~4.
@@ -478,7 +487,7 @@ And the things that hold however the files are arranged:
 - **Event wiring**: `listen("pty-output" | "pty-exit" | "telemetry" | "permission" | "tray-select")` at the bottom of `main.ts`. Telemetry is routed by `data.session_id?.toLowerCase()` — session ids are matched case-insensitively, so keep them lowercase.
 - `applyHook` maps lifecycle events → a `Phase` state machine (idle/thinking/working/done/error/ended) and attention flags; `applyStatusline` fills model/context%/cost/duration. **Rate limits are account-wide**, held in a single `rl` object and shown identically on every session, not per-session.
 - **A turn that died is not a turn that finished, and only one hook knows which.** Claude Code fires `StopFailure` (not `Stop`) when the API kills a turn — a 529, a rate limit, a dead key — carrying an `error` enum (`overloaded`, `rate_limit`, `authentication_failed`, `max_output_tokens`, …) and the `error_details` text the pane shows. Everything *after* that point looks identical to a clean finish: the same 60-second idle `Notification` (`notification_type: "idle_prompt"`) arrives either way. Unguarded it relabelled the turn "your turn" and turned the red ✕ green a minute after the failure — which shipped, and is why `Sess.apiErr` exists. It is set by `StopFailure`, cleared only when the session genuinely starts another turn (`UserPromptSubmit` / `PreToolUse` / `SessionStart` / `SessionEnd`), and **`endTurn` is the single place that decides done vs. error** — both `Stop` and the idle nudge go through it, and the run-on-stop rule is skipped while it's set. Every surface that spells a state out reads `phaseText(s)`, not `PILL_TEXT[s.phase]`, so the reason travels with the glyph: "API overloaded" means wait, "auth failed" means go fix your credentials, and a bare ✕ means neither.
-- **Persistence is all `localStorage`**, ~20 keys prefixed `cc-` (favorites, drag order, colours, icons, engine, permission mode, font size, sort/grouping, frecency, caffeinate, the `cc-usage` daily cost rollup, the `cc-restore` roster, and the task keys `cc-task-{prefs,pins,hidden,onstop,runner,inputs}` + `cc-trusted`). `grep '"cc-'` for the current set.
+- **Persistence is all `localStorage`**, ~20 keys prefixed `cc-` (favorites, drag order, colours, icons, engine, permission mode, font size, sort/grouping, frecency, caffeinate, the `cc-usage` daily cost rollup, the `cc-restore` roster, the sidebar's `cc-peek` timings, and the task keys `cc-task-{prefs,pins,hidden,onstop,runner,inputs}` + `cc-trusted`). `grep '"cc-'` for the current set.
 - **Debug console** (🐞 button, bottom-right): an in-app event log + live state via `dlog()`/`dbgSnapshot()`. It flags **unrouted telemetry** (the routing-drift class of bug above) and JS errors, and mirrors a snapshot to `$TMPDIR/cc-launcher/episko-debug.json` (written by the `write_debug_file` command) so an external tool or an LLM agent can read live app state while it runs.
 - **Two-tier logging — live snapshot vs. durable timeline.** The `episko-debug.json` snapshot is a *state-of-now* blob that is overwritten each flush and does **not** survive a crash (the frontend never flushes if the process dies). The durable tier is the backend rolling `episko.log` (+ `panic.log`) in the OS app-log dir (macOS `~/Library/Logs/io.respeak.episko/`), via `tauri-plugin-log` and a panic hook — the only on-disk trace of a panic that unwinds cleanly out of `main` (no crash dump / WER otherwise). Every `dlog()` line tees into it through the `log_frontend` command (tagged `[ui]`), so the UI and backend event streams land in **one time-ordered file**. A `episko.log` that stops without an `exit · clean shutdown` line is itself evidence of an abnormal termination. Use the snapshot for "what is it doing *now*", the rolling log for "why did it *die*".
 
@@ -528,17 +537,45 @@ call `refreshGitViews` on success rather than waiting for the poll — `renderAl
 paints the roster, it never re-reads it, so without this the cluster you just deleted
 stays on screen.
 
-**The ⑃ cluster header is the surface for a checkout** (subheader mode). It renders
-whether or not anything runs beneath it, which is what lets the roster's discovery show:
-a worktree an agent created appears as a dimmed header (`.wtvacant`) rather than as a
-row that says "no session". It carries a `＋` (→ `launchWorktree`, which keys the new
-session's `colorKey` to the **repo root**, or the pane splits off into a project group of
-its own) and a **right-click menu** in `projmenu.ts` — terminal, folder, copy path, the ⑃
-dialog, and remove. That menu shares `#ctxMenu` with the project one: `data-wt` is
-matched *ahead* of `data-key` in the `contextmenu` handler, because a cluster sits inside
-a project group and a combined `closest()` would be decided by tree distance rather than
-by what was clicked. Chip mode has no headers, so the "no session" row survives there
-alone.
+**The ⑃ cluster header is the surface for a checkout** (subheader mode), and it renders
+only for a checkout something is actually running in (`clusterIsLive`). It carries a `＋`
+(→ `launchWorktree`, which keys the new session's `colorKey` to the **repo root**, or the
+pane splits off into a project group of its own) and a **right-click menu** in
+`projmenu.ts` — terminal, folder, copy path, the ⑃ dialog, and remove. That menu shares
+`#ctxMenu` with the project one: `data-wt` is matched *ahead* of `data-key` in the
+`contextmenu` handler, because a cluster sits inside a project group and a combined
+`closest()` would be decided by tree distance rather than by what was clicked.
+
+**The idle checkouts are peek rows** (`peekBody` → `.pgpeek`), collapsed until the
+pointer rests on the project group. They used to be permanent dimmed headers, and a repo
+with four worktrees spent four rows saying "no session" four times: those rows are worth
+*reaching*, not *showing*, and the moment you want one is the moment the pointer is
+already on the project. The whole row launches — there is no ＋ to aim at, because it has
+exactly one thing it can do and a target the width of the sidebar beats a glyph. Four
+things about it are load-bearing:
+
+- **`peek.ts` owns the rules and is pure** — `peekEnter`/`peekLeave`/`peekTick` over an
+  explicit `now`, no timers and no DOM, so what-cancels-what is unit-tested. `sidebar.ts`
+  is a thin driver that schedules **one** timeout to `peekNextDeadline`; an idle sidebar
+  arms nothing.
+- **Hover is not a render input.** `peekBody` emits the rows on every paint and the
+  expansion is one class applied outside the render path. Making it part of the markup
+  would bust `renderSidebar`'s byte-identical cache (84.5% of repaints) on every mouse
+  move — and worse, a telemetry tick would rebuild `#projects` and collapse a group under
+  the pointer. That is also why `PeekState.open` is a **project path**, not an element:
+  `renderSidebar` re-applies it through `applyPeek()` after each DOM write. The listeners
+  are delegated `mouseover`/`mouseout` (which bubble) on the persistent `#projects`, for
+  the same reason — `mouseenter` would need re-binding on every repaint.
+- **Moving between two expanded groups skips the delay.** The delay exists to ignore a
+  pointer passing *over* the rail; one already inside it is not passing over anything.
+- **Off keeps the old behaviour** rather than hiding the rows for good — the wrapper
+  renders already-open, so nothing that used to be reachable stops being so.
+
+Timings live in `cc-peek` and are set in Settings › Worktrees, where the control is a
+pair of steppers over a **live preview built from the real `.pgroup`/`.pgpeek`/`.pkrow`
+CSS and driven by the real reducer**. That is the point of it: "is 1000ms right?" has no
+answer until you have rested a pointer on something for 1000ms, and a preview styled
+separately from the thing it previews is just a picture.
 
 **`openWt` has two modes, and the difference is framing, not machinery.** `launch` is
 the original — "where should this session start?", so every branch in the repo is a row.

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -15,16 +15,18 @@ import { basename } from "./format";
 import { probeIcon } from "./icons";
 import { refit } from "./terminal";
 import { activeCwd, closeSession, launch } from "./panes";
-import { renderMini, renderSidebar } from "./sidebar";
+import { closePeek, renderMini, renderSidebar } from "./sidebar";
 import { renderSettings } from "./settings";
 import { waitForExit } from "./tasks";
 import { queueRosterSave } from "./mirror";
 import {
-  FAVORITES, markWorkdirStale, permMode, permModeDef, saveFavorites, sessions,
-  setFavorites, setPermMode as setPermModeState, setSortMode, SORT_META, SORT_MODES,
+  FAVORITES, markWorkdirStale, peekPrefs, permMode, permModeDef, saveFavorites, sessions,
+  setFavorites, setPeekPrefs as setPeekPrefsState, setPermMode as setPermModeState,
+  setSortMode, SORT_META, SORT_MODES,
   sortMode, setWtGroup as setWtGroupState, wtGroup,
   type SortMode, type WtGroup,
 } from "./state";
+import type { PeekPrefs } from "./peek";
 import type { PermMode } from "./types";
 
 // Every action here ends in a repaint of everything, which main.ts owns.
@@ -82,6 +84,20 @@ export function setWtGroup(m: WtGroup) {
 }
 // Dev affordance until the settings window ships: episkoWtGroup("chip") in the console.
 (window as unknown as { episkoWtGroup: typeof setWtGroup }).episkoWtGroup = setWtGroup;
+
+// The same shape again for the sidebar's peek timings. `renderSidebar` rather than
+// `renderAll`: switching peek off has to drop the collapsed rows *and* clear whatever
+// is currently expanded, and neither the tray nor the inspector shows any of this.
+export function setPeekPrefs(p: PeekPrefs) {
+  setPeekPrefsState(p);
+  localStorage.setItem("cc-peek", JSON.stringify(peekPrefs));
+  // Drop whatever is expanded before repainting. Without this, switching peek off
+  // leaves a stale open path behind that would re-apply itself the moment it is
+  // switched back on, expanding a group the pointer is nowhere near.
+  closePeek();
+  renderSidebar();
+  renderSettings(); // the live preview in the Worktrees tab reads these values
+}
 
 // Which permission mode the NEXT session launches in — the same shape as the sort and
 // the grouping above (state assigns, this persists and announces). Announced rather

--- a/src/grouping.ts
+++ b/src/grouping.ts
@@ -69,6 +69,11 @@ export function clusterByWorktree(p: ProjGroup, withEmpty = false): WtCluster[] 
   for (const c of order) if (!c.branch) c.branch = c.isMain ? "main" : basename(c.key);
   return order;
 }
+// Does anything actually run in this checkout? The line the sidebar now draws: live
+// clusters are rows, everything else is a peek row that only appears when you rest on
+// the project (./peek, ./sidebarview). Externals count — a colleague's session in a
+// checkout is still a reason for it to hold its place in the list.
+export const clusterIsLive = (c: WtCluster): boolean => c.sessions.length + c.externals.length > 0;
 // toplevel mode: explode any project whose sessions span >1 worktree into one group
 // per worktree. The root checkout keeps the project's identity (path/favourite/
 // externals); each worktree gets its own group keyed by its checkout dir, carrying

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ import { applyFontSize, bumpFont, refit } from "./terminal";
 import {
   addProject, addProjectPath, cycleSort, effectiveTheme, openProjectFolder,
   followSessionDrift, removeFavorite, resolvePermission, revealActiveFolder,
-  setActionsRenderAll, setPermMode, setSort, setTheme, setWtGroup, toggleInsp,
+  setActionsRenderAll, setPeekPrefs, setPermMode, setSort, setTheme, setWtGroup, toggleInsp,
   toggleRail, toggleTheme,
 } from "./actions";
 import {
@@ -45,8 +45,8 @@ import {
 import "./update";
 import { probeIcon, setIconRenderMini, setIconRenderSidebar } from "./icons";
 import {
-  initFileDrop, initProjectDnD, renderMini, renderSidebar, reorderGuardUntil,
-  setReorderGuard, setSidebarRenderAll, setSidebarSetSort,
+  closePeek, initFileDrop, initProjectDnD, initSidebarPeek, renderMini, renderSidebar,
+  reorderGuardUntil, setReorderGuard, setSidebarRenderAll, setSidebarSetSort,
 } from "./sidebar";
 import {
   closeBranchPop, closeWt, setWtCloseSession, setWtHandToTerminal, setWtLaunch,
@@ -211,11 +211,11 @@ setActionsRenderAll(renderAll);
 setMirrorSetActive(setActive);
 setMirrorLaunch(launch);
 setMirrorRenderAll(renderAll);
-// The settings window changes nine things it does not own; this is the whole of
+// The settings window changes ten things it does not own; this is the whole of
 // what it can reach back for.
 setSettingsHost({
   setTheme, effectiveTheme, setSort, setEngine, bumpFont, applyFontSize, refreshTokens,
-  setWtGroup, setPermMode,
+  setWtGroup, setPermMode, setPeekPrefs,
 });
 // The task panels run tasks, hand commands to terminals and put panes on stage —
 // none of which they own.
@@ -491,7 +491,10 @@ document.addEventListener("click", (e) => {
   // A launch into one specific checkout. Unlike data-launch this keeps colorKey pinned
   // to the repo root (data-root), so the new session joins the project it belongs to
   // rather than becoming a project of its own — the same contract the ⑃ dialog uses.
-  else if (el.dataset.wtadd) launchWorktree(el.dataset.proj || basename(el.dataset.wtadd), el.dataset.root || el.dataset.wtadd, el.dataset.wtadd, el.dataset.branch || "");
+  // closePeek first: the row just clicked is about to reappear as a session row in the
+  // list above it, and leaving the rail expanded over a pane you started reads as the
+  // click not having landed.
+  else if (el.dataset.wtadd) { closePeek(); launchWorktree(el.dataset.proj || basename(el.dataset.wtadd), el.dataset.root || el.dataset.wtadd, el.dataset.wtadd, el.dataset.branch || ""); }
   else if (el.dataset.launch) requestLaunch(el.dataset.proj || basename(el.dataset.launch), el.dataset.launch);
   else if (el.dataset.pal) openPalette();
   else if (el.dataset.rail) toggleRail();
@@ -723,6 +726,7 @@ void refreshGitViews(); // seed the roster so the first paint isn't a checkout s
 
 setSort(sortMode, false); // paint the sort button's glyph/title for the persisted mode
 initProjectDnD();
+initSidebarPeek();
 initFileDrop();
 // caffeinate always starts off — the assertion is bound to the last run's process
 // (`-w <pid>` on macOS, the parked thread on Windows) and died with it; renderAll's

--- a/src/peek.ts
+++ b/src/peek.ts
@@ -1,0 +1,113 @@
+// Peek — resting on a project reveals the checkouts nothing is running in.
+//
+// WHY THIS EXISTS. The sidebar listed every checkout of every repo all the time, and
+// most of them had no session in them, so a project with four worktrees spent four
+// rows saying "no session" four times. Those rows are worth *reaching*, not worth
+// *showing*: you want them when you are about to start something, which is exactly
+// when the pointer is already on the project. So they collapse, and resting on the
+// group brings them back.
+//
+// THE RULES ARE HERE AND THE TIMERS ARE NOT. Everything below is a pure transition
+// over an explicit `now` — no `setTimeout`, no DOM, no ./state — so the awkward part
+// (what cancels what) is unit-testable and ./sidebar is left as a thin driver that
+// only has to schedule a timeout to `peekNextDeadline`. See test/peek.test.ts.
+//
+// The one rule worth reading twice is in `peekEnter`: **moving from one expanded
+// group to another skips the delay entirely.** The delay exists to ignore a pointer
+// passing *over* the rail; a pointer that is already inside an expanded rail is not
+// passing over anything, and making it wait a second again reads as the app being
+// slow rather than as it being careful.
+
+/// What the user set. Milliseconds, already clamped — see `clampPeekPrefs`.
+export interface PeekPrefs {
+  /// Off means the checkouts simply stay hidden; the ⑃ dialog is still the way in.
+  enabled: boolean;
+  /// How long the pointer must rest on a project before it expands.
+  openMs: number;
+  /// How long an expanded group survives after the pointer leaves it. Generous on
+  /// purpose: the whole point of expanding is that you are about to click something
+  /// in there, and a panel that vanishes as you travel towards it is worse than one
+  /// that never opened.
+  closeMs: number;
+}
+
+export const PEEK_DEFAULTS: PeekPrefs = { enabled: true, openMs: 1000, closeMs: 3000 };
+
+/// Bounds for the two timings. Not taste — these are the values either side of which
+/// the feature stops working: below ~150ms it fires while you are travelling past,
+/// and a close grace under ~400ms collapses before the pointer can arrive. The upper
+/// bounds only exist so a typo can't wedge a group open for an hour.
+export const PEEK_OPEN_RANGE = { min: 150, max: 4000 } as const;
+export const PEEK_CLOSE_RANGE = { min: 400, max: 10000 } as const;
+
+const clamp = (n: number, lo: number, hi: number, dflt: number) =>
+  Number.isFinite(n) ? Math.min(hi, Math.max(lo, Math.round(n))) : dflt;
+
+/** Whatever came out of `localStorage` (or a settings stepper), made safe. */
+export function clampPeekPrefs(p: Partial<PeekPrefs> | null | undefined): PeekPrefs {
+  return {
+    enabled: p?.enabled !== false,
+    openMs: clamp(Number(p?.openMs), PEEK_OPEN_RANGE.min, PEEK_OPEN_RANGE.max, PEEK_DEFAULTS.openMs),
+    closeMs: clamp(Number(p?.closeMs), PEEK_CLOSE_RANGE.min, PEEK_CLOSE_RANGE.max, PEEK_DEFAULTS.closeMs),
+  };
+}
+
+/// Exactly one group is ever expanded. `open` is a project path (`.pgroup`'s
+/// `data-path`), which is also what survives a re-render — the sidebar rebuilds its
+/// DOM constantly, so the expanded group has to be identified by something in the
+/// data rather than by an element reference.
+export interface PeekState {
+  open: string | null;
+  /// The group whose open timer is running, and when it fires.
+  arming: { path: string; at: number } | null;
+  /// When `open` collapses, once the pointer has left it. Null while the pointer is
+  /// still inside.
+  closingAt: number | null;
+}
+
+export const PEEK_IDLE: PeekState = { open: null, arming: null, closingAt: null };
+
+/** The pointer entered a project group. */
+export function peekEnter(s: PeekState, path: string, now: number, p: PeekPrefs): PeekState {
+  if (!p.enabled) return s.open || s.arming ? PEEK_IDLE : s;
+  // Already showing this one: the pointer came back, so cancel the collapse.
+  if (s.open === path) return s.closingAt === null ? s : { ...s, closingAt: null };
+  // Already inside an expanded rail — see the header comment. No delay, and the
+  // previous group closes in the same beat rather than overlapping with this one.
+  if (s.open) return { open: path, arming: null, closingAt: null };
+  if (s.arming?.path === path) return s;                   // its timer is already running
+  return { ...s, arming: { path, at: now + p.openMs } };
+}
+
+/** The pointer left a project group — for a sibling, for the gap, or for the page. */
+export function peekLeave(s: PeekState, path: string, now: number, p: PeekPrefs): PeekState {
+  const arming = s.arming?.path === path ? null : s.arming;
+  // Only the group actually on screen gets a grace period; leaving a group that was
+  // merely arming just cancels it.
+  const closingAt = s.open === path && s.closingAt === null ? now + p.closeMs : s.closingAt;
+  return arming === s.arming && closingAt === s.closingAt ? s : { ...s, arming, closingAt };
+}
+
+/** The pointer left the sidebar entirely. */
+export function peekLeaveAll(s: PeekState, now: number, p: PeekPrefs): PeekState {
+  if (!s.open) return s.arming ? { ...s, arming: null } : s;
+  return { ...s, arming: null, closingAt: s.closingAt ?? now + p.closeMs };
+}
+
+/** Apply whatever deadlines have come due. */
+export function peekTick(s: PeekState, now: number): PeekState {
+  if (s.arming && now >= s.arming.at) return { open: s.arming.path, arming: null, closingAt: null };
+  if (s.closingAt !== null && now >= s.closingAt) return PEEK_IDLE;
+  return s;
+}
+
+/**
+ * The next moment `peekTick` would change something, or null when nothing is pending.
+ *
+ * The driver schedules one timeout to this rather than keeping an interval running —
+ * an idle sidebar should cost nothing at all, and this is what makes that true.
+ */
+export function peekNextDeadline(s: PeekState): number | null {
+  if (s.arming) return s.arming.at;
+  return s.closingAt;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,10 +16,14 @@ import { $, dropScrim, toast } from "./dom";
 import { basename, esc, tilde } from "./format";
 import type { Engine, PermMode } from "./types";
 import {
-  ALL_PERM_MODES, availEngines, engineDef, permMode, setTermFontSize, SORT_META,
-  SORT_MODES, sortMode, termEngine, termFontSize, wtGroup,
+  ALL_PERM_MODES, availEngines, engineDef, peekPrefs, permMode, setTermFontSize,
+  SORT_META, SORT_MODES, sortMode, termEngine, termFontSize, wtGroup,
   type SortMode, type WtGroup,
 } from "./state";
+import {
+  PEEK_CLOSE_RANGE, PEEK_DEFAULTS, PEEK_IDLE, PEEK_OPEN_RANGE, peekEnter, peekLeave,
+  peekLeaveAll, peekNextDeadline, peekTick, type PeekPrefs, type PeekState,
+} from "./peek";
 import {
   ALL_PROVIDERS, clearStopRule, explicitlyTrusted, PROVIDER_LABEL, saveTaskPrefs,
   stopRules, taskPrefs, untrustProject, type Provider, type TaskPrefs,
@@ -45,11 +49,13 @@ export interface SettingsHost {
   // Same reason as setWtGroup: the app-level one (./actions), which persists and
   // announces — state.ts's same-named setter only assigns.
   setPermMode: (m: PermMode) => void;
+  // Ditto. ./actions clamps through ./peek, persists and repaints the sidebar.
+  setPeekPrefs: (p: PeekPrefs) => void;
 }
 let host: SettingsHost = {
   setTheme: () => {}, effectiveTheme: () => "dark", setSort: () => {}, setEngine: () => {},
   bumpFont: () => {}, applyFontSize: () => {}, refreshTokens: () => {},
-  setWtGroup: () => {}, setPermMode: () => {},
+  setWtGroup: () => {}, setPermMode: () => {}, setPeekPrefs: () => {},
 };
 export function setSettingsHost(h: SettingsHost) { host = h; }
 
@@ -64,6 +70,10 @@ type SetControl =
   | { kind: "seg"; set: string; label: string; hint?: string; active: () => string; segs: () => SetSeg[] }
   | { kind: "font"; label: string; hint?: string }
   | { kind: "wtpreview"; label: string; hint?: string; active: () => string }
+  // The sidebar's peek: one switch, two millisecond steppers, and a mini-sidebar you
+  // can actually hover to feel the numbers. A stepper alone is a guess — "is 1000ms
+  // right?" has no answer until you have rested a pointer on something for 1000ms.
+  | { kind: "peek"; label: string; hint?: string }
   // A single on/off switch.
   | { kind: "toggle"; set: string; label: string; hint?: string; on: () => boolean }
   // Independently-toggled values — "which providers to scan" isn't a pick-one.
@@ -157,6 +167,8 @@ const SET_TABS: SetTab[] = [
       { kind: "wtpreview", label: "Worktree grouping",
         hint: "How several checkouts of one repo are shown within its project group. Pick the look that reads best for you.",
         active: () => wtGroup },
+      { kind: "peek", label: "Reveal idle checkouts on hover",
+        hint: "Checkouts with nothing running in them stay out of the list until you rest on the project, then slide open. Off keeps them listed all the time. Hover the preview to feel the timings." },
     ],
   },
   {
@@ -247,10 +259,69 @@ function renderWtPreview(active: string): string {
   }).join("");
   return `<div class="wt-grid has-sel">${cards}</div>`;
 }
+// ---------- the peek control: two steppers and something to hover ----------
+// The preview is built from the REAL `.pgroup` / `.pgpeek` / `.pkrow` classes and
+// driven by the REAL ./peek reducer, so it cannot drift from the sidebar it is
+// previewing — a mock of a timing is worth nothing, because the timing is the thing
+// being judged. The only thing that is fake is the sessions.
+const PEEK_DEMO = [
+  { path: "demo:episko", name: "episko", hue: "#818cf8", rows: [
+      { title: "Fix telemetry routing", st: "work" as const, ctx: 12 },
+      { title: "Review PR #49", st: "done" as const, ctx: 61 },
+    ], idle: [{ g: "⌂", b: "dev" }, { g: "⑃", b: "exp/overview" }, { g: "⑃", b: "feat/board" }] },
+  { path: "demo:redactor", name: "pii-redactor", hue: "#2dd4bf", rows: [
+      { title: "Regex fallback pass", st: "done" as const, ctx: 18 },
+    ], idle: [{ g: "⌂", b: "main" }, { g: "⑃", b: "spike/onnx" }] },
+];
+function peekDemoHtml(): string {
+  const groups = PEEK_DEMO.map((p) =>
+    `<div class="pgroup" data-peekdemo="${esc(p.path)}">`
+    + `<div class="p-phead"><span class="p-pdot" style="background:${p.hue}"></span>`
+    + `<span class="p-pname">${esc(p.name)}</span><span class="p-pcount">${p.rows.length}</span></div>`
+    + `<div class="p-rows">${p.rows.map((r) =>
+        `<div class="p-row"><span class="p-dot p-${r.st}"></span><span class="p-lbl">${esc(r.title)}</span>`
+        + `<span class="p-ctx">${r.ctx}%</span></div>`).join("")}</div>`
+    + `<div class="pgpeek"><div class="pgpeek-in">${p.idle.map((w) =>
+        `<div class="pkrow"><span class="pkglyph" style="color:${p.hue}">${w.g}</span>`
+        + `<span class="pkname">${esc(w.b)}</span><span class="pkgo">＋</span></div>`).join("")}</div></div>`
+    + `</div>`).join("");
+  return `<div class="p-mini peekdemo" id="peekDemo">${groups}</div>`;
+}
+function stepper(which: "open" | "close", value: number, step: number, range: { min: number; max: number }): string {
+  return `<div class="set-font peekstep">
+    <span class="peekstep-l">${which === "open" ? "Opens after" : "Closes after"}</span>
+    <button class="set-fbtn" data-setpeek="${which}:${-step}" ${value <= range.min ? "disabled" : ""} aria-label="Shorter">−</button>
+    <span class="set-fval mono">${value}ms</span>
+    <button class="set-fbtn" data-setpeek="${which}:${step}" ${value >= range.max ? "disabled" : ""} aria-label="Longer">+</button>
+  </div>`;
+}
+function renderPeekControl(): string {
+  const on = peekPrefs.enabled;
+  const dflt = peekPrefs.openMs === PEEK_DEFAULTS.openMs && peekPrefs.closeMs === PEEK_DEFAULTS.closeMs;
+  return `<div class="peekbox${on ? "" : " off"}">
+    <div class="peekrow">
+      ${stepper("open", peekPrefs.openMs, 100, PEEK_OPEN_RANGE)}
+      ${stepper("close", peekPrefs.closeMs, 250, PEEK_CLOSE_RANGE)}
+      <button class="set-freset" data-setpeek="reset" ${dflt ? "disabled" : ""}>Reset</button>
+    </div>
+    ${peekDemoHtml()}
+    <div class="peekhint">${on
+      ? "Rest on a project above. Moving straight to the other one opens it at once — the delay is there to ignore a pointer passing over, and you are already inside."
+      : "Peek is off, so idle checkouts stay listed all the time. The preview shows them open."}</div>
+  </div>`;
+}
+
 function renderSetControl(c: SetControl): string {
   const head = `<div class="set-glabel">${esc(c.label)}</div>${c.hint ? `<div class="set-hint">${esc(c.hint)}</div>` : ""}`;
   if (c.kind === "wtpreview") {
     return `<div class="set-group">${head}${renderWtPreview(c.active())}</div>`;
+  }
+  if (c.kind === "peek") {
+    // The switch sits on the label row (set-inline), the steppers and the preview
+    // below it — one group, because they are one decision.
+    return `<div class="set-group"><div class="set-inline"><div class="set-itxt">${head}</div>`
+      + `<button class="sw${peekPrefs.enabled ? " on" : ""}" data-setpeek="toggle" role="switch"`
+      + ` aria-checked="${peekPrefs.enabled}"></button></div>${renderPeekControl()}</div>`;
   }
   if (c.kind === "font") {
     return `<div class="set-group">${head}<div class="set-font">
@@ -307,6 +378,50 @@ function applySetting(set: string, val: string) {
   else if (set === "unstop") clearStopRule(val);
   renderSettings();
 }
+// A stepper press, the switch, or Reset. Everything routes through the host's
+// clamping setter, so a value that would break the feature can't be reached by
+// holding − : the button disables at the bound and the clamp catches the rest.
+function applyPeekSetting(cmd: string) {
+  if (cmd === "reset") { host.setPeekPrefs({ ...peekPrefs, ...PEEK_DEFAULTS, enabled: peekPrefs.enabled }); return; }
+  if (cmd === "toggle") {
+    const enabled = !peekPrefs.enabled;
+    host.setPeekPrefs({ ...peekPrefs, enabled });
+    // Off means the preview shows the rows open, so a demo mid-hover would fight it.
+    peekDemoReset();
+    return;
+  }
+  const [which, delta] = cmd.split(":");
+  if (which === "open") host.setPeekPrefs({ ...peekPrefs, openMs: peekPrefs.openMs + +delta });
+  else if (which === "close") host.setPeekPrefs({ ...peekPrefs, closeMs: peekPrefs.closeMs + +delta });
+}
+
+// ---------- the preview's own peek driver ----------
+// Same reducer as the sidebar's, its own state. It reads `peekPrefs` at event time
+// rather than capturing it, so a stepper press is felt on the very next hover with
+// no re-wiring. renderSettings() rebuilds #setBody under it, hence the reset.
+let demoPeek: PeekState = PEEK_IDLE;
+let demoTimer: number | null = null;
+let demoHover: string | null = null;
+
+function demoApply() {
+  for (const el of document.querySelectorAll<HTMLElement>("#peekDemo .pgroup")) {
+    el.classList.toggle("peek", el.dataset.peekdemo === demoPeek.open);
+  }
+}
+function demoAdvance(next: PeekState) {
+  const was = demoPeek.open;
+  demoPeek = next;
+  if (demoPeek.open !== was) demoApply();
+  if (demoTimer !== null) { clearTimeout(demoTimer); demoTimer = null; }
+  const at = peekNextDeadline(demoPeek);
+  if (at === null) return;
+  demoTimer = window.setTimeout(() => {
+    demoTimer = null;
+    demoAdvance(peekTick(demoPeek, Date.now()));
+  }, Math.max(0, at - Date.now()));
+}
+function peekDemoReset() { demoHover = null; demoAdvance(PEEK_IDLE); }
+
 function setFontFromSettings(cmd: string) {
   if (cmd === "reset") { setTermFontSize(12.5); host.applyFontSize(); toast("Terminal font 12.5px"); }
   else host.bumpFont(parseFloat(cmd));
@@ -323,11 +438,43 @@ $("setTabs").addEventListener("click", (e) => {
 $("setBody").addEventListener("click", (e) => {
   const f = (e.target as HTMLElement).closest<HTMLElement>("[data-setfont]");
   if (f) { setFontFromSettings(f.dataset.setfont!); return; }
+  const pk = (e.target as HTMLElement).closest<HTMLElement>("[data-setpeek]");
+  if (pk) { applyPeekSetting(pk.dataset.setpeek!); return; }
   const r = (e.target as HTMLElement).closest<HTMLElement>("[data-urange]");
   if (r) { setUsageRange(+r.dataset.urange!); renderSettings(); return; }
   const o = (e.target as HTMLElement).closest<HTMLElement>("[data-set]");
   if (o) applySetting(o.dataset.set!, o.dataset.val!);
 });
+// The preview's hover, delegated on the persistent #setBody for the same reason the
+// sidebar's is delegated on #projects: renderSettings() replaces the demo's DOM on
+// every stepper press, and per-element listeners would go with it.
+$("setBody").addEventListener("mouseover", (e) => {
+  const g = (e.target as HTMLElement).closest<HTMLElement>("#peekDemo .pgroup");
+  const path = g?.dataset.peekdemo;
+  if (!path || path === demoHover) return;
+  demoHover = path;
+  demoAdvance(peekEnter(demoPeek, path, Date.now(), peekPrefs));
+});
+$("setBody").addEventListener("mouseout", (e) => {
+  const g = (e.target as HTMLElement).closest<HTMLElement>("#peekDemo .pgroup");
+  const path = g?.dataset.peekdemo;
+  if (!path) return;
+  const to = e.relatedTarget as Node | null;
+  if (to && g!.contains(to)) return;
+  if (demoHover === path) demoHover = null;
+  demoAdvance(peekLeave(demoPeek, path, Date.now(), peekPrefs));
+});
+// Leaving the preview entirely — the pointer can exit through the gap between the
+// two demo groups, where no group mouseout fires.
+$("setBody").addEventListener("mouseout", (e) => {
+  const demo = (e.target as HTMLElement).closest<HTMLElement>("#peekDemo");
+  if (!demo) return;
+  const to = e.relatedTarget as Node | null;
+  if (to && demo.contains(to)) return;
+  demoHover = null;
+  demoAdvance(peekLeaveAll(demoPeek, Date.now(), peekPrefs));
+});
+
 // Shared hover tooltip for the Usage panel's heatmap cells and cost bars. One
 // element on <body> (not #setBody), so a renderSettings() rebuild never drops it.
 const uTip = Object.assign(document.createElement("div"), { className: "u-tip", hidden: true });

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -15,9 +15,13 @@ import { dlog } from "./debug";
 import { esc, tilde } from "./format";
 import { iconFor, projGlyph } from "./icons";
 import { projectList } from "./grouping";
-import { dormantRows, groupBody } from "./sidebarview";
 import {
-  activeId, extMirrorId, FAVORITES, folderDirty, saveProjOrder, sessions,
+  PEEK_IDLE, peekEnter, peekLeave, peekLeaveAll, peekNextDeadline, peekTick,
+  type PeekState,
+} from "./peek";
+import { dormantRows, groupBody, peekBody } from "./sidebarview";
+import {
+  activeId, extMirrorId, FAVORITES, folderDirty, peekPrefs, saveProjOrder, sessions,
   setProjOrder, sortMode, type SortMode,
 } from "./state";
 
@@ -95,11 +99,94 @@ export function renderSidebar() {
         : `<span class="pcount ext">${p.dormants.length} past</span>`;
       head = `<div class="phead ext-only" data-key="${esc(p.path)}" title="${esc(tilde(p.path))}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" title="Launch an Episko session here">＋</span></div>`;
     }
-    return `<div class="pgroup" data-path="${esc(p.path)}">${head}${rows ? `<div class="psessions">${rows}</div>` : ""}</div>`;
+    return `<div class="pgroup" data-path="${esc(p.path)}">${head}${rows ? `<div class="psessions">${rows}</div>` : ""}${peekBody(p)}</div>`;
   }).join("");
   if (html === lastHtml) return; // nothing the sidebar shows has changed
   lastHtml = html;
   $("projects").innerHTML = html;
+  // The DOM the expansion lives on was just replaced, so re-apply it. This is the
+  // whole reason ./peek tracks a project *path* rather than an element.
+  applyPeek();
+}
+
+// ---------- peek: resting on a project reveals its idle checkouts ----------
+// ./peek owns the rules and is pure; this is the driver. Three things it has to get
+// right, and each of them is why the state does not live in the DOM:
+//
+//   1. **Hover must not be a render input.** renderSidebar skips its (7ms) DOM write
+//      when the markup is unchanged; making the expansion part of the string would
+//      bust that on every mouse move. So peekBody always renders the rows and this
+//      only toggles a class.
+//   2. **A repaint must not collapse an open group.** renderAll() fires on every
+//      telemetry event, so #projects is rebuilt under the pointer constantly —
+//      applyPeek() above re-applies the class to the new nodes.
+//   3. **An idle sidebar must cost nothing.** One timeout scheduled to the next
+//      deadline, not an interval.
+let peek: PeekState = PEEK_IDLE;
+let peekTimer: number | null = null;
+/// Which group the pointer is in. mouseover fires for every descendant, so this is
+/// what turns that stream into "entered a different group".
+let peekHover: string | null = null;
+
+function applyPeek() {
+  for (const el of $("projects").querySelectorAll<HTMLElement>(".pgroup")) {
+    el.classList.toggle("peek", el.dataset.path === peek.open);
+  }
+}
+function peekSchedule() {
+  if (peekTimer !== null) { clearTimeout(peekTimer); peekTimer = null; }
+  const at = peekNextDeadline(peek);
+  if (at === null) return;
+  peekTimer = window.setTimeout(() => {
+    peekTimer = null;
+    peekAdvance(peekTick(peek, Date.now()));
+  }, Math.max(0, at - Date.now()));
+}
+/// Commit a new state: repaint only when what's on screen actually changed, then
+/// re-arm the timer.
+function peekAdvance(next: PeekState) {
+  const wasOpen = peek.open;
+  peek = next;
+  if (peek.open !== wasOpen) applyPeek();
+  peekSchedule();
+}
+
+export function initSidebarPeek() {
+  const container = $("projects");
+  // mouseover/mouseout rather than mouseenter/mouseleave: these bubble, so one pair
+  // of delegated listeners survives every re-render. Per-group listeners would have
+  // to be re-attached on each repaint, which is the bug this shape avoids.
+  container.addEventListener("mouseover", (e) => {
+    const g = (e.target as HTMLElement).closest<HTMLElement>(".pgroup");
+    const path = g?.dataset.path;
+    if (!path || path === peekHover) return;
+    peekHover = path;
+    peekAdvance(peekEnter(peek, path, Date.now(), peekPrefs));
+  });
+  container.addEventListener("mouseout", (e) => {
+    const g = (e.target as HTMLElement).closest<HTMLElement>(".pgroup");
+    const path = g?.dataset.path;
+    if (!path) return;
+    // mouseout also fires when crossing between children of the same group; only a
+    // pointer that has genuinely left the group's subtree counts as leaving it.
+    const to = e.relatedTarget as Node | null;
+    if (to && g!.contains(to)) return;
+    if (peekHover === path) peekHover = null;
+    peekAdvance(peekLeave(peek, path, Date.now(), peekPrefs));
+  });
+  // Leaving the rail through a gap between groups fires no group mouseout, so the
+  // container gets its own (non-bubbling, but bound directly) leave.
+  container.addEventListener("mouseleave", () => {
+    peekHover = null;
+    peekAdvance(peekLeaveAll(peek, Date.now(), peekPrefs));
+  });
+}
+
+/// Collapse whatever is expanded — called when peek is switched off in Settings, and
+/// after a launch, so the rail doesn't stay open over a pane you just started.
+export function closePeek() {
+  peekHover = null;
+  peekAdvance(PEEK_IDLE);
 }
 // Reordering of project groups, on pointer events (not HTML5 drag). The window now
 // sets dragDropEnabled:true so external file drops paste a path instead of navigating

--- a/src/sidebarview.ts
+++ b/src/sidebarview.ts
@@ -14,9 +14,10 @@
 import { basename, esc, fmtShort, relTime, tilde } from "./format";
 import { apiErrText, statusKey, type ExtSession, type Restorable, type Sess } from "./types";
 import {
-  accentFor, activeId, externals, extMirrorId, pastMirrorId, sessions, wtGroup,
+  accentFor, activeId, externals, extMirrorId, folderDirty, pastMirrorId, peekPrefs,
+  sessions, wtGroup,
 } from "./state";
-import { clusterByWorktree, type ProjGroup, type WtCluster } from "./grouping";
+import { clusterByWorktree, clusterIsLive, type ProjGroup, type WtCluster } from "./grouping";
 
 // The status glyph vocabulary. Shared with the mini-rail, the tray and the
 // inspector pill, which is why it sits beside the rows rather than inside them.
@@ -86,42 +87,89 @@ function sessionRow(s: Sess, chip?: WtCluster): string {
 // flat rows each tagged with a colour-coded branch chip; off/toplevel → plain flat
 // rows. A single-checkout project (one cluster) always renders flat — nothing to
 // disambiguate. Externals cluster right alongside owned sessions (same checkout dir).
+//
+// **Only checkouts with something running in them appear here.** The idle ones moved
+// to `peekBody` — see the block comment there for why.
 export function groupBody(p: ProjGroup): string {
   const flat = () => p.sessions.map((s) => sessionRow(s)).join("") + p.externals.map((e) => extRow(e)).join("");
   if (wtGroup === "subheader") {
+    // `cl` still folds the idle checkouts in (`withEmpty`), because their *count* is
+    // what decides whether this project is worth clustering at all: one live checkout
+    // beside three idle ones is exactly the case a ⑃ header disambiguates. They are
+    // filtered out of the rows, not out of the question.
     const cl = clusterByWorktree(p, true);
-    if (cl.length >= 2) return cl.map((c) => {
+    if (cl.length >= 2) return cl.filter(clusterIsLive).map((c) => {
       const col = branchHue(c), n = c.sessions.length + c.externals.length;
       const body = c.sessions.map((s) => sessionRow(s)).join("") + c.externals.map((e) => extRow(e)).join("");
       // The cluster header already answers the only question the worktree dialog
       // would ask — which checkout — so its ＋ launches straight into `c.key`.
       // `data-root` carries the repo root separately: it is the colorKey every
       // session in this project groups by, and a worktree's own path is not it.
-      //
-      // This is also what makes an *empty* cluster carry its own weight: the header
-      // renders whether or not anything runs in the checkout, so a worktree nobody has
-      // started a session in is still visible — and startable — without spending a
-      // whole row on saying so.
       const add = `<span class="wtadd" data-wtadd="${esc(c.key)}" data-proj="${esc(p.name)}" data-root="${esc(p.path)}"`
         + ` data-branch="${esc(c.branch)}" title="New session in ${esc(c.branch)}">＋</span>`;
-      return `<div class="wthead${n ? "" : " wtvacant"}" ${wtMenuAttrs(p, c)}>`
+      return `<div class="wthead" ${wtMenuAttrs(p, c)}>`
         + `<span class="wtglyph" style="color:${col}">${clusterGlyph(c)}</span>`
         + `<span class="wtname" style="color:${col}" title="${esc(clusterTip(c))}">${esc(c.branch)}</span>`
-        + `<span class="wtcount">${n || ""}</span>${add}</div>`
-        // No rows, no rail: an empty `.wtsessions` would draw a stub of left border
-        // under a header that has nothing beneath it.
-        + (n ? `<div class="wtsessions" style="--wtc:${col}">${body}</div>` : "");
+        + `<span class="wtcount">${n}</span>${add}</div>`
+        + `<div class="wtsessions" style="--wtc:${col}">${body}</div>`;
     }).join("");
   } else if (wtGroup === "chip") {
     const cl = clusterByWorktree(p, true);
     if (cl.length >= 2) {
       const byKey = new Map(cl.map((c) => [c.key, c]));
       return p.sessions.map((s) => sessionRow(s, byKey.get(s.workdir || p.path))).join("")
-        + p.externals.map((e) => extRow(e, byKey.get(e.cwd || p.path))).join("")
-        + cl.filter((c) => !c.sessions.length && !c.externals.length).map((c) => wtEmptyRow(p, c)).join("");
+        + p.externals.map((e) => extRow(e, byKey.get(e.cwd || p.path))).join("");
     }
   }
   return flat();
+}
+// The checkouts nothing is running in — collapsed until the pointer rests on the
+// project group, then revealed (./peek owns the timing, ./sidebar drives it).
+//
+// WHY THEY LEFT THE MAIN LIST. A row that permanently says "no session" costs the
+// same vertical space as one that is doing something, and a repo with four worktrees
+// spent four rows saying it. These rows are worth *reaching*, not *showing*: you want
+// them at the moment you are about to start something, which is exactly the moment
+// the pointer is already on the project.
+//
+// Rendered whether or not the group is expanded — hover must never change the markup.
+// `renderSidebar` skips its DOM write when the string is byte-identical (84.5% of
+// repaints), so making hover a render input would bust that cache on every mouse
+// move *and* let a telemetry tick rebuild the DOM out from under an open group.
+// The expansion is one class, applied outside the render path.
+//
+// Peek switched off keeps the old behaviour rather than hiding these for good: the
+// wrapper renders already-open, so nothing that used to be reachable stops being so.
+export function peekBody(p: ProjGroup): string {
+  // Only the two modes that showed idle checkouts before. `toplevel` gives each
+  // worktree its own group (there is nothing nested to reveal) and `off` is the
+  // deliberately flat legacy mode.
+  if (wtGroup !== "subheader" && wtGroup !== "chip") return "";
+  const cl = clusterByWorktree(p, true);
+  if (cl.length < 2) return "";
+  const vacant = cl.filter((c) => !clusterIsLive(c));
+  if (!vacant.length) return "";
+  return `<div class="pgpeek${peekPrefs.enabled ? "" : " open"}"><div class="pgpeek-in">`
+    + vacant.map((c) => peekRow(p, c)).join("")
+    + `</div></div>`;
+}
+// One idle checkout. The whole row launches — there is no ＋ to aim at, because the
+// row has exactly one thing it can do and a target the width of the sidebar is easier
+// to hit than a glyph. Same `data-wtadd` contract as the cluster header's ＋, so the
+// new session keeps the repo's identity (`data-root`) instead of splintering into a
+// project group of its own, and the same `wtMenuAttrs` so right-click still reaches
+// the checkout menu.
+function peekRow(p: ProjGroup, c: WtCluster): string {
+  const col = branchHue(c);
+  // The one piece of state worth carrying at this size. Anything more (ahead/behind,
+  // merged) costs a `git` process per checkout — that is what the ⑃ dialog is for.
+  const dirty = folderDirty(c.key)
+    ? `<span class="pkdirty" title="Uncommitted changes in this checkout"></span>` : "";
+  return `<div class="pkrow" data-wtadd="${esc(c.key)}" ${wtMenuAttrs(p, c)}`
+    + ` title="${esc(`Start a session in ${c.branch} — ${tilde(c.key)}`)}">`
+    + `<span class="pkglyph" style="color:${col}">${clusterGlyph(c)}</span>`
+    + `<span class="pkname">${esc(c.branch)}</span>${dirty}`
+    + `<span class="pkgo">＋</span></div>`;
 }
 // What identifies one checkout to the worktree context menu (./projmenu). `data-wt`
 // is the marker its contextmenu handler matches on, and it must be matched *ahead* of
@@ -130,26 +178,6 @@ export function groupBody(p: ProjGroup): string {
 export function wtMenuAttrs(p: ProjGroup, c: WtCluster): string {
   return `data-wt="${esc(c.key)}" data-root="${esc(p.path)}" data-proj="${esc(p.name)}"`
     + ` data-branch="${esc(c.branch)}"${c.isMain ? ` data-main="1"` : ""}`;
-}
-// A checkout that exists on disk with nothing running in it. Rendered rather than
-// dropped for the same reason a blocked task is: a missing row reads as "Episko didn't
-// notice my worktree", which is exactly the gap this path was built to close.
-//
-// **chip mode only.** In subheader mode the ⑃ cluster header renders whether or not
-// anything runs in the checkout and carries its own ＋, so a whole row saying "no
-// session" was a second, bulkier way of stating what the header already showed. Chip
-// mode has no headers at all — a flat list of rows each wearing a branch chip — so
-// without this row an empty checkout would have nowhere to appear.
-//
-// Clicking it launches into that checkout while keeping the repo's identity — colorKey
-// stays the repo root (`data-root`), so the new session joins this project group
-// instead of splintering into one of its own. That is the same `data-wtadd` contract
-// the cluster header's ＋ uses.
-function wtEmptyRow(p: ProjGroup, c: WtCluster): string {
-  // `o3` widens the grid for the chip and arms its hover-expand, exactly as sessionRow does.
-  return `<div class="srow wtempty o3" data-wtadd="${esc(c.key)}" ${wtMenuAttrs(p, c)} title="No session here yet — start one in ${esc(tilde(c.key))}">
-    <span class="sglyph g-idle">＋</span>
-    <span class="sbranch">no session</span>${clusterChip(c)}</div>`;
 }
 // Dormant rows always sit below the live ones, outside any worktree cluster.
 export function dormantRows(p: ProjGroup): string {

--- a/src/state.ts
+++ b/src/state.ts
@@ -21,6 +21,7 @@
 // scope*, so `import { store } from "./localstorage"` must sit on the line above
 // this module's import (see test/localstorage.ts).
 import { basename, hslToHex } from "./format";
+import { clampPeekPrefs, type PeekPrefs } from "./peek";
 import type { DiffStat, Engine, ExtSession, PermMode, Res, Restorable, Sess, WtHead } from "./types";
 
 export interface Favorite { name: string; path: string }
@@ -70,6 +71,19 @@ const WT_GROUPS: WtGroup[] = ["off", "subheader", "toplevel", "chip"];
 export let wtGroup: WtGroup = (localStorage.getItem("cc-worktree-group") as WtGroup) || "subheader";
 if (!WT_GROUPS.includes(wtGroup)) wtGroup = "subheader";
 export function setWtGroup(m: WtGroup) { wtGroup = WT_GROUPS.includes(m) ? m : "subheader"; }
+
+// --- sidebar peek ---------------------------------------------------------------
+// Whether resting on a project reveals the checkouts nothing is running in, and for
+// how long. The rules (and the clamping below) live in ./peek, which is pure and
+// tested; this only holds the value. Persisted under cc-peek as one JSON blob rather
+// than three keys, because the three are only ever read together.
+export let peekPrefs: PeekPrefs = clampPeekPrefs(safeParse(localStorage.getItem("cc-peek")));
+export function setPeekPrefs(p: PeekPrefs) { peekPrefs = clampPeekPrefs(p); }
+function safeParse(raw: string | null): Partial<PeekPrefs> | null {
+  // A corrupt or hand-edited value must not take the app down during module import,
+  // the same stance ./tasks and ./notes take with their own stores.
+  try { return raw ? JSON.parse(raw) : null; } catch { return null; }
+}
 
 // A hand-picked accent per project path, overriding the hash below. A `const` map
 // mutated in place (like `sessions`), so it needs no setter; the colour picker in

--- a/src/styles.css
+++ b/src/styles.css
@@ -285,16 +285,41 @@ html.win .wctl { display: flex; }
 .wthead:hover .wtadd { opacity: 1; }
 .wtadd:hover { color: var(--text); background: var(--surface-2); }
 .wtsessions { padding-left: 8px; margin-left: 6px; border-left: 1px solid color-mix(in srgb, var(--wtc, var(--hair)) 45%, transparent); display: flex; flex-direction: column; gap: 1px; }
-/* A cluster with nothing running in it. The header is the whole row — it renders with
-   or without sessions, so an idle checkout costs one line instead of two. Dimmed, but
-   still hover-to-＋ like every other header: it is one of a list, and the one thing it
-   must do unprompted is say the checkout is there. */
-.wthead.wtvacant .wtglyph, .wthead.wtvacant .wtname { opacity: .55; }
-/* chip mode has no cluster headers, so an idle checkout still needs a row of its own:
-   present, but clearly not a session */
-.srow.wtempty .sbranch { font-style: italic; color: var(--muted-2); }
-.srow.wtempty .sglyph { color: var(--muted-2); }
-.srow.wtempty:hover .sbranch, .srow.wtempty:hover .sglyph { color: var(--accent-ink); }
+/* ---------- peek: the checkouts nothing is running in ----------------------------
+   Collapsed until the pointer rests on the project group (./peek owns the timing,
+   ./sidebar drives it, ./sidebarview renders the rows). Always in the DOM — hover
+   must never change the markup, or renderSidebar's byte-identical cache is busted on
+   every mouse move.
+
+   `grid-template-rows: 0fr → 1fr` is what animates an unknown height without one
+   being measured; the inner element carries `overflow:hidden` and `min-height:0`,
+   which is what makes the 0fr row actually clip rather than overflow. */
+.pgpeek { display: grid; grid-template-rows: 0fr; transition: grid-template-rows .26s cubic-bezier(.32,.72,0,1); }
+.pgroup.peek .pgpeek, .pgpeek.open { grid-template-rows: 1fr; }
+.pgpeek-in { overflow: hidden; min-height: 0; padding-left: 8px; margin-left: 10px; border-left: 1px solid var(--hair); }
+/* The rows fade and settle a beat behind the box opening — the box is the movement,
+   this is what stops it reading as a jump-cut. Staggered so the list arrives in
+   order, and capped at three so a repo with a dozen worktrees still feels instant. */
+.pkrow { display: flex; align-items: center; gap: 7px; padding: 4px 8px; border-radius: 7px; cursor: pointer;
+  opacity: 0; transform: translateY(-3px); transition: opacity .2s ease, transform .26s cubic-bezier(.32,.72,0,1), background .12s; }
+.pgroup.peek .pkrow, .pgpeek.open .pkrow { opacity: 1; transform: none; }
+.pgroup.peek .pkrow:nth-child(2) { transition-delay: .035s; }
+.pgroup.peek .pkrow:nth-child(3) { transition-delay: .07s; }
+.pgroup.peek .pkrow:nth-child(n+4) { transition-delay: .105s; }
+.pkrow:hover { background: var(--surface); }
+.pkglyph { flex: none; font-size: 10px; line-height: 1; opacity: .8; }
+.pkname { flex: 1; min-width: 0; font-family: var(--font-mono); font-size: 10.5px; color: var(--muted-2);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pkrow:hover .pkname { color: var(--muted); }
+.pkdirty { flex: none; width: 5px; height: 5px; border-radius: 50%; background: var(--st-working); opacity: .75; }
+/* The ＋ is a hint, not a target — the whole row launches. Visible only on the row
+   you are actually on, so a revealed list of four checkouts isn't four ＋ glyphs. */
+.pkgo { flex: none; font-size: 11px; line-height: 1; color: var(--muted-2); opacity: 0; transition: opacity .12s; }
+.pkrow:hover .pkgo { opacity: 1; color: var(--accent-ink); }
+@media (prefers-reduced-motion: reduce) {
+  .pgpeek, .pkrow { transition: none; }
+  .pkrow { transition-delay: 0s !important; }
+}
 /* toplevel mode: the branch suffix on a per-worktree group header */
 .pwt { margin-left: 5px; color: var(--muted-2); font-weight: 550; }
 /* chip mode: a colour-coded ⑃ that expands to the branch name on row hover */
@@ -1259,6 +1284,37 @@ select.in-ctl { cursor: pointer; }
 .p-wtcount { margin-left: auto; font: 600 8px var(--font-mono); color: var(--muted-2); }
 .p-wts { display: flex; flex-direction: column; gap: 1px; padding-left: 6px; margin-left: 5px; border-left: 1px solid color-mix(in srgb, var(--h, var(--hair)) 48%, transparent); }
 @media (prefers-reduced-motion: no-preference) { .p-work { animation: pulse 1.5s ease-in-out infinite; } }
+
+/* ---------- the peek control (Settings › Worktrees) -----------------------------
+   Two steppers and a mini-sidebar you can actually hover. The preview reuses the
+   REAL .pgroup / .pgpeek / .pkrow rules above rather than restating them, which is
+   the whole reason it is trustworthy: a preview of a timing that is styled
+   separately from the thing it previews is just a picture. */
+.peekbox { display: flex; flex-direction: column; gap: 11px; margin-top: 11px; }
+.peekbox.off { opacity: .55; }
+.peekrow { display: flex; align-items: center; flex-wrap: wrap; gap: 10px; }
+.peekstep { gap: 6px; }
+.peekstep-l { font-size: 10px; letter-spacing: .08em; text-transform: uppercase; color: var(--muted-2); font-weight: 700; margin-right: 2px; }
+.peekstep .set-fbtn { width: 26px; height: 26px; font-size: 14px; }
+.peekstep .set-fval { min-width: 52px; text-align: center; font-size: 11px; }
+.peekbox .set-fbtn[disabled] { opacity: .35; cursor: default; }
+.peekbox .set-fbtn[disabled]:hover { border-color: var(--hair-strong); background: var(--surface); }
+.peekbox .set-freset[disabled] { opacity: .35; cursor: default; }
+.peekbox .set-freset[disabled]:hover { color: var(--muted); border-color: var(--hair); }
+/* Taller than the grouping cards' preview: this one has to hold two groups with
+   their idle rows revealed, and a box that resizes as you hover would itself be the
+   most distracting thing on the page. */
+.peekdemo { margin: 0; min-height: 210px; cursor: default; }
+.peekdemo .pgroup { padding-bottom: 2px; }
+.peekdemo .p-phead { border-radius: 7px; }
+.peekdemo .pgroup:hover .p-phead { background: var(--surface); }
+/* The demo's rows are preview-scale, so the sidebar's own sizes are stepped down. */
+.peekdemo .pgpeek-in { padding-left: 6px; margin-left: 5px; }
+.peekdemo .pkrow { padding: 3px 5px; }
+.peekdemo .pkname { font-size: 9.5px; }
+.peekdemo .pkglyph { font-size: 9px; }
+.peekdemo .pkgo { font-size: 10px; }
+.peekhint { font-size: 11px; line-height: 1.5; color: var(--muted-2); max-width: 58ch; }
 
 .toast { position: fixed; bottom: 40px; left: 50%; transform: translateX(-50%) translateY(14px); background: var(--text); color: var(--bg); padding: 8px 14px; border-radius: 9px; font-size: 11.5px; font-weight: 600; box-shadow: 0 18px 46px -20px rgba(0,0,0,.7); opacity: 0; pointer-events: none; transition: opacity .2s, transform .2s; z-index: 50; }
 .toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }

--- a/test/grouping.test.ts
+++ b/test/grouping.test.ts
@@ -6,9 +6,9 @@ import {
   setProjOrder, setSortMode, setWtGroup, worktreesByRepo,
 } from "../src/state";
 import {
-  allProjects, clusterByWorktree, needsYou, needsYouSessions, nextAfterClose,
-  orderedSessions, projectList, reactorLabel, reactorState, splitByWorktree,
-  urgencyRank, type ProjGroup,
+  allProjects, clusterByWorktree, clusterIsLive, needsYou, needsYouSessions,
+  nextAfterClose, orderedSessions, projectList, reactorLabel, reactorState,
+  splitByWorktree, urgencyRank, type ProjGroup,
 } from "../src/grouping";
 import { taskPrefs } from "../src/tasks";
 
@@ -114,6 +114,28 @@ describe("clusterByWorktree — one cluster per checkout dir", () => {
   it("takes a cluster's branch from an external when no session carries one", () => {
     const p = grp({ externals: [ext({ cwd: "/w/wt", branch: "feature" })] });
     expect(clusterByWorktree(p)[0].branch).toBe("feature");
+  });
+});
+
+// The line the sidebar draws: live clusters are rows, the rest are peek rows that
+// only appear while the pointer rests on the project (./peek, ./sidebarview).
+describe("clusterIsLive", () => {
+  it("counts a checkout with an Episko session as live", () => {
+    const p = grp({ sessions: [sess({ workdir: "/w/epi" })] });
+    expect(clusterByWorktree(p).map(clusterIsLive)).toEqual([true]);
+  });
+  it("counts an EXTERNAL session as live too — a colleague's pane still holds the row", () => {
+    const p = grp({ externals: [ext({ cwd: "/w/wt" })] });
+    expect(clusterByWorktree(p).map(clusterIsLive)).toEqual([true]);
+  });
+  it("is false for a roster checkout nobody has started anything in", () => {
+    worktreesByRepo.set("/w/epi", [
+      { path: "/w/epi", branch: "main", is_main: true, exists: true },
+      { path: "/w/wt-x", branch: "feat/x", is_main: false, exists: true },
+    ]);
+    const p = grp({ sessions: [sess({ workdir: "/w/epi" })] });
+    const cl = clusterByWorktree(p, true);
+    expect(cl.map((c) => [c.key, clusterIsLive(c)])).toEqual([["/w/epi", true], ["/w/wt-x", false]]);
   });
 });
 

--- a/test/peek.test.ts
+++ b/test/peek.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampPeekPrefs, PEEK_CLOSE_RANGE, PEEK_DEFAULTS, PEEK_IDLE, PEEK_OPEN_RANGE,
+  peekEnter, peekLeave, peekLeaveAll, peekNextDeadline, peekTick, type PeekPrefs,
+} from "../src/peek";
+
+const P: PeekPrefs = { enabled: true, openMs: 1000, closeMs: 3000 };
+const T = 1_000_000;
+
+/** Drive the machine the way ./sidebar does: apply every deadline up to `now`. */
+function run(s: Parameters<typeof peekTick>[0], now: number) {
+  let next = peekTick(s, now);
+  // One tick can arm→open; a second can then close. Loop until it settles.
+  while (next !== s) { s = next; next = peekTick(s, now); }
+  return s;
+}
+
+describe("clampPeekPrefs", () => {
+  it("defaults a missing or corrupt value rather than throwing", () => {
+    expect(clampPeekPrefs(null)).toEqual(PEEK_DEFAULTS);
+    expect(clampPeekPrefs({})).toEqual(PEEK_DEFAULTS);
+    expect(clampPeekPrefs({ openMs: NaN, closeMs: undefined })).toEqual(PEEK_DEFAULTS);
+    // A hand-edited string is the realistic corruption, not a random object.
+    expect(clampPeekPrefs({ openMs: "abc" } as never).openMs).toBe(PEEK_DEFAULTS.openMs);
+  });
+
+  it("holds both timings inside the range where the feature actually works", () => {
+    expect(clampPeekPrefs({ openMs: 0 }).openMs).toBe(PEEK_OPEN_RANGE.min);
+    expect(clampPeekPrefs({ openMs: 99_999 }).openMs).toBe(PEEK_OPEN_RANGE.max);
+    expect(clampPeekPrefs({ closeMs: 1 }).closeMs).toBe(PEEK_CLOSE_RANGE.min);
+    expect(clampPeekPrefs({ closeMs: 99_999 }).closeMs).toBe(PEEK_CLOSE_RANGE.max);
+  });
+
+  it("only treats an explicit false as off, so a missing key stays enabled", () => {
+    expect(clampPeekPrefs({}).enabled).toBe(true);
+    expect(clampPeekPrefs({ enabled: false }).enabled).toBe(false);
+  });
+
+  it("rounds, because a fractional millisecond in a stepper reads as a bug", () => {
+    expect(clampPeekPrefs({ openMs: 1000.6 }).openMs).toBe(1001);
+  });
+});
+
+describe("peek: opening", () => {
+  it("arms on enter and opens only once the delay has passed", () => {
+    const armed = peekEnter(PEEK_IDLE, "/a", T, P);
+    expect(armed.arming).toEqual({ path: "/a", at: T + 1000 });
+    expect(armed.open).toBeNull();
+
+    expect(run(armed, T + 999).open).toBeNull();
+    const open = run(armed, T + 1000);
+    expect(open.open).toBe("/a");
+    expect(open.arming).toBeNull();
+  });
+
+  it("leaving before the delay cancels it — a pointer passing over opens nothing", () => {
+    const armed = peekEnter(PEEK_IDLE, "/a", T, P);
+    const gone = peekLeave(armed, "/a", T + 300, P);
+    expect(gone.arming).toBeNull();
+    expect(run(gone, T + 5000)).toEqual(PEEK_IDLE);
+  });
+
+  it("re-entering the same group does not restart its timer", () => {
+    const armed = peekEnter(PEEK_IDLE, "/a", T, P);
+    expect(peekEnter(armed, "/a", T + 500, P).arming).toEqual({ path: "/a", at: T + 1000 });
+  });
+
+  it("does nothing at all when peek is switched off", () => {
+    const off = { ...P, enabled: false };
+    expect(peekEnter(PEEK_IDLE, "/a", T, off)).toEqual(PEEK_IDLE);
+    expect(peekNextDeadline(peekEnter(PEEK_IDLE, "/a", T, off))).toBeNull();
+  });
+
+  it("collapses an already-open group when peek is switched off mid-hover", () => {
+    const open = run(peekEnter(PEEK_IDLE, "/a", T, P), T + 1000);
+    expect(peekEnter(open, "/a", T + 1200, { ...P, enabled: false })).toEqual(PEEK_IDLE);
+  });
+});
+
+describe("peek: moving between groups", () => {
+  it("opens the next group with NO delay once one is already expanded", () => {
+    const a = run(peekEnter(PEEK_IDLE, "/a", T, P), T + 1000);
+    expect(a.open).toBe("/a");
+    // Real sequence: mouseout of /a, then mouseover of /b.
+    const leaving = peekLeave(a, "/a", T + 2000, P);
+    const b = peekEnter(leaving, "/b", T + 2001, P);
+    expect(b.open).toBe("/b");
+    expect(b.arming).toBeNull();
+    // …and /a's pending collapse is dropped rather than firing later onto /b.
+    expect(b.closingAt).toBeNull();
+    expect(run(b, T + 99_999).open).toBe("/b");
+  });
+
+  it("never shows two groups at once", () => {
+    const a = run(peekEnter(PEEK_IDLE, "/a", T, P), T + 1000);
+    const b = peekEnter(a, "/b", T + 1500, P);
+    expect(b.open).toBe("/b");   // a single field — /a cannot still be open
+  });
+});
+
+describe("peek: closing", () => {
+  it("holds the group for the grace period after the pointer leaves", () => {
+    const a = run(peekEnter(PEEK_IDLE, "/a", T, P), T + 1000);
+    const leaving = peekLeave(a, "/a", T + 2000, P);
+    expect(leaving.closingAt).toBe(T + 5000);
+    expect(run(leaving, T + 4999).open).toBe("/a");
+    expect(run(leaving, T + 5000)).toEqual(PEEK_IDLE);
+  });
+
+  it("coming back cancels the collapse", () => {
+    const a = run(peekEnter(PEEK_IDLE, "/a", T, P), T + 1000);
+    const leaving = peekLeave(a, "/a", T + 2000, P);
+    const back = peekEnter(leaving, "/a", T + 3000, P);
+    expect(back.closingAt).toBeNull();
+    expect(run(back, T + 99_999).open).toBe("/a");
+  });
+
+  it("does not extend an already-running grace period on a second leave", () => {
+    // mouseout can fire more than once on the way out (a child, then the group).
+    const a = run(peekEnter(PEEK_IDLE, "/a", T, P), T + 1000);
+    const once = peekLeave(a, "/a", T + 2000, P);
+    const twice = peekLeave(once, "/a", T + 2500, P);
+    expect(twice.closingAt).toBe(T + 5000);
+  });
+
+  it("leaving the sidebar closes whatever is open and cancels whatever is arming", () => {
+    const armed = peekEnter(PEEK_IDLE, "/a", T, P);
+    expect(peekLeaveAll(armed, T + 100, P)).toEqual(PEEK_IDLE);
+
+    const a = run(peekEnter(PEEK_IDLE, "/a", T, P), T + 1000);
+    const out = peekLeaveAll(a, T + 2000, P);
+    expect(out.closingAt).toBe(T + 5000);
+    expect(run(out, T + 5000)).toEqual(PEEK_IDLE);
+  });
+
+  it("leaving a group that was only arming closes nothing", () => {
+    const armed = peekEnter(PEEK_IDLE, "/a", T, P);
+    expect(peekLeave(armed, "/a", T + 100, P).closingAt).toBeNull();
+  });
+});
+
+describe("peekNextDeadline", () => {
+  it("is null when idle, so an untouched sidebar schedules no timer at all", () => {
+    expect(peekNextDeadline(PEEK_IDLE)).toBeNull();
+    const open = run(peekEnter(PEEK_IDLE, "/a", T, P), T + 1000);
+    expect(peekNextDeadline(open)).toBeNull();   // open and hovered — nothing pending
+  });
+
+  it("reports the arm deadline, then the close deadline", () => {
+    const armed = peekEnter(PEEK_IDLE, "/a", T, P);
+    expect(peekNextDeadline(armed)).toBe(T + 1000);
+    const open = run(armed, T + 1000);
+    expect(peekNextDeadline(peekLeave(open, "/a", T + 2000, P))).toBe(T + 5000);
+  });
+});
+
+describe("peek: identity survives a re-render", () => {
+  it("tracks a project path, not an element — the sidebar rebuilds its DOM constantly", () => {
+    const open = run(peekEnter(PEEK_IDLE, "/Users/t/repo", T, P), T + 1000);
+    // Whatever the driver does to the DOM, this is all it needs to re-apply.
+    expect(open.open).toBe("/Users/t/repo");
+    expect(typeof open.open).toBe("string");
+  });
+});


### PR DESCRIPTION
First of three PRs for the project dashboard. **Design mock:** https://claude.ai/code/artifact/dee80fdb-456e-4d55-9e50-c1bdf0da0e0b (§03)

A repo with four worktrees spent four rows saying "no session" four times. Those rows are worth *reaching*, not *showing* — and the moment you want one is the moment the pointer is already on the project. So the ⑃ cluster headers now render only for checkouts something runs in (`clusterIsLive`), and the idle ones collapse into a peek block that slides open after a delay.

## The shape

`peek.ts` is the rules and nothing else — `peekEnter` / `peekLeave` / `peekTick` over an explicit `now`, no timers and no DOM, so what-cancels-what is unit-testable. `sidebar.ts` is a thin driver that schedules **one** timeout to `peekNextDeadline`; an idle sidebar arms nothing.

Three things that shape is protecting:

- **Hover is not a render input.** `peekBody` emits the rows on every paint and the expansion is one class applied outside the render path. In the markup it would bust `renderSidebar`'s byte-identical cache (84.5% of repaints, per the note already in CLAUDE.md) on every mouse move — and worse, a telemetry tick would rebuild `#projects` and collapse a group under the pointer. Hence `PeekState.open` is a project **path**, not an element, and `applyPeek()` re-applies it after each DOM write. Listeners are delegated `mouseover`/`mouseout` (which bubble) on the persistent `#projects`, for the same reason.
- **Moving between two expanded groups skips the delay.** The delay exists to ignore a pointer passing *over* the rail; one already inside it is not passing over anything.
- **Off keeps the old behaviour** rather than hiding the rows for good — the wrapper renders already-open, so nothing that used to be reachable stops being so.

Idle rows launch on whole-row click; the `＋` is a hint shown only on the row you are on. Same `data-wtadd` contract as the cluster header's, so `colorKey` stays the repo root and the new session joins the project it belongs to.

## The timings are a setting, with something to feel them on

Settings › Worktrees gains the switch plus two steppers (open 100ms, close 250ms), bounded to the range where the feature actually works: below ~150ms it fires while you travel past, and a close grace under ~400ms collapses before the pointer arrives.

The preview is built from the **real** `.pgroup` / `.pgpeek` / `.pkrow` CSS and driven by the **real** reducer. "Is 1000ms right?" has no answer until you have rested a pointer on something for 1000ms, and a preview styled separately from the thing it previews will drift and then reassure you about behaviour the app no longer has. CLAUDE.md now records that as the precedent for any future setting whose right value can only be felt.

## Verification

- `tsc` clean · **490 vitest** (468 + 19 `peek` + 3 `clusterIsLive`) · `pnpm build` clean · no import cycles.
- Coverage re-measured: **88.4%** over loaded modules, **19.3%** over all of `src/`. CLAUDE.md's counts updated in the same commit — including one paragraph that had gone factually wrong (it described `.wtvacant`, which no longer exists).
- **No Rust changed**, so `cargo`/`clippy` were not run — the `src-tauri` diff is empty.
- **Not verified:** whether 1000/3000ms feels right against real projects, and how the collapse animates in the running app. That is the click-through, and it is what the settings preview exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
