### PR TITLE
The project dashboard: a project is a place you arrive at

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ pnpm coverage           # the same suites with v8 coverage
 ```
 
 Coverage is a **yardstick, not a target** — there is deliberately no gate, because the
-render and DOM-owning modules are untested by design. Current: **88.0%** statements
-over the modules the suites load, **19.4%** over all of `src/`, and **71.0%** Rust
+render and DOM-owning modules are untested by design. Current: **89.5%** statements
+over the modules the suites load, **20.55%** over all of `src/`, and **71.0%** Rust
 lines (`cargo llvm-cov --summary-only` from `src-tauri/`). Both gaps are the OS edge,
 which `RELEASE.md` covers by hand. Note vitest's `text` reporter **hides any file at
 100% in all four columns**, so a fully-covered module looks absent; use
@@ -52,9 +52,9 @@ Mac has the same symlink — but it is one both legs will find at once.
 
 **Package manager: `pnpm`** for this repo (there's a `pnpm-lock.yaml`; both CI workflows use `pnpm install --frozen-lockfile`, and `packageManager` in `package.json` pins the version for corepack/CI). Use pnpm here, not npm. Windows code-signing / release-signing setup lives in `src-tauri/SIGNING.md`.
 
-Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **468 vitest + cargo (100 on macOS, 97 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
+Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **519 vitest + cargo (118 on macOS, 115 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
 
-**vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which twelve those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
+**vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which fifteen those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
 
 What is **untested by design**: the render, view and DOM-owning modules on both sides of the app — snapshotting template literals mostly re-asserts itself. Anything touching the DOM, PTYs, or live telemetry is still verified by **running the app and exercising it** — the statusLine half of telemetry only fires in interactive mode, so it cannot be checked end to end with `claude -p`. Split that one carefully, because the split is not where it looks: whether the generated statusLine command *works* is checked headlessly and in CI (the shell runs it for real — see the constraint above). What needs a live REPL is only whether **Claude still picks the shell and payload we expect**. That costs a TTY, not tokens: a session you launch and never prompt makes no API call, and the statusLine fires on start and every `refreshInterval` seconds regardless. It's a `RELEASE.md` click-through, and a cheap one. `tsc` (strict) is the real linter. Requires `claude` on PATH, the Node in `.nvmrc` (`nvm use`; `engines` floors it at 24), and Rust stable + Tauri system deps.
 
@@ -240,6 +240,64 @@ Four smaller P4 affordances, all in the frontend:
   button and the picker's ⌘⇧R both route through it. The escape hatch for the one
   thing the stamp can't see: a file an introspector imports itself.
 
+## The project dashboard (`dash.ts`, `dashview.ts`, `dashboard.ts`)
+
+**Left-clicking a project opens it.** That click used to select whichever session
+sorted first, so one gesture meant two different things depending on state, and "what
+is going on in this repo" lived in a right-click menu nobody opens. The sessions are
+the rows directly beneath the header; this is the header's own answer.
+
+The split is `graph.ts`/`graphview.ts` again: **`dash.ts` is pure and tested**
+(`projectTier`, `dashDays`, `dashPulse`, `projectCost`, `densePerDay`), **`dashview.ts`
+takes data and returns a string**, **`dashboard.ts`** owns the pane, the IPC, the
+summary queue and the delegated events. It rides the same `mirror` pointer as the
+read-only session mirrors (`kind: "dash"`) rather than adding a second flag every
+`activeId` check would have to be paired with.
+
+**Nothing runs until a project is clicked.** No probe at startup, nothing on
+`renderAll`'s path — a dashboard that cost anything to *not* open would tax every
+session in the app for a view most ticks never show.
+
+**Three gates decide what it can show, and they are not the same gate** (`projectTier`,
+from one `project_facts` call):
+
+- **GitHub** — issues, pull requests, claims. All `gh`, all still to come.
+- **git** — the commit half of the timeline, the checkouts card, and *everything
+  shared*: `.episko/` only means anything if it can be committed, so **sharing needs
+  git, not GitHub**. A GitLab or self-hosted remote is this tier, which is why
+  `parse_remote` mints a slug for `github.com` and nothing else.
+- **neither** — sessions, spend and personal notes. None of those ever cared about git.
+
+A card with nothing to say is **absent, not empty** — an "Issues" panel in a folder
+that has no issues reads as breakage — and `missingCard` says once, plainly, what this
+folder cannot do instead.
+
+Three things that are easy to get wrong:
+
+- **Per-project cost comes from `cc-usage-detail`, never `cc-usage`.** The plain rollup
+  is every project's spend that day at once, so attributing it to whichever dashboard
+  is open would invent a number. The detail split only exists going forward, so older
+  days legitimately have none, and the strip shows a dash rather than `$0.00` — "we
+  didn't keep this" and "it was free" are different facts.
+- **The list drops empty days and the sparkline must not.** `trailDays` omits a day
+  nothing happened on (a column of blank rows reads as broken); `densePerDay` fills
+  them back in, because two busy days a week apart otherwise render as two adjacent
+  bars and read as "constantly busy".
+- **⌘I collapses to a 44px rail here, not to nothing.** The dashboard header carries
+  only `＋ Session`, `✕` and `◨` — History, Terminal and Run act on the *project* and
+  live in the inspector — so hiding the panel outright would hide real verbs. On a
+  session ⌘I still hides it completely.
+
+**The work log is the one thing Episko generates and then commits.** `summarize_day`
+spends money (one `claude -p` per day, Haiku), so it is cached, opt-in, and **read
+before it is generated**: `read_digest` parses `.episko/digest.md` first, which means
+the second person to open a week pays nothing for it. Writing it is gated on an
+explicit per-project yes (`cc-digest-ok`), because a new committable file in someone's
+repo is a real side effect — the same stance `tasks.rs` takes with `tasks.toml`. This
+is the **third** thing Episko writes outside its own config, after `.episko/tasks.toml`
+and the `~/.claude` transcript move. Only a *closed* day is written: today's line
+changes as the day goes on, and each change would dirty a tracked file.
+
 ## Project history — the commit graph panel (`git_graph`, `graph.ts`, `graphview.ts`)
 
 A project's lanes, refs and recent commits, opened from the **project right-click menu**
@@ -361,20 +419,21 @@ Lane colours are `--gl-0…7`, re-stepped for the light theme like every other p
 `styles.css`. Scope (`all refs` / `this branch`) resets on each open and is deliberately
 **not** persisted — all-refs is the answer the panel exists to give.
 
-## Backend (`src-tauri/src/`) — ten modules
+## Backend (`src-tauri/src/`) — eleven modules
 
-`main.rs` only calls `episko_lib::run()`. `lib.rs` is **bootstrap, not the backend**: 504 lines out of ~10,215 (the counts below are whole files, in-file `#[cfg(test)] mod tests` included — that is most of `telemetry.rs`). Dependencies point downward, `platform.rs` at the bottom.
+`main.rs` only calls `episko_lib::run()`. `lib.rs` is **bootstrap, not the backend**: 518 lines out of ~11,020 (the counts below are whole files, in-file `#[cfg(test)] mod tests` included — that is most of `telemetry.rs`). Dependencies point downward, `platform.rs` at the bottom.
 
 | Module | Lines | What |
 | --- | --- | --- |
-| `lib.rs` | 504 | `run()`, `AppState`/`Session`, the window (see One title bar), the tray mirror, the panic hook, `write_debug_file`/`log_frontend`, `confirm_quit`, and the `invoke_handler!` list |
-| `git.rs` | 2,363 | worktrees, branches (local **and** remote-only), the working-set diff, the paged commit graph, the toolbar's fetch/pull/push, commit info |
+| `lib.rs` | 518 | `run()`, `AppState`/`Session`, the window (see One title bar), the tray mirror, the panic hook, `write_debug_file`/`log_frontend`, `confirm_quit`, and the `invoke_handler!` list |
+| `git.rs` | 2,718 | worktrees, branches (local **and** remote-only), the working-set diff, the paged commit graph, the toolbar's fetch/pull/push, commit info |
 | `tasks.rs` | 2,399 | runnable discovery — see Runnables above |
 | `usage.rs` | 1,613 | transcripts (incl. History's whole-machine scan) + the token ledger — everything read out of `~/.claude` |
 | `pty.rs` | 1,071 | the four launch engines, the permission-mode whitelist, app-wide disk I/O, `stream_pty_session`, the PTY lifecycle |
 | `telemetry.rs` | 926 | `write_instrument_settings`, `run_telemetry_server`, `resolve_permission` |
 | `platform.rs` | 750 | OS leaves (top half, incl. `norm_path`/`physical_cwd`) + OS integrations (bottom half) |
 | `external.rs` | 339 | the `~/.claude/sessions` registry, `ProcTable`, terminal focus |
+| `summarize.rs` | 446 | `summarize_day` (Haiku via `claude -p`) + the committed `.episko/digest.md` |
 | `icons.rs` | 184 | project favicon/logo probing |
 | `testutil.rs` | 50 | `git`, `scratch_dir`, `cfg(test)` only |
 
@@ -391,13 +450,13 @@ Four conventions hold across them:
 - **Telemetry server** (`run_telemetry_server`) forwards `/hook` and `/statusline` POSTs as one `telemetry` event each; `/permission` is the blocking path described above.
 - Commands are registered in the `invoke_handler![...]` list at the bottom of `run()` — add new `#[tauri::command]` fns there.
 
-## Frontend (`src/`, `index.html`, `src/styles.css`) — 39 modules
+## Frontend (`src/`, `index.html`, `src/styles.css`) — 44 modules
 
-**No framework, and no longer one file.** ~9,885 lines across 39 modules; `main.ts` is 731 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
+**No framework, and no longer one file.** ~11,180 lines across 44 modules; `main.ts` is 766 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (~70 lines — it is the seam map, and belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, the window controls (see One title bar), and the seven `setInterval`s.
 
-**Tested logic modules** (twelve — no DOM, no Tauri, no render imports; these are what the 468 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
+**Tested logic modules** (fifteen — no DOM, no Tauri, no render imports; these are what the 519 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
 
 | Module | What |
 | --- | --- |
@@ -413,6 +472,9 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 | `history.ts` | History's rules: `histProject` (regrafting a row onto a project), `histBusy`, the scope/search predicates, day buckets |
 | `gitwatch.ts` | `gitMutates` — whether a shell command an agent ran is worth re-reading git for; `driftTarget`/`driftUpdate` — which checkout its work has moved to, from writes *and* `cwd` |
 | `graph.ts` | the commit graph: `layoutGraph`'s lanes, what names a lane (`lineRef`, `lineTip`), `parseRefs`, the geometry and `rowSvg` |
+| `trail.ts` | a day of work assembled from transcripts, git and the usage rollup; `dayFacts` |
+| `notes.ts` | the one thing on the dashboard you type — capture, filing, removal |
+| `dash.ts` | the project dashboard's rules: `projectTier`, `dashDays`, `dashPulse`, `projectCost` |
 
 **Shared**: `state.ts` (the session map, the stage pointer, every persisted preference) and `dom.ts` (`$`, `toast`, the shared scrim, `IS_MAC`/`MOD`/`chord`).
 
@@ -422,7 +484,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 
 **Behaviour** — IPC and DOM all the way down, so untested too, and therefore the thinnest ice in the app: `panes` (the three spawners + a pane's lifecycle), `terminal` (the xterm plumbing), `taskrun` (run on stop), `actions` (the app-level verbs), `icons` (the per-project glyph store).
 
-Four rules keep that graph honest. **There are no import cycles across the 39 modules; re-run a cycle check after any change that adds an import.**
+Four rules keep that graph honest. **There are no import cycles across the 44 modules; re-run a cycle check after any change that adds an import.**
 
 - **Dependency direction is state ← render ← wiring.** A logic module must not import render code or `main.ts`.
 - **When an extracted function needs something that lives further up**, resolve it in this order: (1) **move the callee down too** if it is itself leaf-shaped — that is why `icons.ts` sits below `sidebar.ts` and `usage.ts` below `phase.ts`; (2) **a settable hook defaulting to a no-op** (`setRlLogger`, `setPanesRenderAll`) when the callee genuinely belongs to the render layer; (3) **an extra parameter** only as a last resort, since it changes a signature the move was supposed to leave alone. A control panel touching many things it doesn't own may take **one host object** instead of N setters (`settings`, `palui`, `projmenu`); prefer per-callee setters below ~4.
@@ -478,7 +540,7 @@ And the things that hold however the files are arranged:
 - **Event wiring**: `listen("pty-output" | "pty-exit" | "telemetry" | "permission" | "tray-select")` at the bottom of `main.ts`. Telemetry is routed by `data.session_id?.toLowerCase()` — session ids are matched case-insensitively, so keep them lowercase.
 - `applyHook` maps lifecycle events → a `Phase` state machine (idle/thinking/working/done/error/ended) and attention flags; `applyStatusline` fills model/context%/cost/duration. **Rate limits are account-wide**, held in a single `rl` object and shown identically on every session, not per-session.
 - **A turn that died is not a turn that finished, and only one hook knows which.** Claude Code fires `StopFailure` (not `Stop`) when the API kills a turn — a 529, a rate limit, a dead key — carrying an `error` enum (`overloaded`, `rate_limit`, `authentication_failed`, `max_output_tokens`, …) and the `error_details` text the pane shows. Everything *after* that point looks identical to a clean finish: the same 60-second idle `Notification` (`notification_type: "idle_prompt"`) arrives either way. Unguarded it relabelled the turn "your turn" and turned the red ✕ green a minute after the failure — which shipped, and is why `Sess.apiErr` exists. It is set by `StopFailure`, cleared only when the session genuinely starts another turn (`UserPromptSubmit` / `PreToolUse` / `SessionStart` / `SessionEnd`), and **`endTurn` is the single place that decides done vs. error** — both `Stop` and the idle nudge go through it, and the run-on-stop rule is skipped while it's set. Every surface that spells a state out reads `phaseText(s)`, not `PILL_TEXT[s.phase]`, so the reason travels with the glyph: "API overloaded" means wait, "auth failed" means go fix your credentials, and a bare ✕ means neither.
-- **Persistence is all `localStorage`**, ~20 keys prefixed `cc-` (favorites, drag order, colours, icons, engine, permission mode, font size, sort/grouping, frecency, caffeinate, the `cc-usage` daily cost rollup, the `cc-restore` roster, and the task keys `cc-task-{prefs,pins,hidden,onstop,runner,inputs}` + `cc-trusted`). `grep '"cc-'` for the current set.
+- **Persistence is all `localStorage`**, ~20 keys prefixed `cc-` (favorites, drag order, colours, icons, engine, permission mode, font size, sort/grouping, frecency, caffeinate, the `cc-usage` daily cost rollup, the `cc-restore` roster, the dashboard's `cc-dash-*` and `cc-digest-ok`, and the task keys `cc-task-{prefs,pins,hidden,onstop,runner,inputs}` + `cc-trusted`). `grep '"cc-'` for the current set.
 - **Debug console** (🐞 button, bottom-right): an in-app event log + live state via `dlog()`/`dbgSnapshot()`. It flags **unrouted telemetry** (the routing-drift class of bug above) and JS errors, and mirrors a snapshot to `$TMPDIR/cc-launcher/episko-debug.json` (written by the `write_debug_file` command) so an external tool or an LLM agent can read live app state while it runs.
 - **Two-tier logging — live snapshot vs. durable timeline.** The `episko-debug.json` snapshot is a *state-of-now* blob that is overwritten each flush and does **not** survive a crash (the frontend never flushes if the process dies). The durable tier is the backend rolling `episko.log` (+ `panic.log`) in the OS app-log dir (macOS `~/Library/Logs/io.respeak.episko/`), via `tauri-plugin-log` and a panic hook — the only on-disk trace of a panic that unwinds cleanly out of `main` (no crash dump / WER otherwise). Every `dlog()` line tees into it through the `log_frontend` command (tagged `[ui]`), so the UI and backend event streams land in **one time-ordered file**. A `episko.log` that stops without an `exit · clean shutdown` line is itself evidence of an abnormal termination. Use the snapshot for "what is it doing *now*", the rolling log for "why did it *die*".
 

--- a/index.html
+++ b/index.html
@@ -98,10 +98,27 @@
             <div class="ext-view-bar"><span class="ext-view-dot"></span>Read-only mirror · this session runs in another terminal</div>
             <div class="ext-body" id="extBody"></div>
           </div>
+          <!-- The project dashboard. Nothing inside it runs until a project is
+               clicked: ./dashboard fills every one of these on open, and the pane
+               stays hidden (and empty) for the whole life of the app otherwise. -->
+          <div class="dash-view" id="dashPane" hidden>
+            <div class="dash" id="dashJotHost">
+              <div id="dashPulse"></div>
+              <div class="db-body">
+                <div class="db-spine" id="dashSpine"></div>
+                <div class="db-aside" id="dashAside"></div>
+              </div>
+            </div>
+            <div class="ovl" id="dashOverlay"></div>
+          </div>
         </div>
       </main>
 
       <aside class="insp">
+        <!-- The 44px rail ⌘I collapses to on the dashboard, where the inspector holds
+             the only copy of History / Terminal / Run. Empty (and display:none) on
+             every other view. -->
+        <div class="insp-strip" id="dashStrip"></div>
         <div class="insp-head"><span class="label">Session</span><span class="pill idle" id="iPill"><span class="pd"></span><span id="iPillTxt">–</span></span></div>
         <div class="insp-scroll" id="inspector"></div>
       </aside>

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1501,10 +1501,273 @@ pub(crate) fn git_action(workdir: String, op: String) -> Result<GitActionResult,
     })
 }
 
+/// One commit on the Trail. `when` is the author date in UNIX **seconds**, matching
+/// `HistorySession.mtime` — the frontend converts both once, at the boundary.
+#[derive(serde::Serialize, Debug, PartialEq)]
+pub(crate) struct DayCommit {
+    pub sha: String,
+    pub author: String,
+    pub when: u64,
+    pub subject: String,
+    /// The repo this came from, as the caller named it — so the frontend can attribute
+    /// a commit to a project without re-resolving paths.
+    pub root: String,
+}
+
+/// Resolve a folder to something that identifies its **repository**, not its checkout.
+///
+/// This is the whole reason the Trail doesn't double-count: Episko is worktree-heavy,
+/// and every worktree of one repo shares one object store, so asking each of them for
+/// "commits since Monday" returns the same commits N times. Worktrees share a
+/// *common dir*, so that is the identity.
+///
+/// `--path-format=absolute` matters: plain `--git-common-dir` answers `.git` for a main
+/// worktree, which is relative to the cwd and would compare unequal to the absolute
+/// path a linked worktree reports for the very same repo.
+fn repo_identity(dir: &str) -> Option<String> {
+    let out = sys_command("git")
+        .env("LC_ALL", "C")
+        .arg("-C").arg(dir)
+        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() { None } else { Some(norm_path(&s)) }
+}
+
+/// Commits across `roots` in the last `days` days, for the Trail's "behind you" half.
+///
+/// **One git call per repository, never one per day or per commit.** A day view over a
+/// month is 30 buckets; asking git per bucket would be 30 processes for what one pass
+/// answers, and the frontend groups by date anyway.
+///
+/// Includes every local branch (`--branches`), not just HEAD: with several worktrees
+/// open, the work that landed today is spread across them, and a Trail that only saw
+/// the checked-out branch would miss most of it. Merges are kept — "merged #43" is
+/// exactly the kind of thing a day is remembered by.
+///
+/// Every author is returned, not just the current user. Seeing that a colleague pushed
+/// while you were elsewhere is the point of the collaborator work, and the frontend
+/// decides how to show whose commit it was.
+///
+/// Failures are per-repo and silent: a root that isn't a repo, has no commits yet, or
+/// has since been deleted contributes nothing rather than failing the whole call.
+#[tauri::command(async)]
+pub(crate) fn git_log_days(roots: Vec<String>, days: u64) -> Vec<DayCommit> {
+    let mut seen: Vec<String> = Vec::new();
+    let mut out: Vec<DayCommit> = Vec::new();
+    // git's approxidate cannot express a date before the UNIX epoch, and it fails
+    // *silently*: `--since=36500.days.ago` matches NOTHING rather than everything, so an
+    // over-wide window would blank the Trail instead of widening it — the worst kind of
+    // bug, because "no work happened" is a plausible-looking answer.
+    //
+    // A window wider than git can express simply means "all history", which is what
+    // omitting `--since` already means — so say that, rather than guessing a magic
+    // cutoff that drifts further from the epoch every year.
+    const WIDER_THAN_GIT_CAN_SAY: u64 = 18_000; // ~49 years; the epoch is the real limit
+    let since = format!("--since={days}.days.ago");
+
+    for root in &roots {
+        // Dedupe by repository, keeping the first-named root as the label.
+        let id = repo_identity(root).unwrap_or_else(|| norm_path(root));
+        if seen.contains(&id) {
+            continue;
+        }
+        seen.push(id);
+
+        let mut args: Vec<&str> = vec!["--no-optional-locks", "log", "--branches"];
+        if days < WIDER_THAN_GIT_CAN_SAY {
+            args.push(&since);
+        }
+        // NUL between fields so a subject containing any printable character still
+        // parses; %s is the subject *line*, so it can't contain a newline and records
+        // stay newline-separated.
+        args.push("--format=%H%x00%an%x00%at%x00%s");
+
+        let res = sys_command("git")
+            .env("LC_ALL", "C")
+            .arg("-C").arg(root)
+            .args(&args)
+            .output();
+        let Ok(res) = res else { continue };
+        if !res.status.success() {
+            continue;
+        }
+        for line in String::from_utf8_lossy(&res.stdout).lines() {
+            let mut p = line.split('\0');
+            let (Some(sha), Some(author), Some(at), Some(subject)) =
+                (p.next(), p.next(), p.next(), p.next())
+            else {
+                continue;
+            };
+            let Ok(when) = at.parse::<u64>() else { continue };
+            out.push(DayCommit {
+                sha: sha.chars().take(9).collect(),
+                author: author.to_string(),
+                when,
+                subject: subject.to_string(),
+                root: root.clone(),
+            });
+        }
+    }
+    out
+}
+
+/// What the project dashboard needs to know about a folder before it renders anything.
+///
+/// **One call, because it decides which cards exist at all.** Three tiers, and they are
+/// not the same gate: a GitHub remote unlocks issues and pull requests, *git* unlocks
+/// the commit half of the timeline and everything shared (`.episko/` is only meaningful
+/// if it can be committed), and neither gates sessions, spend or tasks. A card with
+/// nothing to say is absent rather than empty — an empty "Issues" panel in a folder that
+/// has no issues reads as breakage.
+#[derive(serde::Serialize, Debug, PartialEq, Default)]
+pub(crate) struct ProjectFacts {
+    pub is_repo: bool,
+    /// The repo's main checkout, so a dashboard opened on a worktree still speaks for
+    /// the project. None when the folder isn't a repo at all.
+    pub root: Option<String>,
+    /// `origin`'s URL verbatim, for display. None for a repo with no remote — a normal
+    /// local-only project, not an error.
+    pub origin: Option<String>,
+    /// The host, lowercased (`github.com`, `gitlab.com`, `git.example.internal`).
+    pub host: Option<String>,
+    /// `owner/repo`, only when the host is GitHub — it is what `gh` needs, and naming it
+    /// for any other host would imply a capability Episko doesn't have there.
+    pub slug: Option<String>,
+}
+
+/// Host and `owner/repo` out of a git remote URL.
+///
+/// Pure and separated out because the spellings git accepts all appear in the wild and
+/// only some are URIs: `git@host:owner/repo.git` has no scheme and a colon where a slash
+/// belongs, while `ssh://git@host/owner/repo` and `https://host/owner/repo.git` are
+/// ordinary URLs. Getting this wrong does not error — it silently files a GitHub project
+/// under "no GitHub" and drops two cards, which is the failure this test-covers against.
+pub(crate) fn parse_remote(url: &str) -> (Option<String>, Option<String>) {
+    let u = url.trim();
+    if u.is_empty() {
+        return (None, None);
+    }
+    // scp-like `[user@]host:path`, told apart from a scheme by the absence of "://".
+    let rest = if let Some((_, after)) = u.split_once("://") {
+        after.to_string()
+    } else if let Some((hostish, path)) = u.split_once(':') {
+        // A Windows drive letter or a plain relative path is not a remote host.
+        if hostish.contains('/') || hostish.chars().count() <= 1 {
+            return (None, None);
+        }
+        format!("{hostish}/{path}")
+    } else {
+        return (None, None);
+    };
+    let rest = rest.split_once('@').map_or(rest.as_str(), |(_, r)| r); // strip user[:pass]@
+    let (host, path) = rest.split_once('/').unwrap_or((rest, ""));
+    // Strip a port: `git@host:2222/o/r` and `ssh://host:2222/o/r` are both legal.
+    let host = host.split(':').next().unwrap_or(host).to_ascii_lowercase();
+    if host.is_empty() {
+        return (None, None);
+    }
+    let path = path.trim_matches('/').trim_end_matches(".git");
+    let mut seg = path.split('/').filter(|s| !s.is_empty());
+    let slug = match (seg.next(), seg.next()) {
+        // Only GitHub gets a slug: it is what `gh` is handed, and producing one for a
+        // GitLab remote would promise a capability that does not exist.
+        (Some(o), Some(r)) if host == "github.com" => Some(format!("{o}/{r}")),
+        _ => None,
+    };
+    (Some(host), slug)
+}
+
+/// The one probe the dashboard makes before deciding what it can show.
+#[tauri::command(async)]
+pub(crate) fn project_facts(dir: String) -> ProjectFacts {
+    let Some(root) = repo_root_of(&dir) else {
+        return ProjectFacts::default();
+    };
+    // `git remote get-url origin` rather than reading .git/config directly: worktrees,
+    // submodules and `includeIf` all make the file the wrong place to look, and this is
+    // one process on a folder the user just clicked.
+    let origin = sys_command("git")
+        .env("LC_ALL", "C")
+        .arg("-C").arg(&root)
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty());
+    let (host, slug) = origin.as_deref().map_or((None, None), parse_remote);
+    ProjectFacts { is_repo: true, root: Some(root), origin, host, slug }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::testutil::{git, scratch_dir};
+
+    #[test]
+    fn parse_remote_reads_every_spelling_git_accepts() {
+        // scp-like: not a URI at all, and the most common form for an SSH key setup.
+        assert_eq!(parse_remote("git@github.com:respeak-io/episko.git"),
+                   (Some("github.com".into()), Some("respeak-io/episko".into())));
+        assert_eq!(parse_remote("https://github.com/respeak-io/episko.git"),
+                   (Some("github.com".into()), Some("respeak-io/episko".into())));
+        assert_eq!(parse_remote("ssh://git@github.com/respeak-io/episko"),
+                   (Some("github.com".into()), Some("respeak-io/episko".into())));
+        // A token in the URL must not become the host.
+        assert_eq!(parse_remote("https://x-access-token:ghp_abc@github.com/respeak-io/episko.git"),
+                   (Some("github.com".into()), Some("respeak-io/episko".into())));
+        // A port is legal on both forms and is not part of the host.
+        assert_eq!(parse_remote("ssh://git@github.com:2222/respeak-io/episko.git").0,
+                   Some("github.com".into()));
+    }
+
+    #[test]
+    fn a_slug_is_only_ever_produced_for_github() {
+        // The slug is what `gh` is handed. Producing one for another host would promise
+        // issues and pull requests Episko cannot reach there.
+        assert_eq!(parse_remote("git@gitlab.com:team/thing.git"),
+                   (Some("gitlab.com".into()), None));
+        assert_eq!(parse_remote("git@git.respeak.internal:team/thing.git"),
+                   (Some("git.respeak.internal".into()), None));
+        // Host case is normalised — GitHub URLs are written both ways.
+        assert_eq!(parse_remote("git@GitHub.com:o/r.git").1, Some("o/r".into()));
+    }
+
+    #[test]
+    fn a_local_path_is_not_a_remote_host() {
+        assert_eq!(parse_remote("/srv/git/thing.git"), (None, None));
+        assert_eq!(parse_remote("../sibling"), (None, None));
+        assert_eq!(parse_remote("C:/repos/thing"), (None, None));
+        assert_eq!(parse_remote(""), (None, None));
+        assert_eq!(parse_remote("   "), (None, None));
+    }
+
+    #[test]
+    fn project_facts_separates_not_a_repo_from_a_repo_with_no_remote() {
+        // The two are different tiers: one loses the whole git half of the dashboard,
+        // the other only loses issues and pull requests.
+        let plain = scratch_dir();
+        assert_eq!(project_facts(plain.to_string_lossy().to_string()), ProjectFacts::default());
+
+        let repo = scratch_dir();
+        git(&repo, &["init", "-q", "-b", "main"]);
+        let f = project_facts(repo.to_string_lossy().to_string());
+        assert!(f.is_repo);
+        assert!(f.root.is_some());
+        assert_eq!(f.origin, None, "a repo with no remote is normal, not an error");
+        assert_eq!(f.slug, None);
+
+        git(&repo, &["remote", "add", "origin", "git@github.com:respeak-io/episko.git"]);
+        let f = project_facts(repo.to_string_lossy().to_string());
+        assert_eq!(f.slug, Some("respeak-io/episko".into()));
+        assert_eq!(f.host, Some("github.com".into()));
+    }
+
     use std::path::{Path, PathBuf};
     use std::process::Command;
 
@@ -1521,6 +1784,98 @@ mod tests {
             .join(repo.file_name().unwrap())
     }
 
+
+    /// The Trail asks for commits across every project folder it knows, and Episko is
+    /// worktree-heavy — so the same repository arrives under several paths. Counting it
+    /// once per checkout would triple a busy day's history.
+    #[test]
+    fn git_log_days_counts_a_repo_once_however_many_worktrees_name_it() {
+        let repo = scratch_dir();
+        git(&repo, &["init", "-q", "-b", "main"]);
+        let commit = |msg: &str| {
+            git(&repo, &["-c", "user.email=t@example.com", "-c", "user.name=T",
+                         "-c", "commit.gpgsign=false", "commit", "-q", "--allow-empty", "-m", msg]);
+        };
+        commit("first thing");
+        commit("second thing");
+
+        let wt = wt_root(&repo).join("side");
+        std::fs::create_dir_all(wt.parent().unwrap()).unwrap();
+        git(&repo, &["worktree", "add", "-q", "-b", "side", &wt.to_string_lossy()]);
+
+        let root = repo.to_string_lossy().to_string();
+        let side = wt.to_string_lossy().to_string();
+
+        // One checkout: both commits, newest first is not asserted (the frontend sorts).
+        let one = git_log_days(vec![root.clone()], 3650);
+        assert_eq!(one.len(), 2, "expected both commits, got {one:?}");
+        assert!(one.iter().any(|c| c.subject == "first thing"));
+        assert_eq!(one[0].author, "T");
+        assert!(one[0].when > 0, "author date must be a real unix timestamp");
+
+        // Both checkouts of the SAME repo: still two commits, not four.
+        let both = git_log_days(vec![root.clone(), side.clone()], 3650);
+        assert_eq!(both.len(), 2, "worktrees of one repo must not double-count: {both:?}");
+
+        // And the sibling worktree alone answers identically — the dedupe key is the
+        // repository, not whichever path happened to be listed first.
+        assert_eq!(git_log_days(vec![side], 3650).len(), 2);
+
+        let _ = std::fs::remove_dir_all(wt_root(&repo));
+        let _ = std::fs::remove_dir_all(&repo);
+    }
+
+    /// A folder that isn't a repo (or has been deleted) must contribute nothing rather
+    /// than failing the whole call — the Trail spans every project the user has open.
+    #[test]
+    fn git_log_days_shrugs_off_a_root_that_is_not_a_repo() {
+        let plain = scratch_dir();
+        assert!(git_log_days(vec![plain.to_string_lossy().to_string()], 30).is_empty());
+        assert!(git_log_days(vec!["/nope/does/not/exist".into()], 30).is_empty());
+
+        let repo = scratch_dir();
+        git(&repo, &["init", "-q", "-b", "main"]);
+        git(&repo, &["-c", "user.email=t@example.com", "-c", "user.name=T",
+                     "-c", "commit.gpgsign=false", "commit", "-q", "--allow-empty", "-m", "only one"]);
+        // A bad root alongside a good one still yields the good one's commits.
+        let mixed = git_log_days(vec!["/nope".into(), repo.to_string_lossy().to_string()], 3650);
+        assert_eq!(mixed.len(), 1);
+        assert_eq!(mixed[0].subject, "only one");
+
+        let _ = std::fs::remove_dir_all(&plain);
+        let _ = std::fs::remove_dir_all(&repo);
+    }
+
+    /// `--since` is what bounds the scan; a commit outside the window must not appear,
+    /// or the "last 30 days" window silently becomes "everything".
+    #[test]
+    fn git_log_days_honours_the_window() {
+        let repo = scratch_dir();
+        git(&repo, &["init", "-q", "-b", "main"]);
+        // GIT_AUTHOR_DATE/COMMITTER_DATE are the only way to fabricate an old commit.
+        let out = Command::new("git")
+            .current_dir(&repo)
+            .env("GIT_AUTHOR_DATE", "2001-02-03T04:05:06")
+            .env("GIT_COMMITTER_DATE", "2001-02-03T04:05:06")
+            .args(["-c", "user.email=t@example.com", "-c", "user.name=T",
+                   "-c", "commit.gpgsign=false", "commit", "-q", "--allow-empty", "-m", "ancient"])
+            .output()
+            .expect("git");
+        assert!(out.status.success());
+
+        let root = repo.to_string_lossy().to_string();
+        assert!(git_log_days(vec![root.clone()], 30).is_empty(),
+                "a 2001 commit must fall outside a 30-day window");
+        assert_eq!(git_log_days(vec![root.clone()], 20_000).len(), 1, "a wide window must include it");
+
+        // The clamp, asserted as behaviour rather than trusted: git's approxidate
+        // matches NOTHING past ~100 years, so without clamping an over-wide window
+        // would silently blank the Trail. It must widen, never empty.
+        assert_eq!(git_log_days(vec![root.clone()], 36_500).len(), 1, "an over-wide window must not go blank");
+        assert_eq!(git_log_days(vec![root], u64::MAX).len(), 1, "and neither must an absurd one");
+
+        let _ = std::fs::remove_dir_all(&repo);
+    }
 
     /// `repo_root_of` replaces a `git rev-parse` that cost ~140ms per call, so it has
     /// to give the same answer git does — including where git *refuses* one. Each case

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod git;
 mod icons;
 mod platform;
 mod pty;
+mod summarize;
 mod tasks;
 mod telemetry;
 mod usage;
@@ -463,6 +464,8 @@ pub fn run() {
             git::delete_branch,
             git::switch_branch,
             git::git_commit_info,
+            git::git_log_days,
+            git::project_facts,
             pty::spawn_ghostty,
             pty::spawn_shell,
             pty::spawn_task,
@@ -484,6 +487,10 @@ pub fn run() {
             usage::list_past_sessions,
             usage::list_session_history,
             usage::token_usage_by_day,
+            summarize::summarize_day,
+            summarize::read_digest,
+            summarize::has_digest,
+            summarize::write_digest,
             icons::find_project_icon,
             icons::read_custom_icon,
             platform::read_legacy_localstorage,

--- a/src-tauri/src/summarize.rs
+++ b/src-tauri/src/summarize.rs
@@ -1,0 +1,446 @@
+// The Trail's one generated sentence — and nothing else.
+//
+// Everything else the Trail shows is derived from evidence Episko already keeps
+// (transcripts, the usage rollup, git). This module exists for the single part that
+// cannot be derived: a readable one-line label for a day. It is deliberately the only
+// place in Episko that spends money to render a view, which is why it is also the only
+// place with a cache, a timeout and an off switch.
+//
+// Four rules shape it:
+//
+// - **Ask once, ever.** A day that is over cannot change, so its summary is written to
+//   disk and never recomputed. Only today re-summarises (the frontend decides, via
+//   `dayIsClosed`, and asks with `force`). Opening the Trail ten times costs nothing.
+// - **Never touch a real session.** `claude -p` still writes a transcript, under an
+//   encoding of its cwd — so this runs in a scratch directory. Pointing it at a project
+//   folder would scatter one-line summariser transcripts through the user's own history,
+//   and reusing a session id would *append to that conversation*.
+// - **A stripped PATH is the norm.** Same constraint as the hooks: a GUI app launched
+//   from Finder inherits almost no PATH, so the binary comes from `resolve_claude()` and
+//   the environment from `augmented_path()`.
+// - **It must be allowed to fail.** No summary is a fine state — the day still renders
+//   with its deterministic headline — so every failure path returns an error the caller
+//   shrugs off rather than surfacing as breakage.
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use tauri::{AppHandle, Manager};
+
+use crate::platform::{augmented_path, resolve_claude, sys_command};
+
+/// Long enough for a small prompt on a slow link, short enough that a wedged CLI is
+/// noticed rather than leaking a blocked thread for the life of the app.
+const TIMEOUT: Duration = Duration::from_secs(45);
+
+/// Where summaries live. The app config dir, not `$TMPDIR/cc-launcher` where the
+/// instrument files go: those are per-launch scratch and *should* evaporate, while a
+/// summary that vanished on reboot would be silently re-bought.
+fn cache_path(app: &AppHandle) -> Option<PathBuf> {
+    let dir = app.path().app_config_dir().ok()?;
+    let _ = std::fs::create_dir_all(&dir);
+    Some(dir.join("trail-summaries.json"))
+}
+
+fn read_cache(app: &AppHandle) -> serde_json::Map<String, serde_json::Value> {
+    cache_path(app)
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+        .and_then(|v| v.as_object().cloned())
+        .unwrap_or_default()
+}
+
+/// Temp-then-rename, like `tasks.rs` writes `tasks.toml`: a crash mid-write must not
+/// leave a truncated file that then fails to parse and loses every earlier summary.
+fn write_cache(app: &AppHandle, map: &serde_json::Map<String, serde_json::Value>) {
+    let Some(path) = cache_path(app) else { return };
+    let tmp = path.with_extension("json.tmp");
+    if serde_json::to_string_pretty(map)
+        .ok()
+        .and_then(|s| std::fs::write(&tmp, s).ok())
+        .is_some()
+    {
+        let _ = std::fs::rename(&tmp, &path);
+    }
+}
+
+/// A scratch cwd for the summariser's own transcripts, kept out of every real project.
+fn scratch_cwd() -> PathBuf {
+    let mut d = std::env::temp_dir();
+    d.push("cc-launcher");
+    d.push("trail-summary");
+    let _ = std::fs::create_dir_all(&d);
+    d
+}
+
+/// The instruction. Deliberately narrow: the model is labelling facts it is handed, not
+/// investigating anything, so it gets no tools, no context and no room to editorialise.
+fn prompt_for(facts: &str) -> String {
+    format!(
+        "Below is a factual record of one day of a developer's work — the sessions their \
+AI coding agents ran, the commits that landed, and what it cost.\n\n\
+Write ONE plain sentence, at most 18 words, describing what the day was about. Name the \
+dominant project if one clearly dominates. Prefer concrete nouns from the facts over \
+generic words like \"various\" or \"development\". Output only the sentence: no preamble, \
+no bullet points, no markdown, no quotes.\n\n\
+FACTS\n{facts}"
+    )
+}
+
+/// Run `claude -p`, bounded. Returns the trimmed stdout.
+///
+/// The child's stdout is drained by a reader thread rather than collected after the
+/// wait: a `wait()` that only reads afterwards deadlocks the moment the child writes
+/// more than one pipe buffer, and "the summariser hung the app" is a far worse failure
+/// than "there is no summary today".
+fn run_claude(model: &str, prompt: &str) -> Result<String, String> {
+    let mut child = sys_command(resolve_claude())
+        .env("PATH", augmented_path())
+        .current_dir(scratch_cwd())
+        .args(["-p", prompt, "--model", model])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("could not start claude: {e}"))?;
+
+    let mut stdout = child.stdout.take().ok_or("no stdout")?;
+    let reader = std::thread::spawn(move || {
+        let mut s = String::new();
+        let _ = stdout.read_to_string(&mut s);
+        s
+    });
+
+    let deadline = Instant::now() + TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let text = reader.join().unwrap_or_default();
+                if !status.success() {
+                    return Err(format!("claude exited {status}"));
+                }
+                return Ok(text.trim().to_string());
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err("claude timed out".into());
+                }
+                std::thread::sleep(Duration::from_millis(120));
+            }
+            Err(e) => return Err(e.to_string()),
+        }
+    }
+}
+
+// ---------- the shared half: .episko/digest.md ----------
+// A summary costs money, and every teammate opening the same dashboard would pay for
+// the same sentence again. So a generated day is also written into the project as a
+// plain markdown file, which is committable, diffable, and readable by a colleague who
+// never opens Episko. Read before generate: the second person to look at a week pays
+// nothing for it.
+//
+// ONE file, not one per month. A year of one-line entries is ~365 lines — small enough
+// that a single read answers any window, and a single diff shows what changed. It is
+// also the second file Episko is allowed to write inside a user's repo (after
+// `.episko/tasks.toml`), which is why creating it asks first: see `create`.
+
+/// The digest is markdown because a human reads it in a PR, not because anything here
+/// needs markdown. `## YYYY-MM-DD` sections, newest first, one paragraph each.
+const DIGEST_HEAD: &str = "# Work log\n\n\
+One line per day, generated by [Episko](https://episko.dev) from that day's commits and \
+agent sessions. Committed so the team shares one history instead of each re-deriving it.\n";
+
+fn digest_path(root: &str) -> PathBuf {
+    PathBuf::from(root).join(".episko").join("digest.md")
+}
+
+/// Day → sentence, from whatever is on disk. A missing or malformed file is an empty
+/// map, never an error: a digest is an optimisation, and a project without one has to
+/// behave exactly like a project that has never heard of it.
+fn parse_digest(text: &str) -> std::collections::BTreeMap<String, String> {
+    let mut out = std::collections::BTreeMap::new();
+    let mut day: Option<String> = None;
+    let mut buf: Vec<&str> = Vec::new();
+    let flush = |day: &mut Option<String>,
+                 buf: &mut Vec<&str>,
+                 out: &mut std::collections::BTreeMap<String, String>| {
+        if let Some(d) = day.take() {
+            let s = buf.join(" ").trim().to_string();
+            if !s.is_empty() {
+                out.insert(d, s);
+            }
+        }
+        buf.clear();
+    };
+    for line in text.lines() {
+        if let Some(rest) = line.trim_end().strip_prefix("## ") {
+            flush(&mut day, &mut buf, &mut out);
+            let d = rest.trim();
+            // Only a real date starts a section. Anything else is prose in someone's
+            // hand-edited file and must not become a key.
+            if d.len() == 10 && d.as_bytes()[4] == b'-' && d.as_bytes()[7] == b'-'
+                && d.bytes().enumerate().all(|(i, b)| i == 4 || i == 7 || b.is_ascii_digit())
+            {
+                day = Some(d.to_string());
+            }
+        } else if day.is_some() && !line.trim().is_empty() {
+            buf.push(line.trim());
+        }
+    }
+    flush(&mut day, &mut buf, &mut out);
+    out
+}
+
+fn render_digest(map: &std::collections::BTreeMap<String, String>) -> String {
+    let mut s = String::from(DIGEST_HEAD);
+    // Newest first: the file is read top-down by a human, and the useful end is today.
+    for (day, line) in map.iter().rev() {
+        s.push_str(&format!("\n## {day}\n{line}\n"));
+    }
+    s
+}
+
+/// Every day the project's committed digest already knows about.
+#[tauri::command]
+pub(crate) fn read_digest(root: String) -> std::collections::BTreeMap<String, String> {
+    std::fs::read_to_string(digest_path(&root))
+        .map(|t| parse_digest(&t))
+        .unwrap_or_default()
+}
+
+/// Whether this project already has a digest — what the frontend asks before offering
+/// to create one, so "may Episko write a file into your repo" is asked once and only
+/// when the answer isn't already yes.
+#[tauri::command]
+pub(crate) fn has_digest(root: String) -> bool {
+    digest_path(&root).is_file()
+}
+
+/// Add or replace one day, preserving every other entry.
+///
+/// Read-modify-write rather than append: today's line is re-generated as the day goes
+/// on, and appending would leave a file with the same date three times over.
+/// `create` gates the very first write, because a new committable file in someone's
+/// repo is a real side effect — the same stance `tasks.rs` takes with `tasks.toml`.
+#[tauri::command]
+pub(crate) fn write_digest(root: String, key: String, line: String, create: bool) -> Result<(), String> {
+    let path = digest_path(&root);
+    if !path.is_file() && !create {
+        return Err("no digest yet".into());
+    }
+    let mut map = std::fs::read_to_string(&path).map(|t| parse_digest(&t)).unwrap_or_default();
+    if map.get(&key).is_some_and(|cur| *cur == line) {
+        return Ok(()); // unchanged — don't dirty the working tree for nothing
+    }
+    map.insert(key, line);
+    let dir = path.parent().ok_or("bad root")?;
+    std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+    // Temp-then-rename, like the cache above and like tasks.toml: a crash mid-write
+    // must not truncate a file that is under version control.
+    let tmp = path.with_extension("md.tmp");
+    std::fs::write(&tmp, render_digest(&map)).map_err(|e| e.to_string())?;
+    std::fs::rename(&tmp, &path).map_err(|e| e.to_string())
+}
+
+/// One day's summary sentence, cached.
+///
+/// `root` scopes it to a project — the dashboard is per-project, and two projects on
+/// the same day are two different sentences. `key` is the calendar day (`YYYY-MM-DD`),
+/// `facts` the record built by `dayFacts` in the frontend — titles and commit subjects
+/// only, never transcript bodies. `force` re-asks for a day that is still being written
+/// (today); every other day is answered from disk forever after the first time.
+///
+/// Runs on a blocking thread: a synchronous command would hold the main thread for the
+/// length of a model call and freeze the UI.
+#[tauri::command]
+pub(crate) async fn summarize_day(
+    app: AppHandle,
+    root: String,
+    key: String,
+    facts: String,
+    model: String,
+    force: bool,
+) -> Result<String, String> {
+    // Project-scoped, so two dashboards can't answer each other's days. The old
+    // day-only key is not migrated: it was never shipped outside the spike branch.
+    let cache_key = format!("{root}\u{0}{key}");
+    if !force {
+        if let Some(hit) = read_cache(&app).get(&cache_key).and_then(|v| v.as_str()) {
+            if !hit.is_empty() {
+                return Ok(hit.to_string());
+            }
+        }
+    }
+    if facts.trim().is_empty() {
+        return Err("nothing to summarise".into());
+    }
+
+    let model = if model.trim().is_empty() { "haiku".to_string() } else { model };
+    let prompt = prompt_for(&facts);
+    let text = tauri::async_runtime::spawn_blocking(move || run_claude(&model, &prompt))
+        .await
+        .map_err(|e| e.to_string())??;
+
+    // A model that answers with nothing is a failure, not an empty summary to cache —
+    // caching "" would make the day permanently unsummarisable.
+    let line = first_sentence(&text);
+    if line.is_empty() {
+        return Err("empty summary".into());
+    }
+
+    let mut map = read_cache(&app);
+    map.insert(cache_key, serde_json::Value::String(line.clone()));
+    write_cache(&app, &map);
+    Ok(line)
+}
+
+/// Keep the first non-empty line, and only that.
+///
+/// The prompt asks for one sentence; this enforces it rather than trusting it. A model
+/// that adds a preamble line or a bulleted afterthought would otherwise break the day
+/// row's layout, and clamping here is cheaper than re-prompting.
+fn first_sentence(raw: &str) -> String {
+    let line = raw
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.starts_with(['-', '*', '#', '>']))
+        .unwrap_or("")
+        .trim_matches('"')
+        .trim();
+    // A long paragraph that slipped through is cut at a word boundary rather than
+    // mid-word, so the row degrades to something still readable.
+    if line.chars().count() <= 160 {
+        return line.to_string();
+    }
+    let mut out = String::new();
+    for w in line.split_whitespace() {
+        if out.chars().count() + w.chars().count() + 1 > 157 {
+            break;
+        }
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(w);
+    }
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{first_sentence, parse_digest, render_digest, write_digest};
+    use crate::testutil::scratch_dir;
+
+    #[test]
+    fn digest_round_trips_through_markdown() {
+        let mut m = std::collections::BTreeMap::new();
+        m.insert("2026-07-30".to_string(), "Filed the performance backlog.".to_string());
+        m.insert("2026-07-31".to_string(), "Six branches landed and 0.12.0 went out.".to_string());
+        let out = parse_digest(&render_digest(&m));
+        assert_eq!(out, m);
+        // Newest first, because a human reads the file top-down and today is the useful end.
+        let text = render_digest(&m);
+        assert!(text.find("2026-07-31").unwrap() < text.find("2026-07-30").unwrap());
+    }
+
+    #[test]
+    fn a_hand_edited_file_keeps_its_prose_out_of_the_keys() {
+        // Someone will add a heading. It must not become a day, and it must not eat
+        // the entry above it either.
+        let text = "# Work log\n\n## Notes for the team\nignore me\n\n## 2026-07-31\nReal entry.\n";
+        let m = parse_digest(text);
+        assert_eq!(m.len(), 1);
+        assert_eq!(m.get("2026-07-31").map(String::as_str), Some("Real entry."));
+    }
+
+    #[test]
+    fn a_missing_or_junk_file_is_an_empty_map_not_an_error() {
+        assert!(parse_digest("").is_empty());
+        assert!(parse_digest("nothing structured here at all").is_empty());
+        // A date-shaped heading with no body is not an entry.
+        assert!(parse_digest("## 2026-07-31\n").is_empty());
+    }
+
+    #[test]
+    fn writing_refuses_to_create_the_file_until_it_is_allowed_to() {
+        let root = scratch_dir();
+        let root_s = root.to_string_lossy().to_string();
+        // The first write into someone's repo is a real side effect, so it is gated.
+        assert!(write_digest(root_s.clone(), "2026-07-31".into(), "One.".into(), false).is_err());
+        assert!(!root.join(".episko").join("digest.md").exists());
+
+        write_digest(root_s.clone(), "2026-07-31".into(), "One.".into(), true).unwrap();
+        let f = root.join(".episko").join("digest.md");
+        assert!(f.is_file());
+
+        // …and once it exists, no further permission is needed.
+        write_digest(root_s.clone(), "2026-07-30".into(), "Two.".into(), false).unwrap();
+        let m = parse_digest(&std::fs::read_to_string(&f).unwrap());
+        assert_eq!(m.len(), 2);
+        assert_eq!(m.get("2026-07-30").map(String::as_str), Some("Two."));
+    }
+
+    #[test]
+    fn re_writing_a_day_replaces_it_rather_than_appending() {
+        // Today's line is regenerated as the day goes on; appending would leave the
+        // same date in the file three times over.
+        let root = scratch_dir();
+        let root_s = root.to_string_lossy().to_string();
+        write_digest(root_s.clone(), "2026-07-31".into(), "First take.".into(), true).unwrap();
+        write_digest(root_s.clone(), "2026-07-31".into(), "Better take.".into(), false).unwrap();
+        let text = std::fs::read_to_string(root.join(".episko").join("digest.md")).unwrap();
+        assert_eq!(text.matches("## 2026-07-31").count(), 1);
+        assert_eq!(parse_digest(&text).get("2026-07-31").map(String::as_str), Some("Better take."));
+    }
+
+    #[test]
+    fn an_unchanged_day_does_not_rewrite_the_file() {
+        // The dashboard re-summarises today on every open; dirtying a tracked file
+        // each time would put .episko/digest.md in every `git status` for nothing.
+        let root = scratch_dir();
+        let root_s = root.to_string_lossy().to_string();
+        write_digest(root_s.clone(), "2026-07-31".into(), "Same.".into(), true).unwrap();
+        let f = root.join(".episko").join("digest.md");
+        let before = std::fs::metadata(&f).unwrap().modified().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        write_digest(root_s, "2026-07-31".into(), "Same.".into(), false).unwrap();
+        assert_eq!(std::fs::metadata(&f).unwrap().modified().unwrap(), before);
+    }
+
+    #[test]
+    fn takes_the_first_real_line() {
+        assert_eq!(first_sentence("\n\nMostly episko — the overview spike.\n"), "Mostly episko — the overview spike.");
+    }
+
+    #[test]
+    fn strips_a_preamble_or_bullets_the_model_added() {
+        // The prompt forbids these; enforcing it keeps one bad generation from
+        // breaking the row rather than trusting the model to have complied.
+        assert_eq!(first_sentence("- point one\n- point two"), "");
+        assert_eq!(first_sentence("# Summary\nShipped the release."), "Shipped the release.");
+    }
+
+    #[test]
+    fn unquotes() {
+        assert_eq!(first_sentence("\"Filed the performance backlog.\""), "Filed the performance backlog.");
+    }
+
+    #[test]
+    fn clamps_a_runaway_paragraph_at_a_word_boundary() {
+        let long = "word ".repeat(80);
+        let out = first_sentence(&long);
+        assert!(out.chars().count() <= 160, "got {}", out.chars().count());
+        assert!(out.ends_with('…'));
+        assert!(!out.contains("wor…"), "must not cut mid-word: {out}");
+    }
+
+    #[test]
+    fn empty_input_is_empty_not_a_panic() {
+        assert_eq!(first_sentence(""), "");
+        assert_eq!(first_sentence("   \n  \n"), "");
+    }
+}

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -14,13 +14,15 @@ import { $, toast } from "./dom";
 import { basename } from "./format";
 import { probeIcon } from "./icons";
 import { refit } from "./terminal";
-import { activeCwd, closeSession, launch } from "./panes";
+import { activeCwd, closeSession, launch, launchShell } from "./panes";
 import { renderMini, renderSidebar } from "./sidebar";
 import { renderSettings } from "./settings";
 import { waitForExit } from "./tasks";
 import { queueRosterSave } from "./mirror";
 import {
-  FAVORITES, markWorkdirStale, permMode, permModeDef, saveFavorites, sessions,
+  dashMirror, FAVORITES, markWorkdirStale, permMode, permModeDef, saveFavorites,
+  sessions,
+  termEngine,
   setFavorites, setPermMode as setPermModeState, setSortMode, SORT_META, SORT_MODES,
   sortMode, setWtGroup as setWtGroupState, wtGroup,
   type SortMode, type WtGroup,
@@ -30,6 +32,19 @@ import type { PermMode } from "./types";
 // Every action here ends in a repaint of everything, which main.ts owns.
 let renderAll: () => void = () => {};
 export function setActionsRenderAll(fn: typeof renderAll) { renderAll = fn; }
+
+// A plain shell in a project's folder — embedded gets an in-app pane, the external
+// engines their own window. Here rather than in ./projmenu because the context menu,
+// the project dashboard and (soon) the checkouts overlay all want it, which is this
+// module's whole reason to exist.
+export function openTerminalIn(project: string, dir: string) {
+  if (termEngine !== "embedded") { invoke("open_terminal_here", { workdir: dir, engine: termEngine }).catch((e) => toast("terminal: " + e)); return; }
+  void launchShell(project, dir, { colorKey: dir });
+}
+export async function copyPath(dir: string) {
+  try { await navigator.clipboard.writeText(dir); toast("Path copied"); }
+  catch { toast(dir); } // clipboard denied — at least show what it was
+}
 
 export async function openProjectFolder(key: string) {
   try { await invoke("open_folder", { dir: key }); }
@@ -110,7 +125,23 @@ export function setSort(m: SortMode, announce = true) {
 }
 export function cycleSort() { setSort(SORT_MODES[(SORT_MODES.indexOf(sortMode) + 1) % SORT_MODES.length]); }
 export function toggleRail() { $("app").classList.toggle("rail-mini"); }
-export function toggleInsp() { $("app").classList.toggle("insp-off"); $("inspBtn").classList.toggle("on", !$("app").classList.contains("insp-off")); refit(); }
+// ⌘I / ◨. On a session this hides the inspector outright — nothing in it is
+// unreachable from that header. **On the dashboard it collapses to a 44px icon rail
+// instead**, because there the inspector holds the ONLY copy of History, Terminal and
+// Run: the dashboard header gave those up on the grounds that they act on the project
+// rather than on what is on the stage, so hiding the panel would hide real verbs.
+export function toggleInsp() {
+  const app = $("app");
+  if (dashMirror()) {
+    const mini = app.classList.toggle("insp-mini");
+    $("inspBtn").classList.toggle("on", !mini);
+  } else {
+    app.classList.remove("insp-mini");
+    app.classList.toggle("insp-off");
+    $("inspBtn").classList.toggle("on", !app.classList.contains("insp-off"));
+  }
+  refit();
+}
 // The effective theme = an explicit data-theme override, else the OS preference.
 export function effectiveTheme(): "dark" | "light" {
   const a = document.documentElement.getAttribute("data-theme");

--- a/src/dash.ts
+++ b/src/dash.ts
@@ -1,0 +1,167 @@
+// The project dashboard's rules — what one project's recent history *was*, and which
+// of the dashboard's cards a given folder can even have.
+//
+// No DOM and no Tauri, so it unit-tests in isolation like ./trail and ./usage;
+// ./dashview owns the markup and ./dashboard owns the pane, the IPC and the events —
+// the same three-way split as ./palette + ./palui and ./graph + ./graphview.
+//
+// WHY THIS EXISTS SEPARATELY FROM ./trail. `trail.ts` assembles days across the whole
+// fleet and is already tested; this scopes that to one project and adds the two
+// questions a per-project view has to answer that a fleet-wide one never did: what can
+// this folder actually show, and what did *this* project cost.
+
+import type { HistEntry } from "./history";
+import { histProject } from "./history";
+import { dayKeyOf, trailDays, type TrailCommit, type TrailDay } from "./trail";
+import type { UDay } from "./usage";
+
+// ---------- what a folder can show ----------
+
+/// What `project_facts` answers. Mirrors the Rust struct field-for-field.
+export interface ProjectFacts {
+  is_repo: boolean;
+  root: string | null;
+  origin: string | null;
+  host: string | null;
+  slug: string | null;
+}
+
+/**
+ * Which cards this folder can have.
+ *
+ * **Three tiers, and they are not the same gate** — conflating them is the bug this
+ * type exists to prevent:
+ *   • `github` — issues, pull requests and claims, all of which are `gh`.
+ *   • `git`    — the commit half of the timeline, the checkouts card, and *everything
+ *                shared*: `.episko/` is only meaningful if it can be committed, so
+ *                **sharing needs git, not GitHub**.
+ *   • `none`   — sessions, spend, tasks and personal notes still work. None of those
+ *                ever cared about git, and a plain folder is a real way to work.
+ *
+ * A card with nothing to say is absent, never empty: an "Issues" panel in a folder
+ * that has no issues reads as breakage rather than as an honest blank.
+ */
+export type ProjectTier = "github" | "git" | "none";
+
+export function projectTier(f: ProjectFacts | null | undefined): ProjectTier {
+  if (!f?.is_repo) return "none";
+  // A slug is minted only for github.com (see `parse_remote`), so this cannot be
+  // fooled by a GitLab or self-hosted remote — which is the whole point of it.
+  return f.slug ? "github" : "git";
+}
+
+/** Whether this project can carry a committed `.episko/` — digests, and later notes. */
+export const canShare = (t: ProjectTier): boolean => t !== "none";
+
+// ---------- one project's days ----------
+
+/**
+ * The last `window.length` days of THIS project, newest first.
+ *
+ * Everything is filtered to the project *before* `trailDays` assembles it, rather than
+ * assembled and then filtered: a day that had work in three projects would otherwise
+ * survive into this list carrying the other two's counts, and the pulse strip above it
+ * would then be describing somebody else's afternoon.
+ *
+ * `costFor` is injected rather than read here so this module stays pure over its
+ * arguments — ./dashboard supplies it from the `cc-usage-detail` rollup.
+ */
+export function dashDays(
+  root: string,
+  hist: HistEntry[],
+  commits: TrailCommit[],
+  window: UDay[],
+  costFor: (dayKey: string) => number,
+): TrailDay[] {
+  // `histProject` is the sidebar's own grouping rule — the same one that decides a
+  // worktree belongs to its repo. Re-deriving it here would let History and the
+  // dashboard disagree about which project a session was in.
+  const mine = hist.filter((h) => histProject(h).colorKey === root);
+  const myCommits = commits.filter((c) => c.root === root);
+  // Cost is re-stated per project (see below), so the fleet-wide figure on each UDay
+  // must not survive into the result.
+  const scoped = window.map((d) => ({ ...d, cost: costFor(d.key), tok: 0 }));
+  return trailDays(mine, scoped, myCommits, []);
+}
+
+/**
+ * One project's spend on one day, from the `cc-usage-detail` rollup.
+ *
+ * **Returns 0 when the day has no detail record, never the fleet total.** The plain
+ * `cc-usage` rollup is a per-day figure across every project at once, so attributing it
+ * to whichever dashboard happens to be open would invent a number. The detail split has
+ * only been recorded going forward, so older days legitimately have none — and a blank
+ * is the honest rendering of "we didn't keep this", where a borrowed total is a lie
+ * that looks like data.
+ *
+ * Keyed by project *name* because that is what `addUsage` records; two unrelated repos
+ * with the same folder name would share a bucket, which is the known limit of the
+ * split rather than something this can fix.
+ */
+export function projectCost(
+  detail: Record<string, { projects?: Record<string, number> } | undefined>,
+  dayKey: string,
+  projectName: string,
+): number {
+  const v = detail[dayKey]?.projects?.[projectName];
+  return typeof v === "number" && Number.isFinite(v) && v > 0 ? v : 0;
+}
+
+// ---------- the pulse strip ----------
+
+/// The five numbers above the timeline. Summary before detail: the window has to
+/// answer itself before anyone reads a single row.
+export interface Pulse {
+  commits: number;
+  sessions: number;
+  spend: number;
+  /// Everyone who committed in the window, busiest first — "did anyone else touch
+  /// this?" is the question a shared project asks first.
+  authors: string[];
+  /// Commits per day, OLDEST first, for the sparkline. Oldest-first because a chart
+  /// reads left-to-right in time while `days` is newest-first for the list.
+  perDay: number[];
+}
+
+export function dashPulse(days: TrailDay[]): Pulse {
+  const byAuthor = new Map<string, number>();
+  let commits = 0, sessions = 0, spend = 0;
+  for (const d of days) {
+    commits += d.commits.length;
+    sessions += d.sessions.length;
+    spend += d.cost;
+    for (const c of d.commits) byAuthor.set(c.author, (byAuthor.get(c.author) || 0) + 1);
+  }
+  return {
+    commits,
+    sessions,
+    spend,
+    // Ties broken by name so a repaint of unchanged state never reorders the list.
+    authors: [...byAuthor.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])).map(([n]) => n),
+    perDay: [...days].reverse().map((d) => d.commits.length),
+  };
+}
+
+/**
+ * The window as a dense oldest-first series, including days nothing happened on.
+ *
+ * `trailDays` drops empty days on purpose — a column of blank rows reads as a broken
+ * view rather than as a quiet weekend — but a sparkline must NOT drop them, or a
+ * fortnight with two busy days renders as two adjacent bars and reads as "constantly
+ * busy". The list and the chart want opposite things from the same data.
+ */
+export function densePerDay(days: TrailDay[], span: number, now: number): number[] {
+  const byKey = new Map(days.map((d) => [d.key, d.commits.length]));
+  const out: number[] = [];
+  const day = 86_400_000;
+  for (let i = span - 1; i >= 0; i--) out.push(byKey.get(dayKeyOf(now - i * day)) ?? 0);
+  return out;
+}
+
+/// How many days back the dashboard looks. A preference, because "how far back is
+/// useful" is genuinely per-person, and the same list the Trail offered.
+export const DASH_RANGES = [7, 14, 30] as const;
+export const DASH_RANGE_DEFAULT = 7;
+export function clampRange(n: number): number {
+  return (DASH_RANGES as readonly number[]).includes(n) ? n : DASH_RANGE_DEFAULT;
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,0 +1,380 @@
+// The project dashboard — what a project *is*, rather than which of its sessions you
+// happened to land in.
+//
+// WHY THIS EXISTS. Left-clicking a project used to select whichever session sorted
+// first, so one click did two different things depending on state, and the answer to
+// "what is going on in this repo" lived in a right-click menu nobody opens. This pane
+// is the answer: the last week assembled from evidence Episko already keeps, the
+// checkouts that exist, and the notes you left yourself.
+//
+// ./dash owns the rules and is pure; ./dashview owns the markup; this owns the pane,
+// the IPC, the summary queue and the delegated events — the same three-way split as
+// ./palette + ./palui and ./graph + ./graphview.
+//
+// THE ONE INVARIANT: **nothing here runs until a project is clicked.** No probe at
+// startup, nothing on renderAll's path. A dashboard that cost anything to *not* open
+// would tax every session in the app for a view most ticks never show.
+
+import { invoke } from "@tauri-apps/api/core";
+import { $, toast } from "./dom";
+import { dlog } from "./debug";
+import {
+  canShare, clampRange, DASH_RANGE_DEFAULT, dashDays, dashPulse, densePerDay,
+  projectCost, projectTier, type ProjectFacts, type ProjectTier,
+} from "./dash";
+import {
+  checkoutsCard, checkoutsOverlay, dashInspector, dashStrip, dayHtml, missingCard,
+  notesCard, notesOverlay, pulseHtml,
+} from "./dashview";
+import type { HistEntry } from "./history";
+import { addNote, noteList, removeNote } from "./notes";
+import { GLYPH, GCLASS } from "./sidebarview";
+import { deterministicHeadline, dayFacts, dayIsClosed, type TrailCommit, type TrailDay } from "./trail";
+import { statusKey, type WtHead } from "./types";
+import { usageDetail, usageWindow } from "./usage";
+import {
+  accentFor, dashMirror, folderDirty, sessions, setActiveId, setMirror,
+} from "./state";
+
+// What this pane does but does not own. Same host-object shape as ./settings and
+// ./palui: a control surface that touches many things it isn't responsible for takes
+// one host rather than a dozen setters.
+export interface DashHost {
+  launch: (project: string, workdir: string, opts?: { colorKey?: string }) => Promise<unknown>;
+  openWorktreeDialog: (project: string, root: string) => void;
+  openTerminal: (dir: string) => void;
+  openRun: (root: string) => void;
+  openGraph: (root: string) => void;
+  openHistory: (root: string) => void;
+  openFolder: (dir: string) => void;
+  copyPath: (dir: string) => void;
+  setActive: (id: string) => void;
+  renderAll: () => void;
+}
+let host: DashHost = {
+  launch: async () => {}, openWorktreeDialog: () => {}, openTerminal: () => {},
+  openRun: () => {}, openGraph: () => {}, openHistory: () => {}, openFolder: () => {},
+  copyPath: () => {}, setActive: () => {}, renderAll: () => {},
+};
+export function setDashHost(h: DashHost) { host = h; }
+
+// ---------- preferences ----------
+export let dashRange = clampRange(+(localStorage.getItem("cc-dash-range") || DASH_RANGE_DEFAULT));
+export function setDashRange(n: number) {
+  dashRange = clampRange(n);
+  localStorage.setItem("cc-dash-range", String(dashRange));
+  if (dashMirror()) void loadDash();
+}
+/// Generated day summaries cost money, so they are opt-in and the switch is honest
+/// about it. Off means the deterministic headline stands, which is a complete view.
+export let dashSummaries = (localStorage.getItem("cc-dash-summaries") ?? "1") === "1";
+export function setDashSummaries(on: boolean) {
+  dashSummaries = on;
+  localStorage.setItem("cc-dash-summaries", on ? "1" : "0");
+  if (dashMirror()) { if (on) void runSummaryQueue(); else renderDash(); }
+}
+/// Projects whose `.episko/digest.md` the user has agreed to create. Asked once per
+/// project, because a new committable file in someone's repo is a real side effect —
+/// the same stance `tasks.rs` takes with `tasks.toml`.
+const OK_KEY = "cc-digest-ok";
+const digestOk = (): string[] => { try { return JSON.parse(localStorage.getItem(OK_KEY) || "[]"); } catch { return []; } };
+function allowDigest(root: string) {
+  const l = digestOk();
+  if (!l.includes(root)) localStorage.setItem(OK_KEY, JSON.stringify([...l, root]));
+}
+
+// ---------- state ----------
+let facts: ProjectFacts | null = null;
+let tier: ProjectTier = "none";
+let days: TrailDay[] = [];
+let heads: WtHead[] = [];
+let hasDigest = false;
+let loading = false;
+/// Generated summaries for the open project, keyed by day. Separate from `days` so a
+/// reload doesn't drop sentences already paid for in this session.
+const summaries = new Map<string, string>();
+/// Which day rows are expanded. Survives a re-render because it is keyed by day, not
+/// by element — the pane rebuilds its innerHTML on every repaint.
+const openDays = new Set<string>();
+/// Which enlarge overlay is up, if any.
+let openView: "checkouts" | "notes" | null = null;
+
+const root = () => dashMirror()?.root ?? "";
+const name = () => dashMirror()?.name ?? "";
+
+// ---------- data ----------
+async function loadDash(): Promise<void> {
+  const r = root();
+  if (!r) return;
+  loading = true;
+  summaries.clear();
+  renderDash();
+  try {
+    // `project_facts` first and alone: it decides which of the calls below are even
+    // worth making, and a folder that isn't a repo must not be asked for a git log.
+    facts = await invoke<ProjectFacts>("project_facts", { dir: r }).catch(() => null);
+    tier = projectTier(facts);
+    const wantGit = tier !== "none";
+    const [hist, commits, wt, digest] = await Promise.all([
+      invoke<HistEntry[]>("list_session_history", { limit: 400 }).catch((e) => {
+        dlog("warn", `dash: history scan failed — ${e}`);
+        return [] as HistEntry[];
+      }),
+      wantGit ? invoke<TrailCommit[]>("git_log_days", { roots: [r], days: dashRange }).catch(() => [] as TrailCommit[])
+              : Promise.resolve([] as TrailCommit[]),
+      wantGit ? invoke<WtHead[]>("worktree_heads", { dir: r }).catch(() => [] as WtHead[])
+              : Promise.resolve([] as WtHead[]),
+      // The committed work log, read BEFORE anything is generated: the second person
+      // to open a week pays nothing for it.
+      wantGit ? invoke<Record<string, string>>("read_digest", { root: r }).catch(() => ({}))
+              : Promise.resolve({} as Record<string, string>),
+    ]);
+    heads = wt.filter((w) => w.exists);
+    for (const [k, v] of Object.entries(digest)) if (v) summaries.set(k, v);
+    hasDigest = Object.keys(digest).length > 0
+      || (wantGit && await invoke<boolean>("has_digest", { root: r }).catch(() => false));
+    days = dashDays(r, hist, commits, usageWindow(dashRange), (k) => projectCost(usageDetail, k, name()));
+  } finally {
+    loading = false;
+  }
+  renderDash();
+  if (dashSummaries) void runSummaryQueue();
+}
+
+/**
+ * Ask for the missing summaries **one at a time**.
+ *
+ * Each one spawns a `claude -p`; firing a fortnight of those at once would put
+ * fourteen CLI processes on the machine at the moment the user clicked a project,
+ * which is exactly the kind of thing that makes an app feel like it took the machine
+ * away. Sequential is also self-throttling: navigating away stops the queue.
+ */
+let queueRunning = false;
+async function runSummaryQueue(): Promise<void> {
+  if (queueRunning) return;
+  queueRunning = true;
+  const r = root();
+  try {
+    for (const d of days) {
+      if (!dashMirror() || root() !== r || !dashSummaries) break;   // left, or switched off
+      if (summaries.has(d.key)) continue;                           // digest or cache already had it
+      const f = dayFacts(d);
+      if (!f.trim()) continue;
+      try {
+        const line = await invoke<string>("summarize_day", {
+          root: r, key: d.key, facts: f, model: "haiku", force: !dayIsClosed(d),
+        });
+        if (!line) continue;
+        summaries.set(d.key, line);
+        renderDash();
+        // Share it, if this project has said yes. A day still being written is not
+        // written to the repo — today's line changes as the day goes on, and each
+        // change would dirty a tracked file.
+        if (canShare(tier) && dayIsClosed(d) && digestOk().includes(r)) {
+          void invoke("write_digest", { root: r, key: d.key, line, create: true }).catch(() => {});
+        }
+      } catch (e) {
+        // No summary is a fine state — the deterministic headline already reads
+        // correctly — so a failure is logged and the loop moves on.
+        dlog("warn", `dash: summary for ${d.key} failed — ${e}`);
+      }
+    }
+  } finally {
+    queueRunning = false;
+  }
+}
+
+// ---------- render ----------
+const liveIn = (path: string) => [...sessions.values()].filter((s) => (s.workdir || "") === path).length;
+const liveHere = () => [...sessions.values()].filter((s) => s.colorKey === root());
+
+export function renderDash(): void {
+  if (!dashMirror()) return;
+  const p = dashPulse(days);
+  const dense = densePerDay(days, dashRange, Date.now());
+  $("dashPulse").innerHTML = pulseHtml(p, tier, dashRange, dense);
+
+  const spine = $("dashSpine");
+  if (loading) {
+    spine.innerHTML = `<div class="db-empty">Reading this project's history…</div>`;
+  } else if (!days.length) {
+    spine.innerHTML = `<div class="db-empty">Nothing in the last ${dashRange} days.
+      Sessions, commits and spend appear here on their own — there is nothing to fill in.</div>`;
+  } else {
+    spine.innerHTML = days.map((d) =>
+      dayHtml(d, summaries.get(d.key) ?? null, deterministicHeadline(d), openDays.has(d.key))).join("");
+  }
+
+  $("dashAside").innerHTML =
+    checkoutsCard(heads, liveIn, folderDirty)
+    + notesCard(noteList(root()))
+    + missingCard(tier, facts);
+
+  const ovl = $("dashOverlay");
+  ovl.classList.toggle("show", openView !== null);
+  if (openView === "checkouts") ovl.innerHTML = checkoutsOverlay(heads, liveIn, folderDirty);
+  else if (openView === "notes") ovl.innerHTML = notesOverlay(noteList(root()), canShare(tier));
+}
+
+/// Header for the dashboard. Name and location only — no branch chip and no session
+/// title, because a project has neither, and no History/Terminal/Run because those act
+/// on the project and live in the inspector. The header acts on what is on the stage.
+export function renderDashHeader(): void {
+  ($("btnClose") as HTMLButtonElement).hidden = false;
+  $("hProj").textContent = name();
+  const hb = $("hBranch");
+  hb.hidden = true;
+  $("hTitle").textContent = "";
+  $("hPath").textContent = root();
+}
+
+export function renderDashInspector(): void {
+  const pill = $("iPill");
+  const n = liveHere().length;
+  pill.className = n ? "pill working" : "pill idle";
+  $("iPillTxt").textContent = n ? `${n} live` : "project";
+  const live = liveHere().map((s) => ({
+    id: s.id,
+    label: s.title || s.branch || "session",
+    glyph: GLYPH[statusKey(s)] ?? "○",
+    cls: GCLASS[statusKey(s)] ?? "g-idle",
+    ctx: s.ctxPct != null ? `${Math.round(s.ctxPct)}%` : "",
+  }));
+  $("inspector").innerHTML = dashInspector(root(), tier, facts, live, hasDigest);
+  $("dashStrip").innerHTML = dashStrip(accentFor(root()), (name()[0] || "?").toUpperCase(), tier,
+    live.map((s) => ({ id: s.id, glyph: s.glyph, cls: s.cls, label: s.label })));
+}
+
+// ---------- open / close ----------
+export function openDashboard(project: string, path: string): void {
+  const changed = root() !== path;
+  setMirror({ kind: "dash", root: path, name: project });
+  setActiveId(null);
+  for (const x of sessions.values()) x.pane.classList.remove("active");
+  ($("empty") as HTMLElement).style.display = "none";
+  ($("extPane") as HTMLElement).hidden = true;
+  ($("dashPane") as HTMLElement).hidden = false;
+  document.documentElement.style.setProperty("--accent", accentFor(path));
+  if (changed) { days = []; heads = []; facts = null; openDays.clear(); openView = null; }
+  host.renderAll();
+  void loadDash();
+}
+
+export function closeDashboard(): void {
+  if (!dashMirror()) return;
+  setMirror(null);
+  openView = null;
+  ($("dashPane") as HTMLElement).hidden = true;
+  // The collapsed rail is a dashboard-only mode: left set, the next session would get
+  // a 44px inspector holding the wrong buttons.
+  $("app").classList.remove("insp-mini");
+}
+
+/// Esc steps out one layer at a time — the enlarge overlay first, then the pane. Same
+/// rule as the commit graph's message overlay, which is why main.ts calls this rather
+/// than closeDashboard.
+export function dashEscape(): boolean {
+  if (!dashMirror()) return false;
+  if (openView) { openView = null; renderDash(); return true; }
+  closeDashboard();
+  host.renderAll();
+  return true;
+}
+
+// ---------- events ----------
+/// One delegated listener on the pane, bound once at import: the contents are
+/// re-rendered wholesale on every change, so per-element handlers would be rebound on
+/// each repaint and leak.
+export function wireDashboard(): void {
+  $("dashPane").addEventListener("click", (e) => {
+    const t = e.target as HTMLElement;
+    const range = t.closest<HTMLElement>("[data-dashrange]");
+    if (range) { setDashRange(+range.dataset.dashrange!); return; }
+
+    const more = t.closest<HTMLElement>("[data-dashopen]");
+    if (more) {
+      const k = more.dataset.dashopen!;
+      if (openDays.has(k)) openDays.delete(k); else openDays.add(k);
+      renderDash();
+      return;
+    }
+    const view = t.closest<HTMLElement>("[data-dashopen-view]");
+    if (view) { openView = view.dataset.dashopenView as typeof openView; renderDash(); return; }
+    if (t.closest("[data-dashclose-view]")) { openView = null; renderDash(); return; }
+
+    const drop = t.closest<HTMLElement>("[data-dashdrop]");
+    if (drop) { removeNote(drop.dataset.dashdrop!); renderDash(); return; }
+    const disp = t.closest<HTMLElement>("[data-dashdispatch]");
+    if (disp) { void dispatchNote(disp.dataset.dashdispatch!); return; }
+
+    const wtadd = t.closest<HTMLElement>("[data-dashwtadd]");
+    if (wtadd) { void host.launch(name(), wtadd.dataset.dashwtadd!, { colorKey: root() }); return; }
+    const wtterm = t.closest<HTMLElement>("[data-dashwtterm]");
+    if (wtterm) { host.openTerminal(wtterm.dataset.dashwtterm!); return; }
+  });
+
+  ($("dashJotHost") as HTMLElement).addEventListener("submit", (e) => {
+    const form = (e.target as HTMLElement).closest("#dashJot");
+    if (!form) return;
+    e.preventDefault();
+    const input = $("dashNote") as HTMLInputElement;
+    if (addNote(input.value, root())) { input.value = ""; renderDash(); }
+  });
+
+  // The inspector and its collapsed strip both emit data-dashact; one handler for the
+  // pair, bound on the persistent hosts rather than on the markup they rebuild.
+  for (const id of ["inspector", "dashStrip"]) {
+    $(id).addEventListener("click", (e) => {
+      const a = (e.target as HTMLElement).closest<HTMLElement>("[data-dashact]");
+      if (!a || !dashMirror()) return;
+      dashAction(a.dataset.dashact!);
+    });
+  }
+}
+
+function dashAction(act: string): void {
+  const r = root(), n = name();
+  if (act === "launch") void host.launch(n, r, { colorKey: r });
+  else if (act === "worktree") host.openWorktreeDialog(n, r);
+  else if (act === "terminal") host.openTerminal(r);
+  else if (act === "run") host.openRun(r);
+  else if (act === "graph") host.openGraph(r);
+  else if (act === "history") host.openHistory(r);
+  else if (act === "folder") host.openFolder(r);
+  else if (act === "copypath") host.copyPath(r);
+}
+
+/// Turn a note into a running agent. The text is typed in **without a trailing
+/// newline**: Episko prefills, the human presses Enter — the same rule as the
+/// run-on-stop handoff, and for the same reason.
+async function dispatchNote(id: string): Promise<void> {
+  const n = noteList(root()).find((x) => x.id === id);
+  if (!n) return;
+  const sid = await host.launch(name(), root(), { colorKey: root() });
+  removeNote(id);
+  renderDash();
+  if (typeof sid !== "string") { toast("Dispatched — the note is now a session"); return; }
+  // Claude's REPL needs a moment before it will accept input. Failing to type is
+  // harmless: the session is open and the note text is in the toast.
+  setTimeout(() => {
+    void invoke("write_pty", { sessionId: sid, data: n.text.replace(/\n/g, " ") }).catch(() => {});
+  }, 1400);
+  toast("Dispatched — prefilled, press Enter to send");
+}
+
+/// Offer to start writing the shared work log. Called from the ⤢ notes overlay's
+/// footer and from Settings; asks once per project because it creates a committable
+/// file in someone's repo.
+export async function enableDigest(): Promise<void> {
+  const r = root();
+  if (!r || !canShare(tier)) return;
+  allowDigest(r);
+  const done = [...summaries.entries()].filter(([k]) => days.some((d) => d.key === k && dayIsClosed(d)));
+  for (const [k, line] of done) {
+    await invoke("write_digest", { root: r, key: k, line, create: true }).catch((e) => dlog("warn", `digest: ${e}`));
+  }
+  hasDigest = true;
+  toast(`Work log written to .episko/digest.md — commit it to share`);
+  host.renderAll();
+}
+export const digestAllowed = (r: string) => digestOk().includes(r);

--- a/src/dashview.ts
+++ b/src/dashview.ts
@@ -1,0 +1,292 @@
+// The project dashboard's markup. Data in, string out — no `$()`, no `innerHTML`, no
+// renderer call, the same contract as ./sidebarview, ./inspectorview and ./usageview.
+// ./dash owns the rules and ./dashboard owns the pane, the IPC and the events.
+//
+// Untested by design, like every other *view module: snapshotting template literals
+// mostly re-asserts itself.
+
+import { basename, esc, relTime, sparkline, tilde, uUsd2 } from "./format";
+import type { Pulse, ProjectFacts, ProjectTier } from "./dash";
+import type { Note } from "./notes";
+import type { TrailCommit, TrailDay, TrailSession } from "./trail";
+import type { WtHead } from "./types";
+
+const WEEKDAY = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+// ---------- the pulse strip ----------
+// Five numbers before any detail, so the window answers itself at a glance. Which five
+// depends on the tier: a folder with no git has no commits to count, and showing a
+// permanent zero there would read as "nothing happened" rather than "not applicable".
+
+function tile(k: string, v: string, d = ""): string {
+  return `<div class="db-tile"><span class="k">${esc(k)}</span><span class="v">${v}</span>`
+    + (d ? `<span class="d">${d}</span>` : "") + `</div>`;
+}
+
+export function pulseHtml(p: Pulse, tier: ProjectTier, range: number, dense: number[]): string {
+  const tiles: string[] = [];
+  if (tier !== "none") {
+    tiles.push(`<div class="db-tile"><span class="k">Commits</span><span class="v">${p.commits}</span>`
+      + `<span class="db-spark mono" aria-hidden="true">${esc(sparkline(dense))}</span></div>`);
+  }
+  tiles.push(tile("Sessions", String(p.sessions), `${range} days`));
+  // Spend is per-project and only exists from the day the detail rollup started. A
+  // dash rather than $0.00 — "we didn't keep this" and "it was free" are different
+  // facts and the strip must not conflate them.
+  tiles.push(tile("Agent spend", p.spend > 0 ? esc(uUsd2(p.spend)) : `<span class="dim">—</span>`));
+  if (tier !== "none") {
+    const who = p.authors.length
+      ? esc(p.authors.slice(0, 2).map((a) => a.split(/\s+/)[0]).join(", ")) + (p.authors.length > 2 ? ` +${p.authors.length - 2}` : "")
+      : `<span class="dim">—</span>`;
+    tiles.push(tile("Contributors", String(p.authors.length), who));
+  }
+  return `<div class="db-pulse" data-tiles="${tiles.length + 1}">${tiles.join("")}
+    <div class="db-tile win"><span class="db-seg">
+      ${[7, 14, 30].map((r) => `<button${r === range ? ` class="on"` : ""} data-dashrange="${r}">${r}d</button>`).join("")}
+    </span></div></div>`;
+}
+
+// ---------- the timeline ----------
+
+/// A generated sentence is marked, always. The reader has to be able to tell what the
+/// app observed from what a model wrote about it, and the mark is the only difference
+/// between a log and a claim.
+export function dayHtml(d: TrailDay, summary: string | null, headline: string, open: boolean): string {
+  const dt = new Date(d.when);
+  const rows = dayRows(d);
+  const hidden = rows.length;
+  return `<div class="db-day${open ? " open" : ""}" data-dashday="${esc(d.key)}">
+    <div class="db-gut">
+      <span class="dd">${WEEKDAY[dt.getDay()]} ${dt.getDate()}</span>
+      ${d.cost > 0 ? `<span class="cc">${esc(uUsd2(d.cost))}</span>` : ""}
+    </div>
+    <div class="db-dbody">
+      <p class="db-sum">${esc(summary || headline)}${summary ? `<span class="ai">· ai</span>` : ""}</p>
+      <div class="db-facts">
+        ${d.commits.length ? `<span>${d.commits.length} commit${d.commits.length === 1 ? "" : "s"}</span>` : ""}
+        ${d.commits.length && d.sessions.length ? `<span class="dot">·</span>` : ""}
+        ${d.sessions.length ? `<span>${d.sessions.length} session${d.sessions.length === 1 ? "" : "s"}</span>` : ""}
+        ${authorsOf(d)}
+        ${hidden ? `<button class="db-more" data-dashopen="${esc(d.key)}">${hidden} more <span class="cv">⌄</span></button>` : ""}
+      </div>
+      ${hidden ? `<div class="db-detail"><div><div class="db-rows">${rows.join("")}</div></div></div>` : ""}
+    </div>
+  </div>`;
+}
+
+function authorsOf(d: TrailDay): string {
+  const who = [...new Set(d.commits.map((c) => c.author.split(/\s+/)[0]))];
+  if (!who.length) return "";
+  return `<span class="dot">·</span><span class="who">${esc(who.slice(0, 3).join(", "))}</span>`;
+}
+
+/// One time-ordered list, sessions and commits mixed. Not sessions-then-commits: a
+/// session at 09:00 and the commit it produced at 09:05 are a cause and its effect,
+/// and listing all the causes then all the effects breaks the only ordering that
+/// explains the day. (Same rule as ./trail's `dayItems`, restated per project.)
+function dayRows(d: TrailDay): string[] {
+  const items: { when: number; html: string }[] = [
+    ...d.sessions.map((s) => ({ when: s.when, html: sessionRow(s) })),
+    ...d.commits.map((c) => ({ when: c.when * 1000, html: commitRow(c) })),
+  ];
+  return items.sort((a, b) => b.when - a.when).map((i) => i.html);
+}
+
+const clock = (ms: number) => new Date(ms).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+
+function sessionRow(s: TrailSession): string {
+  return `<div class="db-item"><span class="db-kind sess">session</span>`
+    + `<span class="db-t" title="${esc(s.title)}">${esc(s.title)}</span>`
+    + `<span class="db-r">${clock(s.when)}</span></div>`;
+}
+function commitRow(c: TrailCommit): string {
+  return `<div class="db-item" data-dashsha="${esc(c.sha)}" title="${esc(`${c.subject} — ${c.author}`)}">`
+    + `<span class="db-kind">commit</span>`
+    + `<span class="db-t">${esc(c.subject)}</span>`
+    + `<span class="db-r">${clock(c.when * 1000)}</span></div>`;
+}
+
+// ---------- the aside ----------
+// Four compact cards at most, each one line per row and each with a ⤢ that opens the
+// same detail overlay. A card appears when it has something to say and is absent
+// otherwise: an empty panel reads as breakage, not as an honest blank.
+
+function card(id: string, title: string, count: string, body: string, enlarge = true): string {
+  return `<div class="ac"><div class="ac-h"><span class="t">${esc(title)}</span>`
+    + `<span class="n">${esc(count)}</span>`
+    + (enlarge ? `<button class="xb" data-dashopen-view="${id}" title="See all">⤢</button>` : "")
+    + `</div><div class="ac-b">${body}</div></div>`;
+}
+
+/// A checkout row. Branch and one piece of state — anything more (ahead/behind,
+/// merged) costs a `git` process per checkout, which is what the ⑃ dialog is for.
+function checkoutRow(w: WtHead, live: number, dirty: boolean, main: boolean): string {
+  const tag = live ? `<span class="tag acc">${live} live</span>`
+    : dirty ? `<span class="tag warn">dirty</span>`
+    : `<span class="tag ok">clean</span>`;
+  return `<div class="cr" data-dashwt="${esc(w.path)}" title="${esc(tilde(w.path))}">`
+    + `<span class="k">${main ? "⌂" : "⑃"}</span>`
+    + `<span class="ti mono">${esc(w.branch || basename(w.path))}</span>`
+    + `<span class="rt">${tag}</span></div>`;
+}
+
+export function checkoutsCard(
+  heads: WtHead[],
+  liveFor: (path: string) => number,
+  dirtyFor: (path: string) => boolean,
+): string {
+  if (heads.length < 2) return ""; // one checkout is not a list worth a card
+  const rows = heads.map((w) => checkoutRow(w, liveFor(w.path), dirtyFor(w.path), w.is_main)).join("");
+  return card("checkouts", "Checkouts", String(heads.length), rows);
+}
+
+function noteRow(n: Note): string {
+  return `<div class="nt" data-dashnote="${esc(n.id)}">
+    <span class="ntx"><span class="tx">${esc(n.text)}</span>
+      <span class="mt"><span>${esc(relTime(n.created))}</span></span></span>
+    <span class="nt-b">
+      <button class="nb" data-dashdispatch="${esc(n.id)}" title="Start an agent on this">▶</button>
+      <button class="nb" data-dashdrop="${esc(n.id)}" title="Delete">✕</button>
+    </span></div>`;
+}
+
+export function notesCard(notes: Note[]): string {
+  const body = notes.length
+    ? notes.slice(0, 3).map(noteRow).join("")
+    : `<div class="ac-empty">Nothing queued. Jot the next thing above.</div>`;
+  return `<div class="ac"><div class="ac-h"><span class="t">Notes</span>
+      <span class="n">${notes.length}</span>
+      <button class="xb" data-dashopen-view="notes" title="Open the notes board">⤢</button></div>
+    <form class="nt-form" id="dashJot">
+      <input id="dashNote" placeholder="What's next here?" autocomplete="off" />
+      <button type="submit" title="Add">＋</button>
+    </form>
+    <div class="ac-b">${body}</div></div>`;
+}
+
+/// What this folder can't do, said once and plainly. Rendered *instead of* the cards
+/// it replaces, never alongside empty ones.
+export function missingCard(tier: ProjectTier, f: ProjectFacts | null): string {
+  if (tier === "github") return "";
+  if (tier === "git") {
+    const where = f?.host ? `<code>${esc(f.host)}</code>` : "no remote at all";
+    return `<div class="miss"><span class="t">Not on GitHub</span>
+      <p>Issues, pull requests and claims need a GitHub remote — this project's origin is ${where}.
+         Those cards are absent rather than empty.</p>
+      <p><b>Sharing still works.</b> <code>.episko/</code> is committed like any other file, so the
+         work log reaches whoever pulls. GitHub was never what made it shared.</p></div>`;
+  }
+  return `<div class="miss"><span class="t">Not a repository</span>
+    <p>The timeline is still real — sessions and spend come from Claude's own transcripts, which never
+       needed git. What's missing is the commit half: no checkouts, no contributors, no work log.</p>
+    <p>Notes stay on this machine: there is nothing to commit <code>.episko/</code> into.</p></div>`;
+}
+
+// ---------- the inspector: the project's context menu, standing open ----------
+
+export function dashInspector(
+  root: string, tier: ProjectTier, f: ProjectFacts | null,
+  live: { id: string; label: string; glyph: string; cls: string; ctx: string }[],
+  shared: boolean,
+): string {
+  const act = (a: string, ic: string, lb: string, sb = "", cls = "") =>
+    `<button class="ia ${cls}" data-dashact="${a}"><span class="ic">${ic}</span>`
+    + `<span><span class="lb">${esc(lb)}</span>${sb ? `<span class="sb">${esc(sb)}</span>` : ""}</span></button>`;
+  const chips = [
+    f?.slug ? `<span class="chip">${esc(f.slug)}</span>` : "",
+    f?.host && !f.slug ? `<span class="chip">${esc(f.host)}</span>` : "",
+    tier === "none" ? `<span class="chip warn">not a repo</span>` : "",
+    shared ? `<span class="chip acc" title="This project has a committed .episko/digest.md">.episko/ shared</span>` : "",
+  ].filter(Boolean).join("");
+  return `
+    ${live.length ? `<div><span class="label">Running here</span><div class="ip-live">${live.map((s) =>
+      `<div class="srow" data-sel="${esc(s.id)}"><span class="sglyph ${s.cls}">${s.glyph}</span>`
+      + `<span class="sbranch">${esc(s.label)}</span><span class="sctx">${esc(s.ctx)}</span></div>`).join("")}</div></div>` : ""}
+    <div><span class="label">Do something here</span><div class="ip-acts">
+      ${act("launch", "＋", "New session", live.length ? `${live.length} already running here` : "start Claude Code in this folder")}
+      ${tier !== "none" ? act("worktree", "⑃", "New worktree session…", "on a branch of its own") : ""}
+      ${act("terminal", "❯", "Open terminal here")}
+      ${act("run", "▶", "Run a task…")}
+      <div class="ip-sep"></div>
+      ${tier !== "none" ? act("graph", "⑂", "Commit graph…", "history, branches, merges") : ""}
+      ${act("history", "◷", "History…", "reopen a session you closed")}
+      ${act("folder", "⌂", "Open project folder")}
+      ${act("copypath", "⧉", "Copy path")}
+    </div></div>
+    ${chips ? `<div><span class="label">Repository</span><div class="db-chips">${chips}</div></div>` : ""}
+    <p class="ihint">${esc(tilde(root))}</p>`;
+}
+
+/// The 44px rail ⌘I collapses to on this view. It exists because the inspector holds
+/// the ONLY copy of History / Terminal / Run here — the dashboard header gave them up
+/// — so collapsing to nothing would hide real verbs. The live-session glyphs stay at
+/// the top, so the one thing the lighter header gave up (noticing something needs you)
+/// survives the collapse.
+export function dashStrip(
+  accent: string, initial: string, tier: ProjectTier,
+  live: { id: string; glyph: string; cls: string; label: string }[],
+): string {
+  const b = (a: string, ic: string, t: string, cls = "") =>
+    `<button class="isb ${cls}" data-dashact="${a}" title="${esc(t)}">${ic}</button>`;
+  return `<span class="sglyphs">
+      <span class="pglyph" style="background:${esc(accent)}">${esc(initial)}</span>
+      ${live.map((s) => `<button class="isb live ${s.cls}" data-sel="${esc(s.id)}" title="${esc(s.label)}">${s.glyph}</button>`).join("")}
+    </span>
+    ${b("launch", "＋", "New session")}
+    ${tier !== "none" ? b("worktree", "⑃", "New worktree session…") : ""}
+    ${b("terminal", "❯", "Open terminal here")}
+    ${b("run", "▶", "Run a task…")}
+    <span class="isep"></span>
+    ${tier !== "none" ? b("graph", "⑂", "Commit graph…") : ""}
+    ${b("history", "◷", "History…")}
+    ${b("folder", "⌂", "Open project folder")}
+    ${b("copypath", "⧉", "Copy path")}`;
+}
+
+// ---------- the enlarge overlay ----------
+// One component, N contents — title, subtitle, ✕ Close, and a footer stating the one
+// non-obvious rule. It covers the dashboard rather than replacing it, and Esc steps
+// out one layer, the same as the commit graph's message overlay.
+
+export function overlayHtml(title: string, sub: string, body: string, foot: string): string {
+  return `<div class="ovl-h"><span class="t">${esc(title)}</span><span class="s">${esc(sub)}</span>
+      <span class="rt"><button class="act" data-dashclose-view>✕<span class="txt"> Close</span></button></span></div>
+    <div class="ovl-b">${body}</div>
+    ${foot ? `<div class="ovl-f">${foot}</div>` : ""}`;
+}
+
+/// Checkouts, enlarged: the ⑃ dialog's facts without the dialog. One fixed column
+/// geometry for every row — `auto` would let each row size to its own tag and the
+/// columns would stagger, which is the trap the commit graph's row grid documents.
+export function checkoutsOverlay(
+  heads: WtHead[], liveFor: (p: string) => number, dirtyFor: (p: string) => boolean,
+): string {
+  const rows = heads.map((w) => {
+    const live = liveFor(w.path), dirty = dirtyFor(w.path);
+    return `<div class="dbwt" data-dashwt="${esc(w.path)}">
+      <span class="gl">${w.is_main ? "⌂" : "⑃"}</span>
+      <span class="bn mono">${esc(w.branch || basename(w.path))}</span>
+      <span class="pt mono">${esc(tilde(w.path))}</span>
+      <span class="tags">${live ? `<span class="tag acc">${live} live</span>` : ""}${dirty ? `<span class="tag warn">uncommitted</span>` : `<span class="tag ok">clean</span>`}</span>
+      <span class="acts"><button class="act" data-dashwtadd="${esc(w.path)}" title="New session here">＋</button>
+        <button class="act" data-dashwtterm="${esc(w.path)}" title="Open a terminal here">❯</button></span>
+    </div>`;
+  }).join("");
+  return overlayHtml("Checkouts", `${heads.length} · ${heads.filter((w) => liveFor(w.path)).length} with sessions`,
+    `<div class="dbwt-hd"><span></span><span>Branch</span><span>Folder</span><span>State</span><span class="r">Actions</span></div>${rows}`,
+    `Creating a worktree, pruning a stale one and every warning about a locked or detached checkout stay in the <b>⑃ dialog</b>, which already does all of that. This is a status board.`);
+}
+
+export function notesOverlay(notes: Note[], shared: boolean): string {
+  const body = notes.length
+    ? `<div class="ncol">${notes.map((n) => `<div class="ncard" data-dashnote="${esc(n.id)}">
+        <span class="tx">${esc(n.text)}</span>
+        <span class="mt"><span>${esc(relTime(n.created))}</span></span>
+        <span class="bar"><button class="act" data-dashdispatch="${esc(n.id)}">▶ Start an agent</button>
+          <button class="act" data-dashdrop="${esc(n.id)}">✕</button></span></div>`).join("")}</div>`
+    : `<div class="ac-empty">Nothing queued yet.</div>`;
+  return overlayHtml("Notes", `${notes.length} on this project`, body,
+    shared
+      ? `Notes are yours alone. The committed half of <code>.episko/</code> is the work log; sharing a note is a separate switch and is not in this build yet.`
+      : `Notes stay on this machine — there is no repository to commit them into.`);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,8 @@ import { applyFontSize, bumpFont, refit } from "./terminal";
 import {
   addProject, addProjectPath, cycleSort, effectiveTheme, openProjectFolder,
   followSessionDrift, removeFavorite, resolvePermission, revealActiveFolder,
-  setActionsRenderAll, setPermMode, setSort, setTheme, setWtGroup, toggleInsp,
+  copyPath, openTerminalIn, setActionsRenderAll, setPermMode, setSort, setTheme,
+  setWtGroup, toggleInsp,
   toggleRail, toggleTheme,
 } from "./actions";
 import {
@@ -49,8 +50,8 @@ import {
   setReorderGuard, setSidebarRenderAll, setSidebarSetSort,
 } from "./sidebar";
 import {
-  closeBranchPop, closeWt, setWtCloseSession, setWtHandToTerminal, setWtLaunch,
-  setWtRefreshGit, setWtRenderAll, setWtSetActive,
+  closeBranchPop, closeWt, openWt as openWtDlg, setWtCloseSession, setWtHandToTerminal,
+  setWtLaunch, setWtRefreshGit, setWtRenderAll, setWtSetActive,
 } from "./worktree";
 import {
   dbgLog, dbgSnapshot, dlog, flushDebug, renderDbgBadge, renderDbgPanel, telem,
@@ -63,7 +64,11 @@ import { closeDiff, diffOpen, openDiff, setDiffCloseFootMenus } from "./diffview
 // The commit-graph panel needs nothing from here — it is opened from the project
 // context menu (./projmenu) and owns its own handlers; this file only has to close it
 // with the shared scrim and Esc, like every other dialog.
-import { closeGraph, graphEscape, graphOpen } from "./graphview";
+import { closeGraph, graphEscape, graphOpen, openGraph as openGraphFor } from "./graphview";
+import {
+  closeDashboard, dashEscape, openDashboard, renderDash, renderDashHeader,
+  renderDashInspector, setDashHost, wireDashboard,
+} from "./dashboard";
 import {
   closeInputPrompt, closeRunPicker, closeTaskManager, mgrEdit, openRunPicker,
   renderMgr, setMgrEdit, setTaskUiHost,
@@ -78,8 +83,9 @@ import {
   setPhase,
 } from "./phase";
 import {
-  activeId, ALL_ENGINES, availEngines, dormants, externals, extMirrorId, FAVORITES,
-  markWorkdirStale, mirror, pastMirrorId, sessions, setAvailEngines, setTermEngine,
+  activeId, ALL_ENGINES, availEngines, dashMirror, dormants, externals, extMirrorId,
+  FAVORITES, markWorkdirStale, mirror, pastMirrorId, sessions, setAvailEngines,
+  setTermEngine,
   setTermFontSize, sortMode, termEngine,
 } from "./state";
 import { orderedSessions } from "./grouping";
@@ -219,6 +225,21 @@ setSettingsHost({
 });
 // The task panels run tasks, hand commands to terminals and put panes on stage —
 // none of which they own.
+// The dashboard acts on a project through verbs it does not own — the launcher, the
+// worktree dialog, the task picker, the graph and History all live elsewhere.
+setDashHost({
+  launch: (project, workdir, opts) => launch(project, workdir, opts),
+  openWorktreeDialog: (project, root) => { void openWtDlg(project, root); },
+  openTerminal: (dir) => { openTerminalIn(dashMirror()?.name ?? basename(dir), dir); },
+  openRun: () => { void openRunPicker(); },
+  openGraph: (root) => { void openGraphFor(root, dashMirror()?.name ?? basename(root)); },
+  openHistory: () => { void openHistory(true); },
+  openFolder: (dir) => { void openProjectFolder(dir); },
+  copyPath: (dir) => { void copyPath(dir); },
+  setActive,
+  renderAll,
+});
+wireDashboard();
 setCafHost({ closeFootMenus, renderFoot, renderAll });
 setDiffCloseFootMenus(closeFootMenus);
 setTaskUiHost({
@@ -336,7 +357,9 @@ function renderAll() {
   // belong to that external — render it, NOT the null "no session" state. Skipping
   // this is what let a background Episko session's telemetry tick blank the
   // external header/inspector ~1s after clicking it.
-  if (pastMirrorId()) {
+  if (dashMirror()) {
+    renderDashHeader(); renderDashInspector(); renderDash();
+  } else if (pastMirrorId()) {
     const d = dormants.find((x) => x.id === pastMirrorId());
     if (d) { renderPastHeader(d); renderPastInspector(d); }
   } else if (extMirrorId()) {
@@ -488,6 +511,10 @@ document.addEventListener("click", (e) => {
   else if (el.dataset.ext) openExternal(el.dataset.ext);
   else if (el.dataset.past) openDormant(el.dataset.past);
   else if (el.dataset.sel) { setActive(el.dataset.sel); closeAttnPop(); }
+  // A project header. This used to select whichever session sorted first, so one
+  // click meant two different things depending on state; it now opens the project
+  // dashboard, and the sessions are the rows directly beneath it.
+  else if (el.dataset.dash) { openDashboard(el.dataset.proj || basename(el.dataset.dash), el.dataset.dash); closeAttnPop(); }
   // A launch into one specific checkout. Unlike data-launch this keeps colorKey pinned
   // to the repo root (data-root), so the new session joins the project it belongs to
   // rather than becoming a project of its own — the same contract the ⑃ dialog uses.
@@ -557,7 +584,12 @@ initHistoryEvents();
 $("btnRun").addEventListener("click", () => { void openRunPicker(); });
 $("setClose").addEventListener("click", closeSettings);
 $("fRepo").addEventListener("click", (e) => { e.preventDefault(); openUrl("https://github.com/respeak-io/episko").catch(() => {}); });
-$("btnClose").addEventListener("click", () => { if (activeId) closeSession(activeId); });
+// ✕ closes whatever is on the stage. On the dashboard that is the dashboard — it
+// does not touch the project.
+$("btnClose").addEventListener("click", () => {
+  if (dashMirror()) { closeDashboard(); renderAll(); return; }
+  if (activeId) closeSession(activeId);
+});
 
 $("scrim").addEventListener("click", () => { closePalette(); closeWt(); closeDiff(); closeGraph(); closeSettings(); closeRunPicker(); closeInputPrompt(); closeTaskManager(); closeHistory(); });
 window.addEventListener("keydown", (e) => {
@@ -580,6 +612,9 @@ window.addEventListener("keydown", (e) => {
   // step out of that first.
   else if (e.key === "Escape" && graphOpen) { e.preventDefault(); graphEscape(); }
   else if (e.key === "Escape" && settingsOpen()) { e.preventDefault(); closeSettings(); }
+  // dashEscape, not closeDashboard: an enlarge overlay can be up over the pane and
+  // Esc has to take that first. Same rule as graphEscape above.
+  else if (e.key === "Escape" && dashMirror()) { e.preventDefault(); dashEscape(); }
   else if (e.key === "Escape" && $("mgrDlg").classList.contains("show")) { e.preventDefault(); if (mgrEdit) { setMgrEdit(null); renderMgr(); } else closeTaskManager(); }
 });
 // ⌘⏎ — reveal the current selection's folder. Deliberately a *second* listener, in the

--- a/src/mirror.ts
+++ b/src/mirror.ts
@@ -169,6 +169,10 @@ export function closeExternalView() {
   setMirror(null);   // clears the ext pid with it — one pointer, one lifetime
   clearInterval(extTranscriptTimer);
   ($("extPane") as HTMLElement).hidden = true;
+  // The dashboard rides the same pointer, so it has the same lifetime: whatever took
+  // the stage just replaced it. Hidden here rather than through ./dashboard so this
+  // module keeps no dependency on it — one `hidden` flag is not worth an import edge.
+  ($("dashPane") as HTMLElement).hidden = true;
 }
 // ---------- dormant (restorable) sessions ----------
 // Clicking a dormant row mirrors its transcript read-only — the same pane an

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -1,0 +1,96 @@
+// Notes — the one part of the Trail you type.
+//
+// A note is **a thread with no agent yet**: something you want done, written down
+// before anyone starts it. That framing is the whole point — a note is not a separate
+// kind of object to be reconciled later, it is the same work item at an earlier
+// stage, which is why dispatching one turns it into a session rather than copying it
+// somewhere.
+//
+// WHY CAPTURE MUST BE FREE. One field, one key, no form. An idea you have to
+// categorise is an idea you don't write down, so `project` is optional and everything
+// else is derived. The cost of a wrong or unfiled note is that you delete it later;
+// the cost of friction is that the thought is gone.
+//
+// PERSONAL, NOT SHARED. This is `localStorage`, following the split the app already
+// draws everywhere else — personal preference in `cc-*`, project fact in `.episko/`.
+// Half-formed thoughts are not a teammate's business, and a note only becomes shared
+// when you promote it (which, once the board exists, means writing a card). Keeping
+// that boundary here means the board can never accidentally publish your scratchpad.
+//
+// No DOM and no Tauri, so it tests in isolation; ./trailui owns the markup.
+
+/// One captured intention. `project` is a colorKey (the sidebar's own grouping id),
+/// null when the note isn't about anything in particular yet.
+export interface Note {
+  id: string;
+  text: string;
+  project: string | null;
+  created: number;
+}
+
+const KEY = "cc-notes";
+
+/// Ids only have to be unique within one machine's `localStorage`, so this is a
+/// timestamp plus a short random tail rather than a uuid — no import, no ceremony,
+/// and still collision-free for two notes jotted in the same millisecond.
+const newId = () => `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 7)}`;
+
+// Read once at module load, like every other cc-* store in ./state. A corrupt or
+// hand-edited value must not take the app down with it, so a bad parse degrades to an
+// empty list rather than throwing during import.
+function load(): Note[] {
+  try {
+    const raw = JSON.parse(localStorage.getItem(KEY) || "[]");
+    if (!Array.isArray(raw)) return [];
+    return raw.filter((n): n is Note => !!n && typeof n.id === "string" && typeof n.text === "string");
+  } catch {
+    return [];
+  }
+}
+
+export let notes: Note[] = load();
+
+function save() { localStorage.setItem(KEY, JSON.stringify(notes)); }
+
+/** Newest first — the order the Trail shows them in, and the order they were meant. */
+export function noteList(project?: string | null): Note[] {
+  const all = [...notes].sort((a, b) => b.created - a.created);
+  return project ? all.filter((n) => n.project === project) : all;
+}
+
+/** Capture. Returns null for an empty jot so the caller needn't test first. */
+export function addNote(text: string, project: string | null = null): Note | null {
+  const t = text.trim();
+  if (!t) return null;
+  const n: Note = { id: newId(), text: t, project, created: Date.now() };
+  notes.unshift(n);
+  save();
+  return n;
+}
+
+/** Remove one — used both by an explicit delete and by dispatching it into a session,
+ *  because a note that has become an agent is no longer waiting to be started. */
+export function removeNote(id: string): Note | null {
+  const i = notes.findIndex((n) => n.id === id);
+  if (i < 0) return null;
+  const [n] = notes.splice(i, 1);
+  save();
+  return n;
+}
+
+export function noteById(id: string): Note | null {
+  return notes.find((n) => n.id === id) || null;
+}
+
+/** Re-file a note onto a project (or off one). */
+export function setNoteProject(id: string, project: string | null): void {
+  const n = noteById(id);
+  if (!n) return;
+  n.project = project;
+  save();
+}
+
+/// Test seam: reset module state from storage. Nothing in the app calls this — the
+/// store is read once at load like its neighbours — but a test that writes
+/// `localStorage` needs a way to re-read it.
+export function reloadNotes(): void { notes = load(); }

--- a/src/projmenu.ts
+++ b/src/projmenu.ts
@@ -16,6 +16,7 @@ import { closeFootMenus } from "./footer";
 import { openGraph } from "./graphview";
 import { clearIcon, customIcons, iconFor, pickCustomIcon, resetCustomIcon } from "./icons";
 import { openWt, removeWorktreeAt } from "./worktree";
+import { copyPath, openTerminalIn } from "./actions";
 import { isAgent } from "./types";
 import {
   accentFor, activeId, colorOverrides, engineDef, externals, FAVORITES, sessions,
@@ -257,17 +258,6 @@ $("ctxMenu").addEventListener("click", (e) => {
     case "wtremove": void removeWorktreeAt(t.project, t.root, t.dir, t.branch); break;
   }
 });
-
-// A plain shell in this project's folder — embedded gets an in-app pane, the
-// external engines their own window (the same split as openPlainTerminal).
-function openTerminalIn(project: string, dir: string) {
-  if (termEngine !== "embedded") { invoke("open_terminal_here", { workdir: dir, engine: termEngine }).catch((e) => toast("terminal: " + e)); return; }
-  void host.launchShell(project, dir, { colorKey: dir });
-}
-async function copyPath(dir: string) {
-  try { await navigator.clipboard.writeText(dir); toast("Path copied"); }
-  catch { toast(dir); } // clipboard denied — at least show what it was
-}
 
 // Appearance is the one row that opens rather than commits: the menu stays put and
 // the swatch panel hangs off its edge. Re-entrant — `mouseover` fires again for

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -84,10 +84,10 @@ export function renderSidebar() {
     const wtSuffix = p.wtBranch ? `<span class="pwt">· ${esc(p.wtBranch)}</span>` : "";
     let head: string;
     if (p.sessions.length) {
-      head = `<div class="phead" data-sel="${p.sessions[0].id}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}${wtSuffix}</span>${dot}<span class="pcount">${total}</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}">＋</span></div>`;
+      head = `<div class="phead" data-dash="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}${wtSuffix}</span>${dot}<span class="pcount">${total}</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}">＋</span></div>`;
     } else if (isFav) {
-      const tail = p.externals.length ? `<span class="pcount ext">${p.externals.length} ext</span>` : `<span class="plaunch">launch →</span>`;
-      head = `<div class="phead empty-p" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="premove" data-remove="${esc(p.path)}" title="Remove project">✕</span></div>`;
+      const tail = p.externals.length ? `<span class="pcount ext">${p.externals.length} ext</span>` : `<span class="plaunch">open →</span>`;
+      head = `<div class="phead empty-p" data-dash="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="premove" data-remove="${esc(p.path)}" title="Remove project">✕</span></div>`;
     } else {
       // discovered via an external session or a restorable one only — not a saved project
       const tail = p.externals.length

--- a/src/state.ts
+++ b/src/state.ts
@@ -101,11 +101,19 @@ export function setActiveId(id: string | null) { activeId = id; }
 // what stays stable, so refreshExternals re-binds through it instead of dropping
 // the selection (which used to silently jump the sidebar to an unrelated session).
 // Same rule as Sess.resumeId and the telemetry path: hold the stable handle.
-export let mirror: { kind: "ext"; id: string; pid: number } | { kind: "past"; id: string } | null = null;
+export let mirror:
+  | { kind: "ext"; id: string; pid: number }
+  | { kind: "past"; id: string }
+  // The project dashboard. Not a session at all, but it owns the stage exactly the way
+  // the read-only mirrors do — so it joins this discriminated pointer rather than
+  // becoming a second flag every `activeId` check would have to be paired with.
+  | { kind: "dash"; root: string; name: string }
+  | null = null;
 export function setMirror(m: typeof mirror) { mirror = m; }
 export const extMirrorId = (): string | null => (mirror?.kind === "ext" ? mirror.id : null);
 export const extMirrorPid = (): number | null => (mirror?.kind === "ext" ? mirror.pid : null);
 export const pastMirrorId = (): string | null => (mirror?.kind === "past" ? mirror.id : null);
+export const dashMirror = () => (mirror?.kind === "dash" ? mirror : null);
 // Claude Code sessions started OUTSIDE Episko (a plain terminal, an IDE). We
 // discover them from ~/.claude/sessions/<pid>.json (via the backend), show them
 // in the sidebar as read-only, and can jump to their terminal window.

--- a/src/styles.css
+++ b/src/styles.css
@@ -1531,3 +1531,169 @@ select.in-ctl { cursor: pointer; }
 .fc-rec { display: flex; gap: 8px; align-items: flex-start; margin-top: 13px; font-size: 11.5px; line-height: 1.5; color: var(--muted); }
 .fc-recic { flex: none; margin-top: 1px; }
 .fc-rec b { color: var(--text); font-weight: 650; }
+
+/* ═══ the project dashboard ════════════════════════════════════════════════════
+   Opened by clicking a project. Nothing here is on renderAll's path until then —
+   #dashPane stays hidden and empty for the whole life of the app otherwise.
+   ./dash owns the rules, ./dashview the markup, ./dashboard the pane. */
+.dash-view { position: absolute; inset: 0; display: flex; flex-direction: column; min-height: 0; background: var(--bg); }
+.dash-view[hidden] { display: none; }
+.dash { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+
+/* the pulse strip — five numbers before any detail, so the window answers itself */
+.db-pulse { display: grid; grid-template-columns: repeat(auto-fit, minmax(112px, 1fr)) auto; gap: 1px; background: var(--hair); border-bottom: 1px solid var(--hair); flex: none; }
+.db-tile { padding: 9px 13px 10px; background: var(--panel); display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.db-tile .k { font-size: 9px; letter-spacing: .1em; text-transform: uppercase; color: var(--muted-2); font-weight: 700; }
+.db-tile .v { font: 700 19px var(--font-mono); letter-spacing: -.03em; line-height: 1; font-variant-numeric: tabular-nums; }
+.db-tile .d { font: 9.5px var(--font-mono); color: var(--muted-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.db-tile.win { flex-direction: row; align-items: center; padding: 9px 12px; }
+.db-spark { font-size: 12px; line-height: 1; color: var(--accent-ink); letter-spacing: -1px; }
+.dim { color: var(--muted-2); }
+/* Its own picker — `.seg` belongs to the settings window and is a flex column. */
+.db-seg { display: inline-flex; padding: 2px; border-radius: 8px; background: var(--bg-2); border: 1px solid var(--hair); gap: 1px; flex: none; }
+.db-seg button { border: 0; background: none; color: var(--muted-2); font: 600 10px var(--font-mono); padding: 3px 8px; border-radius: 6px; cursor: pointer; }
+.db-seg button.on { background: var(--accent-wash); color: var(--accent-ink); box-shadow: inset 0 0 0 1px var(--accent-line); }
+
+.db-body { display: grid; grid-template-columns: minmax(0, 1fr) 318px; flex: 1; min-height: 0; }
+.db-spine { min-width: 0; padding: 15px 17px 26px; overflow-y: auto; }
+.db-aside { min-width: 0; border-left: 1px solid var(--hair); background: color-mix(in srgb, var(--panel) 55%, transparent); padding: 12px 12px 20px; overflow-y: auto; display: flex; flex-direction: column; gap: 10px; }
+.db-empty { padding: 18px 6px; max-width: 48ch; font-size: 12px; line-height: 1.6; color: var(--muted-2); }
+
+/* the timeline: the summary IS the row, every commit one ⌄ away */
+.db-day { display: grid; grid-template-columns: 56px minmax(0, 1fr); gap: 12px; }
+.db-gut { text-align: right; padding-top: 1px; }
+.db-gut .dd { display: block; font: 700 10.5px var(--font-mono); color: var(--text); }
+.db-gut .cc { display: block; margin-top: 3px; font: 9px var(--font-mono); color: var(--muted-2); }
+.db-dbody { position: relative; min-width: 0; padding: 0 0 17px 15px; border-left: 1px solid var(--hair); }
+.db-dbody::before { content: ""; position: absolute; left: -4px; top: 4px; width: 7px; height: 7px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 0 3px var(--bg); }
+.db-day:last-child .db-dbody { padding-bottom: 2px; border-left-color: transparent; }
+.db-sum { margin: 0 0 9px; font-size: 12.5px; line-height: 1.58; color: var(--text); max-width: 64ch; }
+/* A generated sentence is marked, always: the reader has to be able to tell what the
+   app observed from what a model wrote about it. */
+.db-sum .ai { display: inline-block; margin-left: 7px; font: 8.5px var(--font-mono); letter-spacing: .09em; color: var(--muted-2); vertical-align: 1px; }
+.db-facts { display: flex; align-items: center; gap: 9px; font: 9.5px var(--font-mono); color: var(--muted-2); }
+.db-facts .dot { opacity: .4; }
+.db-facts .who { color: var(--muted); }
+.db-more { margin-left: auto; display: inline-flex; align-items: center; gap: 4px; border: 0; background: none; cursor: pointer; font: 9.5px var(--font-mono); color: var(--muted-2); padding: 2px 4px; border-radius: 5px; }
+.db-more:hover { color: var(--text); background: var(--surface); }
+.db-more .cv { transition: transform .18s ease; display: inline-block; }
+.db-day.open .db-more .cv { transform: rotate(180deg); }
+.db-detail { display: grid; grid-template-rows: 0fr; transition: grid-template-rows .24s cubic-bezier(.32,.72,0,1), opacity .18s ease; opacity: 0; }
+.db-day.open .db-detail { grid-template-rows: 1fr; opacity: 1; }
+.db-detail > div { overflow: hidden; min-height: 0; }
+.db-rows { display: flex; flex-direction: column; gap: 1px; padding-top: 8px; }
+.db-item { display: flex; align-items: center; gap: 8px; min-width: 0; padding: 3px 5px; border-radius: 6px; font-size: 11.5px; }
+.db-item:hover { background: var(--surface); }
+.db-kind { flex: none; min-width: 50px; text-align: center; padding: 1px 0; border-radius: 4px; font: 8.5px var(--font-mono); letter-spacing: .04em; text-transform: uppercase; border: 1px solid var(--hair); color: var(--muted-2); background: var(--bg-2); }
+.db-kind.sess { color: var(--st-done); border-color: color-mix(in srgb, var(--st-done) 26%, transparent); }
+.db-t { min-width: 0; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.db-r { margin-left: auto; flex: none; font: 9.5px var(--font-mono); color: var(--muted-2); }
+
+/* the aside cards. Both edge tracks of a row are FIXED — `auto` lets each row size to
+   its own tag and the columns stagger, the same trap the commit graph's grid documents. */
+.ac { border-radius: var(--radius); border: 1px solid var(--hair); background: linear-gradient(180deg, var(--lift), transparent 42%), var(--surface); overflow: hidden; flex: none; }
+.ac-h { display: flex; align-items: center; gap: 6px; padding: 7px 9px; border-bottom: 1px solid var(--hair); }
+.ac-h .t { font: 700 9.5px var(--font-ui); letter-spacing: .11em; text-transform: uppercase; color: var(--muted); white-space: nowrap; }
+.ac-h .n { margin-left: auto; font: 9.5px var(--font-mono); color: var(--muted-2); white-space: nowrap; }
+.ac-h .xb { border: 1px solid transparent; background: none; cursor: pointer; color: var(--muted-2); font-size: 11px; width: 19px; height: 19px; border-radius: 6px; display: grid; place-items: center; flex: none; }
+.ac-h .xb:hover { color: var(--accent-ink); background: var(--accent-wash); border-color: var(--accent-line); }
+.ac-b { padding: 3px; display: flex; flex-direction: column; gap: 1px; }
+.ac-empty { padding: 9px 7px; font-size: 11px; line-height: 1.5; color: var(--muted-2); }
+.cr { display: grid; grid-template-columns: 22px minmax(0, 1fr) 74px; gap: 7px; align-items: center; padding: 5px 6px; border-radius: 7px; cursor: pointer; min-width: 0; }
+.cr:hover { background: var(--surface-2); }
+.cr .k { text-align: center; font-size: 11px; color: var(--muted-2); }
+.cr .ti { min-width: 0; font-size: 11.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--muted); }
+.cr:hover .ti { color: var(--text); }
+.cr .rt { display: flex; align-items: center; justify-content: flex-end; gap: 5px; overflow: hidden; }
+.tag { flex: none; font: 9.5px var(--font-mono); padding: 1px 5px; border-radius: 5px; border: 1px solid var(--hair); color: var(--muted-2); background: var(--bg-2); white-space: nowrap; }
+.tag.ok { color: var(--st-done); border-color: color-mix(in srgb, var(--st-done) 28%, transparent); }
+.tag.warn { color: var(--st-working); border-color: color-mix(in srgb, var(--st-working) 28%, transparent); }
+.tag.acc { color: var(--accent-ink); border-color: var(--accent-line); background: var(--accent-wash); }
+
+.nt-form { display: flex; gap: 5px; padding: 4px 4px 3px; }
+.nt-form input { flex: 1; min-width: 0; height: 25px; padding: 0 9px; border-radius: 7px; font: 11.5px var(--font-ui); color: var(--text); background: var(--bg-2); border: 1px solid var(--hair); }
+.nt-form input::placeholder { color: var(--muted-2); }
+.nt-form input:focus { outline: none; border-color: var(--accent-line); }
+.nt-form button { width: 25px; height: 25px; flex: none; border-radius: 7px; border: 1px solid var(--accent-line); background: var(--accent-wash); color: var(--accent-ink); cursor: pointer; font-size: 12px; }
+.nt { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 7px; align-items: center; padding: 5px 6px; border-radius: 7px; }
+.nt:hover { background: var(--surface-2); }
+.nt .ntx { min-width: 0; }
+.nt .tx { display: block; font-size: 11.5px; line-height: 1.35; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.nt .mt { margin-top: 2px; display: flex; align-items: center; gap: 5px; font: 9px var(--font-mono); color: var(--muted-2); }
+.nt-b { display: flex; gap: 2px; opacity: 0; transition: opacity .14s; flex: none; }
+.nt:hover .nt-b { opacity: 1; }
+.nb { border: 0; background: none; cursor: pointer; color: var(--muted-2); font-size: 10px; padding: 2px 4px; border-radius: 5px; }
+.nb:hover { color: var(--text); background: var(--surface); }
+
+/* What this folder can't do, said once — rendered INSTEAD of the cards it replaces. */
+.miss { padding: 11px 12px; border-radius: var(--radius); border: 1px dashed var(--hair-strong); background: color-mix(in srgb, var(--bg-2) 70%, transparent); display: flex; flex-direction: column; gap: 8px; flex: none; }
+.miss .t { font: 700 9.5px var(--font-ui); letter-spacing: .11em; text-transform: uppercase; color: var(--muted-2); }
+.miss p { margin: 0; font-size: 11.5px; line-height: 1.5; color: var(--muted-2); }
+.miss code { font: 10.5px var(--font-mono); color: var(--accent-ink); }
+
+/* the enlarge overlay — covers the dashboard, Esc steps out one layer */
+.ovl { position: absolute; inset: 0; z-index: 20; display: flex; flex-direction: column; background: linear-gradient(180deg, rgba(255,255,255,.04), transparent 30%), color-mix(in srgb, var(--panel) 95%, transparent); backdrop-filter: blur(18px) saturate(1.3); opacity: 0; pointer-events: none; transform: translateY(6px); transition: opacity .2s ease, transform .2s cubic-bezier(.32,.72,0,1); }
+.ovl.show { opacity: 1; pointer-events: auto; transform: none; }
+.ovl-h { display: flex; flex-wrap: nowrap; align-items: center; gap: 9px; padding: 9px 14px; border-bottom: 1px solid var(--hair); min-width: 0; }
+.ovl-h .t { font-size: 12.5px; font-weight: 750; letter-spacing: -.01em; white-space: nowrap; flex: none; }
+.ovl-h .s { font: 10px var(--font-mono); color: var(--muted-2); min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ovl-h .rt { margin-left: auto; display: flex; gap: 6px; flex: none; }
+.ovl-b { flex: 1; min-height: 0; overflow-y: auto; padding: 10px 14px 24px; }
+.ovl-f { padding: 8px 14px; border-top: 1px solid var(--hair); font-size: 11px; line-height: 1.5; color: var(--muted-2); background: var(--bg-2); }
+.ovl-f code { font: 10.5px var(--font-mono); color: var(--accent-ink); }
+/* One geometry for the header and every row, declared once. `.wt-*` is the worktree
+   dialog's own skin, hence the `dbwt` prefix. */
+.dbwt, .dbwt-hd { display: grid; grid-template-columns: 18px 146px minmax(0, 1fr) 178px 81px; gap: 10px; align-items: center; }
+.dbwt-hd { padding: 0 9px 6px; font: 700 8.5px var(--font-ui); letter-spacing: .11em; text-transform: uppercase; color: var(--muted-2); }
+.dbwt-hd .r { text-align: right; }
+.dbwt { min-height: 40px; padding: 4px 9px; border-radius: 8px; border-bottom: 1px solid var(--hair); }
+.dbwt:hover { background: var(--surface); }
+.dbwt .gl { text-align: center; font-size: 11px; }
+.dbwt .bn { font-size: 11.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dbwt .pt { font-size: 9.5px; color: var(--muted-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dbwt .tags { display: flex; gap: 5px; overflow: hidden; }
+/* Icon-only, so a row with two actions ends on the same edge as one with three. */
+.dbwt .acts { display: flex; justify-content: flex-end; gap: 4px; }
+.dbwt .acts .act { width: 23px; padding: 0; justify-content: center; font-size: 10.5px; opacity: .55; }
+.dbwt:hover .acts .act { opacity: 1; }
+.ncol { display: grid; grid-template-columns: repeat(auto-fill, minmax(258px, 1fr)); gap: 9px; align-items: stretch; }
+.ncard { padding: 11px 12px; border-radius: var(--radius); border: 1px solid var(--hair); background: var(--surface); display: flex; flex-direction: column; gap: 8px; }
+.ncard .tx { font-size: 12px; line-height: 1.5; }
+.ncard .mt { display: flex; align-items: center; gap: 7px; font: 9.5px var(--font-mono); color: var(--muted-2); }
+.ncard .bar { display: flex; align-items: center; gap: 8px; margin-top: auto; padding-top: 2px; }
+.ncard .bar .act { height: 23px; font-size: 10px; padding: 0 9px; }
+
+/* the inspector as the project's context menu, standing open */
+.ip-live { display: flex; flex-direction: column; gap: 1px; margin-top: 6px; }
+.ip-live .srow { padding: 4px 7px; }
+.ip-acts { display: flex; flex-direction: column; gap: 1px; margin-top: 6px; }
+.ia { display: grid; grid-template-columns: 19px minmax(0, 1fr); gap: 9px; align-items: center; padding: 6px 7px; border-radius: 7px; cursor: pointer; border: 0; background: none; text-align: left; color: var(--text); font-family: var(--font-ui); width: 100%; }
+.ia:hover { background: var(--surface-2); }
+.ia .ic { font-size: 12px; color: var(--muted-2); text-align: center; }
+.ia:hover .ic { color: var(--accent-ink); }
+.ia .lb { font-size: 11.5px; font-weight: 550; }
+.ia .sb { display: block; font: 9.5px var(--font-mono); color: var(--muted-2); margin-top: 1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ip-sep { height: 1px; background: var(--hair); margin: 5px 3px; }
+.db-chips { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 7px; }
+
+/* The 44px rail ⌘I collapses to on the dashboard. It exists because the inspector
+   holds the ONLY copy of History / Terminal / Run here — the header gave them up — so
+   collapsing to nothing would hide real verbs. */
+.insp-strip { display: none; flex-direction: column; align-items: center; gap: 4px; padding: 9px 0 12px; overflow-y: auto; min-height: 0; }
+.app.insp-mini .insp-strip { display: flex; }
+.app.insp-mini .insp-head, .app.insp-mini .insp-scroll { display: none; }
+.insp-strip .sglyphs { display: flex; flex-direction: column; align-items: center; gap: 3px; padding-bottom: 7px; margin-bottom: 4px; border-bottom: 1px solid var(--hair); width: 26px; }
+.insp-strip .pglyph { width: 22px; height: 22px; border-radius: 6px; font-size: 11px; }
+.isb { width: 28px; height: 28px; border-radius: 8px; display: grid; place-items: center; cursor: pointer; font-size: 12.5px; color: var(--muted-2); background: none; border: 1px solid transparent; }
+.isb:hover { color: var(--accent-ink); background: var(--accent-wash); border-color: var(--accent-line); }
+.isb.live { color: var(--st-working); }
+.isb.live.g-attn { color: var(--st-attention); }
+.isb.live.g-done { color: var(--st-done); }
+.isb.live.g-idle { color: var(--st-idle); }
+.isep { width: 18px; height: 1px; background: var(--hair); margin: 4px 0; }
+
+@media (max-width: 1180px) {
+  .db-body { grid-template-columns: 1fr; }
+  .db-aside { border-left: 0; border-top: 1px solid var(--hair); }
+}
+@media (prefers-reduced-motion: reduce) { .db-detail, .ovl { transition: none; } }

--- a/src/trail.ts
+++ b/src/trail.ts
@@ -1,0 +1,288 @@
+// The Trail's rules — what a day of work *was*. No DOM and no Tauri, so it unit-tests
+// in isolation like ./usage and ./rl; ./trailui owns the markup, the same split as
+// ./history + ./historyui and ./palette + ./palui.
+//
+// WHY THIS EXISTS. "What have I been working on" is a question Episko can already
+// answer from evidence it keeps anyway — Claude's transcripts, the usage rollup and
+// git — so nobody should ever have to write it down. That is the whole design
+// constraint: **the retrospective half is derived and read-only**. If you never open
+// it, it is still correct. A board dies the moment someone stops updating it; a log
+// that writes itself cannot.
+//
+// Everything here is arithmetic over three inputs that already exist:
+//   • `list_session_history` → HistEntry[] (./history), which carries Claude's own
+//     `ai-title` per session — the labels that make a day readable;
+//   • `usageWindow` → UDay[] (./usage), the per-day cost/token join, already tested;
+//   • `git_log_days` → TrailCommit[], the one genuinely new backend call.
+//
+// The only part that is *not* derived is the day summary sentence, and that is
+// deliberately generated elsewhere (./trailui asks the backend) — see `dayFacts`.
+
+import { histLabel, histProject, type HistEntry } from "./history";
+import { uDkey, type UDay } from "./usage";
+
+/// One commit, as `git_log_days` returns it. `when` is UNIX **seconds**, matching
+/// `HistEntry.mtime` — the backend speaks seconds for both, and every consumer here
+/// converts once, at the boundary, rather than each caller remembering to.
+export interface TrailCommit {
+  sha: string; author: string; when: number; subject: string; root: string;
+}
+
+/// A past session, reduced to what a day row shows. Distinct from HistEntry because
+/// the project attribution has already been resolved through `histProject` — the
+/// sidebar's own grouping rule — so the view never re-derives it per render.
+export interface TrailSession {
+  id: string; title: string; project: string; colorKey: string;
+  branch: string; cwd: string; when: number; exists: boolean;
+}
+
+/// One calendar day, local. `key` is deliberately `uDkey`'s format so a day here and
+/// a day in the Usage tab are the *same* key — if these two ever disagreed about
+/// where a midnight falls, the Trail's costs would silently stop matching the
+/// analytics the user already trusts.
+/// One issue or PR that opened, closed or merged. `at` is ISO-8601 from gh; the day
+/// bucketing happens here so the Trail and the Usage tab can never disagree about
+/// where midnight falls.
+export interface TrailEvent {
+  number: number; kind: string; event: "opened" | "closed" | "merged";
+  title: string; url: string; at: string;
+}
+
+export interface TrailDay {
+  key: string;
+  when: number;          // ms at local midnight — for formatting only
+  cost: number;
+  tokens: number;
+  sessions: TrailSession[];
+  commits: TrailCommit[];
+  events: TrailEvent[];
+}
+
+/// A day's work, split by the project it belonged to.
+///
+/// A day is almost never about one thing, and a flat list of everything that happened
+/// reads as noise the moment two projects are in play — you cannot tell which commits
+/// belong to which sessions. Grouping is the smallest change that makes a mixed day
+/// legible.
+export interface DayProject {
+  colorKey: string;
+  project: string;
+  sessions: TrailSession[];
+  commits: TrailCommit[];
+  events: TrailEvent[];
+}
+
+/// Seconds → ms, once, at the boundary. Both backend timestamps are seconds.
+const ms = (secs: number) => secs * 1000;
+
+/** A history row reduced to a trail row, with project attribution already resolved. */
+export function trailSession(h: HistEntry): TrailSession {
+  const p = histProject(h);
+  return {
+    id: h.session_id,
+    title: histLabel(h),
+    project: p.project,
+    colorKey: p.colorKey,
+    branch: p.worktree || h.branch || "",
+    cwd: h.cwd,
+    when: ms(h.mtime),
+    exists: h.exists,
+  };
+}
+
+/// The local calendar day a timestamp falls in. Shared by both groupers so a session
+/// and a commit an hour apart can never land on different days.
+export const dayKeyOf = (msWhen: number) => uDkey(new Date(msWhen));
+
+/**
+ * The Trail proper: the last `days.length` calendar days, **newest first**, each
+ * joined to its sessions, commits and cost.
+ *
+ * Days with nothing in them are dropped rather than rendered empty. A window is a
+ * request for "the last 30 days", not a promise that all 30 had work in them, and a
+ * column of blank rows reads as a broken view rather than as a quiet weekend.
+ */
+export function trailDays(
+  hist: HistEntry[],
+  days: UDay[],
+  commits: TrailCommit[],
+  events: TrailEvent[] = [],
+): TrailDay[] {
+  const byKey = new Map<string, TrailDay>();
+  for (const d of days) {
+    const [y, m, dd] = d.key.split("-").map(Number);
+    byKey.set(d.key, {
+      key: d.key,
+      when: new Date(y, m - 1, dd).getTime(),
+      cost: d.cost,
+      tokens: d.tok,
+      sessions: [],
+      commits: [],
+      events: [],
+    });
+  }
+  // Sessions and commits outside the window are simply not in `byKey` — no day is
+  // invented for them, which is what keeps the window honest.
+  for (const h of hist) {
+    const day = byKey.get(dayKeyOf(ms(h.mtime)));
+    if (day) day.sessions.push(trailSession(h));
+  }
+  for (const c of commits) {
+    const day = byKey.get(dayKeyOf(ms(c.when)));
+    if (day) day.commits.push(c);
+  }
+  for (const ev of events) {
+    const t = Date.parse(ev.at);
+    // A malformed timestamp is dropped rather than bucketed to 1970, where it would
+    // silently vanish from every window anyway.
+    if (!Number.isFinite(t)) continue;
+    const day = byKey.get(dayKeyOf(t));
+    if (day) day.events.push(ev);
+  }
+
+  const out = [...byKey.values()].filter((d) => d.sessions.length || d.commits.length || d.events.length || d.cost > 0);
+  for (const d of out) {
+    d.sessions.sort((a, b) => b.when - a.when);
+    d.commits.sort((a, b) => b.when - a.when);
+    d.events.sort((a, b) => Date.parse(b.at) - Date.parse(a.at));
+  }
+  return out.sort((a, b) => b.when - a.when);
+}
+
+/**
+ * A day split by project, most active first.
+ *
+ * Commits carry the root they came from and sessions carry a colorKey, so both already
+ * know their project — this only has to agree on one key per group. Events are keyed by
+ * the repo root `gh_day_activity` was asked about, which is that same colorKey.
+ *
+ * A project with only an event (a PR merged on a day you touched nothing else) still
+ * gets a group: that IS what happened that day.
+ */
+export function dayByProject(d: TrailDay, nameOf: (colorKey: string) => string): DayProject[] {
+  const groups = new Map<string, DayProject>();
+  const at = (colorKey: string): DayProject => {
+    let g = groups.get(colorKey);
+    if (!g) {
+      g = { colorKey, project: nameOf(colorKey), sessions: [], commits: [], events: [] };
+      groups.set(colorKey, g);
+    }
+    return g;
+  };
+  for (const s of d.sessions) at(s.colorKey).sessions.push(s);
+  for (const c of d.commits) at(c.root).commits.push(c);
+  for (const e of (d.events ?? [])) at(eventRoot(e)).events.push(e);
+  // Busiest first, ties broken by name so a repaint never reorders an unchanged day.
+  return [...groups.values()].sort((a, b) => {
+    const wa = a.sessions.length + a.commits.length + a.events.length;
+    const wb = b.sessions.length + b.commits.length + b.events.length;
+    return wb - wa || a.project.localeCompare(b.project);
+  });
+}
+
+/// One line in a project's day, whatever kind of thing it is.
+export type DayItem =
+  | { kind: "session"; when: number; session: TrailSession }
+  | { kind: "commit"; when: number; commit: TrailCommit };
+
+/**
+ * A project's day as ONE time-ordered list, newest first.
+ *
+ * Not sessions-then-commits. A session at 09:00 and the commit it produced at 09:05
+ * are a cause and its effect; listing all the causes and then all the effects breaks
+ * the only ordering that explains the day. The kind stays visible on each row, so
+ * nothing is lost by mixing them.
+ *
+ * The two sources speak different units — `TrailSession.when` is already ms, while
+ * `TrailCommit.when` is UNIX **seconds**, straight from git. Converting here is the
+ * whole reason this is one function rather than a spread at the call site: sorted
+ * together unconverted, every commit sorts as 1970 and sinks below everything.
+ */
+export function dayItems(g: DayProject): DayItem[] {
+  const items: DayItem[] = [
+    ...g.sessions.map((session) => ({ kind: "session" as const, when: session.when, session })),
+    ...g.commits.map((commit) => ({ kind: "commit" as const, when: ms(commit.when), commit })),
+  ];
+  // Ties broken by kind then id, so a repaint of unchanged state never reorders.
+  return items.sort((a, b) =>
+    b.when - a.when ||
+    a.kind.localeCompare(b.kind) ||
+    (a.kind === "session" ? a.session.id : a.commit.sha).localeCompare(
+      b.kind === "session" ? b.session.id : b.commit.sha));
+}
+
+/// Events are tagged with their repo root when fetched; ./trailui stamps it on so this
+/// module needn't know how the fetch was keyed.
+const eventRoot = (e: TrailEvent & { root?: string }) => e.root ?? "";
+
+/// Which project a day was mostly about, by session count then commit count, or null
+/// when the day was genuinely spread across several. Ties break alphabetically so a
+/// re-render can never reorder a day that hasn't changed.
+export function dominantProject(d: TrailDay): string | null {
+  const n = new Map<string, number>();
+  for (const s of d.sessions) n.set(s.project, (n.get(s.project) || 0) + 1);
+  if (!n.size) return null;
+  const ranked = [...n.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  const total = [...n.values()].reduce((s, v) => s + v, 0);
+  // "Mostly X" has to actually mean mostly, or the headline lies on a mixed day.
+  return ranked[0][1] / total > 0.6 ? ranked[0][0] : null;
+}
+
+const plural = (n: number, w: string) => `${n} ${w}${n === 1 ? "" : "s"}`;
+
+/**
+ * The headline shown before (or instead of) a generated one.
+ *
+ * Always computed, never awaited: a generated summary is asynchronous, can be turned
+ * off, and can fail, so every day must already read correctly without one. When the
+ * model's sentence arrives it replaces this; until then this is what's on screen.
+ */
+export function deterministicHeadline(d: TrailDay): string {
+  const parts: string[] = [];
+  const dom = dominantProject(d);
+  const projects = new Set(d.sessions.map((s) => s.project));
+  if (d.sessions.length) {
+    parts.push(dom
+      ? `Mostly ${dom} — ${plural(d.sessions.length, "session")}`
+      : `${plural(d.sessions.length, "session")} across ${plural(projects.size, "project")}`);
+  }
+  if (d.commits.length) parts.push(plural(d.commits.length, "commit"));
+  const merged = (d.events ?? []).filter((e) => e.event === "merged").length;
+  const closed = (d.events ?? []).filter((e) => e.event === "closed").length;
+  const opened = (d.events ?? []).filter((e) => e.event === "opened").length;
+  if (merged) parts.push(`${merged} merged`);
+  if (closed) parts.push(`${closed} closed`);
+  if (opened && !merged && !closed) parts.push(`${opened} opened`);
+  if (!parts.length) return d.cost > 0 ? "Agent time, nothing committed." : "Quiet day.";
+  return parts.join(" · ") + ".";
+}
+
+/**
+ * The compact, factual description handed to the summariser.
+ *
+ * Deliberately just the day's own evidence — titles and subjects, no transcript
+ * bodies. The summary is a one-line label over work the user already did, so it needs
+ * no conversation content, and keeping it out means the Trail never ships prose from
+ * inside a session to a model that didn't already have it.
+ *
+ * Bounded, because a heavy day would otherwise grow the prompt without bound.
+ */
+export function dayFacts(d: TrailDay, limit = 12): string {
+  const lines: string[] = [];
+  if (d.cost > 0) lines.push(`spend: $${d.cost.toFixed(2)}`);
+  for (const s of d.sessions.slice(0, limit)) {
+    lines.push(`session: ${s.title}${s.project ? ` [${s.project}${s.branch ? `/${s.branch}` : ""}]` : ""}`);
+  }
+  if (d.sessions.length > limit) lines.push(`… and ${d.sessions.length - limit} more sessions`);
+  for (const c of d.commits.slice(0, limit)) lines.push(`commit: ${c.subject}`);
+  if (d.commits.length > limit) lines.push(`… and ${d.commits.length - limit} more commits`);
+  // What landed, not just what ran — a day is remembered by what it finished.
+  for (const e of (d.events ?? []).slice(0, limit)) {
+    lines.push(`${e.event} ${e.kind} #${e.number}: ${e.title}`);
+  }
+  return lines.join("\n");
+}
+
+/// A day is only worth summarising once it can't change again. Today is still being
+/// written, so it re-summarises; every earlier day is final and is cached forever.
+export const dayIsClosed = (d: TrailDay, now = Date.now()) => d.key !== uDkey(new Date(now));

--- a/test/dash.test.ts
+++ b/test/dash.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import "./localstorage"; // must precede the subject imports (state.ts reads it at load)
+import {
+  canShare, clampRange, dashDays, dashPulse, densePerDay, DASH_RANGE_DEFAULT,
+  projectCost, projectTier, type ProjectFacts,
+} from "../src/dash";
+import type { HistEntry } from "../src/history";
+import type { TrailCommit } from "../src/trail";
+import type { UDay } from "../src/usage";
+
+const facts = (o: Partial<ProjectFacts> = {}): ProjectFacts =>
+  ({ is_repo: true, root: "/w/epi", origin: null, host: null, slug: null, ...o });
+
+// A day key as ./usage writes them, for a local-midnight day N days before `now`.
+const NOW = new Date(2026, 6, 31, 14, 0, 0).getTime(); // 31 Jul 2026, local
+const dk = (back: number) => {
+  const d = new Date(NOW - back * 86_400_000);
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+};
+
+const hist = (o: Partial<HistEntry> = {}): HistEntry => ({
+  session_id: "s1", cwd: "/w/epi", project: "epi", branch: "main",
+  title: "a session", last_prompt: "", mtime: NOW / 1000, bytes: 10, exists: true,
+  repo_root: "/w/epi", ...o,
+});
+const commit = (o: Partial<TrailCommit> = {}): TrailCommit =>
+  ({ sha: "abc1234", author: "Tim", when: NOW / 1000, subject: "a commit", root: "/w/epi", ...o });
+const uday = (key: string, cost = 0): UDay => ({ key, cost, tok: 0 } as UDay);
+
+describe("projectTier — three gates, and they are not the same gate", () => {
+  it("is github only when a slug was minted, which only github.com gets", () => {
+    expect(projectTier(facts({ host: "github.com", slug: "respeak-io/episko" }))).toBe("github");
+  });
+  it("is git for a repo with no remote, or a remote that isn't GitHub", () => {
+    expect(projectTier(facts())).toBe("git");
+    expect(projectTier(facts({ host: "gitlab.com" }))).toBe("git");
+    expect(projectTier(facts({ host: "git.respeak.internal" }))).toBe("git");
+  });
+  it("is none for a folder that isn't a repository", () => {
+    expect(projectTier(facts({ is_repo: false }))).toBe("none");
+    expect(projectTier(null)).toBe("none");
+    expect(projectTier(undefined)).toBe("none");
+  });
+  it("gates sharing on git, NOT on GitHub — .episko only needs to be committable", () => {
+    expect(canShare("github")).toBe(true);
+    expect(canShare("git")).toBe(true);
+    expect(canShare("none")).toBe(false);
+  });
+});
+
+describe("projectCost", () => {
+  const detail = { [dk(0)]: { projects: { epi: 4.5, other: 99 } } };
+  it("returns this project's share of the day", () => {
+    expect(projectCost(detail, dk(0), "epi")).toBe(4.5);
+  });
+  it("returns 0 — never the fleet total — for a day with no detail record", () => {
+    // The plain cc-usage rollup is every project at once. Borrowing it here would
+    // invent a number that looks like data.
+    expect(projectCost({}, dk(0), "epi")).toBe(0);
+    expect(projectCost(detail, dk(3), "epi")).toBe(0);
+    expect(projectCost(detail, dk(0), "not-this-one")).toBe(0);
+  });
+  it("ignores a corrupt or negative value rather than propagating it", () => {
+    expect(projectCost({ x: { projects: { epi: NaN } } }, "x", "epi")).toBe(0);
+    expect(projectCost({ x: { projects: { epi: -1 } } }, "x", "epi")).toBe(0);
+    expect(projectCost({ x: undefined }, "x", "epi")).toBe(0);
+  });
+});
+
+describe("dashDays — scoped before assembly, not after", () => {
+  const win = [uday(dk(0)), uday(dk(1))];
+  it("keeps only this project's sessions and commits", () => {
+    const days = dashDays(
+      "/w/epi",
+      [hist({ session_id: "mine" }), hist({ session_id: "theirs", cwd: "/w/other", repo_root: "/w/other", project: "other" })],
+      [commit({ sha: "mine" }), commit({ sha: "theirs", root: "/w/other" })],
+      win, () => 0,
+    );
+    expect(days).toHaveLength(1);
+    expect(days[0].sessions.map((s) => s.id)).toEqual(["mine"]);
+    expect(days[0].commits.map((c) => c.sha)).toEqual(["mine"]);
+  });
+
+  it("restates cost per project instead of carrying the fleet-wide figure", () => {
+    // The window's UDay.cost is every project's spend that day. If it survived, the
+    // pulse strip would describe somebody else's afternoon.
+    const days = dashDays("/w/epi", [hist()], [], [uday(dk(0), 99)], () => 4.5);
+    expect(days[0].cost).toBe(4.5);
+  });
+
+  it("drops a day this project had nothing on, even if the fleet was busy", () => {
+    const days = dashDays("/w/epi", [hist()], [], [uday(dk(0)), uday(dk(1), 50)], () => 0);
+    expect(days.map((d) => d.key)).toEqual([dk(0)]);
+  });
+});
+
+describe("dashPulse", () => {
+  const days = dashDays(
+    "/w/epi",
+    [hist({ session_id: "a" }), hist({ session_id: "b", mtime: (NOW - 86_400_000) / 1000 })],
+    [
+      commit({ sha: "c1", author: "Tim" }),
+      commit({ sha: "c2", author: "Frederic" }),
+      commit({ sha: "c3", author: "Tim", when: (NOW - 86_400_000) / 1000 }),
+    ],
+    [uday(dk(0)), uday(dk(1))],
+    (k) => (k === dk(0) ? 4 : 1),
+  );
+
+  it("totals the window", () => {
+    const p = dashPulse(days);
+    expect(p.commits).toBe(3);
+    expect(p.sessions).toBe(2);
+    expect(p.spend).toBe(5);
+  });
+  it("ranks authors busiest first, ties by name so a repaint never reorders", () => {
+    expect(dashPulse(days).authors).toEqual(["Tim", "Frederic"]);
+  });
+  it("emits the sparkline oldest-first — a chart reads left to right in time", () => {
+    // `days` is newest-first for the list; the series must be the other way round.
+    expect(dashPulse(days).perDay).toEqual([1, 2]);
+  });
+  it("is all zeroes for an empty window rather than throwing", () => {
+    expect(dashPulse([])).toEqual({ commits: 0, sessions: 0, spend: 0, authors: [], perDay: [] });
+  });
+});
+
+describe("densePerDay — the chart must not drop the quiet days", () => {
+  it("fills days with nothing on them, which trailDays deliberately omits", () => {
+    // Two busy days a week apart render as two adjacent bars without this, which reads
+    // as "constantly busy" — the exact opposite of the truth.
+    const days = dashDays("/w/epi",
+      [hist({ mtime: NOW / 1000 }), hist({ session_id: "old", mtime: (NOW - 6 * 86_400_000) / 1000 })],
+      [commit(), commit({ sha: "c2" }), commit({ sha: "c3", when: (NOW - 6 * 86_400_000) / 1000 })],
+      [uday(dk(0)), uday(dk(6))], () => 0);
+    expect(days).toHaveLength(2);          // the list keeps only the two real days…
+    expect(densePerDay(days, 7, NOW)).toEqual([1, 0, 0, 0, 0, 0, 2]); // …the chart keeps all seven
+  });
+  it("is all zeroes when nothing happened at all", () => {
+    expect(densePerDay([], 7, NOW)).toEqual([0, 0, 0, 0, 0, 0, 0]);
+  });
+});
+
+describe("clampRange", () => {
+  it("accepts only the offered windows", () => {
+    expect(clampRange(7)).toBe(7);
+    expect(clampRange(30)).toBe(30);
+    expect(clampRange(999)).toBe(DASH_RANGE_DEFAULT);
+    expect(clampRange(NaN)).toBe(DASH_RANGE_DEFAULT);
+  });
+});

--- a/test/notes.test.ts
+++ b/test/notes.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { store } from "./localstorage"; // must precede the subject import
+import { addNote, noteById, noteList, notes, reloadNotes, removeNote, setNoteProject } from "../src/notes";
+
+beforeEach(() => {
+  store.clear();
+  reloadNotes();
+  notes.length = 0;
+});
+
+describe("capture", () => {
+  it("keeps the newest first and persists", () => {
+    addNote("first");
+    addNote("second");
+    expect(noteList().map((n) => n.text)).toEqual(["second", "first"]);
+    expect(JSON.parse(store.get("cc-notes")!)).toHaveLength(2);
+  });
+
+  it("refuses an empty jot without making the caller check", () => {
+    expect(addNote("   ")).toBeNull();
+    expect(addNote("")).toBeNull();
+    expect(noteList()).toHaveLength(0);
+  });
+
+  it("trims, because a trailing newline from a paste is not part of the thought", () => {
+    expect(addNote("  rate-limit /v1/transcribe \n")!.text).toBe("rate-limit /v1/transcribe");
+  });
+
+  it("files a note against a project only when asked", () => {
+    expect(addNote("unfiled")!.project).toBeNull();
+    expect(addNote("filed", "/w/episko")!.project).toBe("/w/episko");
+    expect(noteList("/w/episko").map((n) => n.text)).toEqual(["filed"]);
+  });
+
+  it("gives two notes jotted in the same millisecond distinct ids", () => {
+    const ids = new Set(Array.from({ length: 50 }, (_, i) => addNote(`n${i}`)!.id));
+    expect(ids.size).toBe(50);
+  });
+});
+
+describe("lifecycle", () => {
+  it("returns the note it removed, so dispatch can use its text as the brief", () => {
+    const n = addNote("try a departures-board layout")!;
+    expect(removeNote(n.id)!.text).toBe("try a departures-board layout");
+    expect(noteById(n.id)).toBeNull();
+    expect(noteList()).toHaveLength(0);
+  });
+
+  it("survives a removal that isn't there", () => {
+    expect(removeNote("nope")).toBeNull();
+  });
+
+  it("re-files onto and off a project", () => {
+    const n = addNote("x")!;
+    setNoteProject(n.id, "/w/api");
+    expect(noteById(n.id)!.project).toBe("/w/api");
+    setNoteProject(n.id, null);
+    expect(noteById(n.id)!.project).toBeNull();
+  });
+});
+
+describe("a corrupt store must not take the app down", () => {
+  // These read at import time, so throwing here would break the whole frontend load.
+  it("degrades to empty on unparseable JSON", () => {
+    store.set("cc-notes", "{not json");
+    reloadNotes();
+    expect(noteList()).toEqual([]);
+  });
+
+  it("drops entries that aren't notes", () => {
+    store.set("cc-notes", JSON.stringify([{ id: "a", text: "keep", project: null, created: 1 }, null, { id: 5 }, "x"]));
+    reloadNotes();
+    expect(noteList().map((n) => n.text)).toEqual(["keep"]);
+  });
+
+  it("degrades when the stored value isn't a list at all", () => {
+    store.set("cc-notes", JSON.stringify({ nope: true }));
+    reloadNotes();
+    expect(noteList()).toEqual([]);
+  });
+});

--- a/test/trail.test.ts
+++ b/test/trail.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { store } from "./localstorage"; // must precede the subject import
+import type { HistEntry } from "../src/history";
+import { usage, usageWindow, type UDay } from "../src/usage";
+import {
+  dayByProject, dayFacts, dayIsClosed, dayItems, dayKeyOf, deterministicHeadline, dominantProject,
+  trailDays, trailSession, type TrailCommit, type TrailDay,
+} from "../src/trail";
+
+// Local wall-clock, like usage.test.ts: every key the Trail produces is a *calendar*
+// day in the user's own timezone, so fixtures are built the way the code reads them.
+const at = (y: number, m: number, d: number, h = 12, min = 0) => new Date(y, m - 1, d, h, min, 0);
+/// Both backend timestamps are UNIX **seconds**, so fixtures speak seconds too — the
+/// bug this guards against is a Date built from seconds, which lands in 1970.
+const secs = (d: Date) => Math.floor(d.getTime() / 1000);
+
+const hist = (over: Partial<HistEntry> & { mtime: number }): HistEntry => ({
+  session_id: "s1", cwd: "/w/episko", project: "episko", branch: "dev",
+  title: "", last_prompt: "", bytes: 10, exists: true, repo_root: "/w/episko",
+  ...over,
+});
+
+const commit = (over: Partial<TrailCommit> & { when: number }): TrailCommit => ({
+  sha: "abc1234", author: "Tim Rietz", subject: "fix: a thing", root: "/w/episko", ...over,
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(at(2027, 3, 14));
+  for (const k of Object.keys(usage)) delete usage[k];
+  store.clear();
+});
+afterEach(() => vi.useRealTimers());
+
+describe("day grouping", () => {
+  it("groups sessions and commits into the local calendar day they happened", () => {
+    const days = usageWindow(3); // 12th, 13th, 14th
+    const out = trailDays(
+      [hist({ mtime: secs(at(2027, 3, 13, 9)), title: "morning" }),
+       hist({ mtime: secs(at(2027, 3, 13, 21)), title: "evening", session_id: "s2" })],
+      days,
+      [commit({ when: secs(at(2027, 3, 12, 15)) })],
+    );
+    expect(out.map((d) => d.key)).toEqual(["2027-03-13", "2027-03-12"]); // newest first
+    expect(out[0].sessions.map((s) => s.title)).toEqual(["evening", "morning"]); // newest first within a day
+    expect(out[1].commits).toHaveLength(1);
+  });
+
+  it("splits either side of local midnight rather than by UTC", () => {
+    // 23:30 and 00:30 are 1h apart but belong to different calendar days. A UTC-based
+    // grouper would put them together (or apart) depending on the runner's offset.
+    const days = usageWindow(3);
+    const out = trailDays(
+      [hist({ mtime: secs(at(2027, 3, 12, 23, 30)), session_id: "late" }),
+       hist({ mtime: secs(at(2027, 3, 13, 0, 30)), session_id: "early" })],
+      days, [],
+    );
+    expect(out.map((d) => d.key)).toEqual(["2027-03-13", "2027-03-12"]);
+    expect(out[0].sessions[0].id).toBe("early");
+    expect(out[1].sessions[0].id).toBe("late");
+  });
+
+  it("uses the same day key as the Usage tab, so costs can never disagree", () => {
+    // The join is by key; if these two ever drifted the Trail would show a day's
+    // sessions against another day's spend.
+    expect(dayKeyOf(at(2027, 3, 13, 23, 59).getTime())).toBe(usageWindow(2)[0].key);
+  });
+
+  it("joins each day to its cost from the usage rollup", () => {
+    usage["2027-03-13"] = 12.5;
+    const out = trailDays([hist({ mtime: secs(at(2027, 3, 13)) })], usageWindow(2), []);
+    expect(out[0].cost).toBe(12.5);
+  });
+
+  it("drops days with nothing in them, but keeps a day that only cost money", () => {
+    usage["2027-03-12"] = 3;
+    const out = trailDays([hist({ mtime: secs(at(2027, 3, 14)) })], usageWindow(5), []);
+    expect(out.map((d) => d.key)).toEqual(["2027-03-14", "2027-03-12"]);
+  });
+
+  it("ignores sessions and commits outside the window rather than inventing days", () => {
+    const out = trailDays(
+      [hist({ mtime: secs(at(2020, 1, 1)) })],
+      usageWindow(3),
+      [commit({ when: secs(at(2020, 1, 1)) })],
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("reads mtime as seconds", () => {
+    // Guards the units trap directly: seconds treated as ms lands in January 1970 and
+    // silently falls outside every window.
+    const s = trailSession(hist({ mtime: secs(at(2027, 3, 13, 8)) }));
+    expect(new Date(s.when).getFullYear()).toBe(2027);
+  });
+});
+
+describe("headlines", () => {
+  const day = (over: Partial<TrailDay>): TrailDay => ({
+    key: "2027-03-13", when: at(2027, 3, 13, 0).getTime(), cost: 0, tokens: 0,
+    sessions: [], commits: [], events: [], ...over,
+  });
+  const sess = (project: string, title = "t") =>
+    ({ id: title, title, project, colorKey: project, branch: "dev", cwd: "/w", when: 0, exists: true });
+
+  it("says 'mostly X' only when X really dominates", () => {
+    expect(deterministicHeadline(day({ sessions: [sess("episko"), sess("episko"), sess("web")] })))
+      .toContain("Mostly episko");
+    // 2 of 4 is not "mostly" — a headline that overclaims is worse than a plain count.
+    expect(deterministicHeadline(day({ sessions: [sess("a"), sess("a"), sess("b"), sess("b")] })))
+      .toBe("4 sessions across 2 projects.");
+  });
+
+  it("degrades sensibly when there is little to say", () => {
+    expect(deterministicHeadline(day({}))).toBe("Quiet day.");
+    expect(deterministicHeadline(day({ cost: 2 }))).toBe("Agent time, nothing committed.");
+    expect(deterministicHeadline(day({ commits: [commit({ when: 0 })] }))).toBe("1 commit.");
+  });
+
+  it("breaks ties deterministically so a repaint never reorders", () => {
+    const d = day({ sessions: [sess("beta"), sess("alpha")] });
+    expect(dominantProject(d)).toBe(dominantProject(d));
+  });
+});
+
+describe("summarising", () => {
+  it("sends titles and subjects, never transcript bodies", () => {
+    const facts = dayFacts({
+      key: "2027-03-13", when: 0, cost: 4.2, tokens: 0,
+      sessions: [{ id: "a", title: "Usage forecast colours", project: "episko", colorKey: "k", branch: "dev", cwd: "/w", when: 0, exists: true }],
+      commits: [commit({ when: 0, subject: "fix: the thing" })], events: [],
+    });
+    expect(facts).toContain("spend: $4.20");
+    expect(facts).toContain("session: Usage forecast colours [episko/dev]");
+    expect(facts).toContain("commit: fix: the thing");
+  });
+
+  it("bounds a heavy day so the prompt cannot grow without limit", () => {
+    const many = Array.from({ length: 30 }, (_, i) =>
+      ({ id: `s${i}`, title: `t${i}`, project: "p", colorKey: "p", branch: "", cwd: "/w", when: 0, exists: true }));
+    const facts = dayFacts({ key: "k", when: 0, cost: 0, tokens: 0, sessions: many, commits: [], events: [] }, 5);
+    expect(facts).toContain("… and 25 more sessions");
+    expect(facts.split("\n").filter((l) => l.startsWith("session:"))).toHaveLength(5);
+  });
+
+  it("treats today as still open and every earlier day as final", () => {
+    const mk = (key: string) => ({ key, when: 0, cost: 0, tokens: 0, sessions: [], commits: [], events: [] });
+    expect(dayIsClosed(mk("2027-03-14"))).toBe(false); // today — may still change
+    expect(dayIsClosed(mk("2027-03-13"))).toBe(true);  // over — cache forever
+  });
+});
+
+describe("a day is split by project", () => {
+  const names = (k: string) => k.split("/").pop() || k;
+  const s = (id: string, colorKey: string) =>
+    ({ id, title: id, project: names(colorKey), colorKey, branch: "", cwd: "/w", when: 1, exists: true });
+  const c = (subject: string, root: string): TrailCommit =>
+    ({ sha: "a", author: "T", when: 1, subject, root });
+  const ev = (n: number, event: "opened" | "closed" | "merged", root: string) =>
+    ({ number: n, kind: "pr", event, title: `#${n}`, url: "u", at: "2027-03-13T10:00:00Z", root });
+  const day = (over: Partial<TrailDay>): TrailDay =>
+    ({ key: "2027-03-13", when: 0, cost: 0, tokens: 0, sessions: [], commits: [], events: [], ...over });
+
+  it("files sessions, commits and events under the project they belong to", () => {
+    const groups = dayByProject(day({
+      sessions: [s("s1", "/w/episko"), s("s2", "/w/api")],
+      commits: [c("fix a", "/w/episko"), c("fix b", "/w/episko")],
+      events: [ev(42, "merged", "/w/api")] as never,
+    }), names);
+    expect(groups.map((g) => g.project)).toEqual(["episko", "api"]); // busiest first
+    expect(groups[0].commits).toHaveLength(2);
+    expect(groups[1].events).toHaveLength(1);
+  });
+
+  it("gives a project a group even when only an event happened there", () => {
+    // A PR merging on a day you touched nothing else IS what happened that day.
+    const groups = dayByProject(day({ events: [ev(9, "merged", "/w/api")] as never }), names);
+    expect(groups.map((g) => g.project)).toEqual(["api"]);
+  });
+
+  it("orders identically on a repaint of unchanged state", () => {
+    const d = day({ sessions: [s("a", "/w/beta"), s("b", "/w/alpha")] });
+    expect(dayByProject(d, names).map((g) => g.project)).toEqual(dayByProject(d, names).map((g) => g.project));
+  });
+});
+
+describe("what a day closed", () => {
+  const day = (events: unknown[]): TrailDay =>
+    ({ key: "k", when: 0, cost: 0, tokens: 0, sessions: [], commits: [], events: events as never });
+
+  it("names merges and closures in the headline, which is what a day is remembered by", () => {
+    const h = deterministicHeadline(day([
+      { number: 1, kind: "pr", event: "merged", title: "x", url: "u", at: "" },
+      { number: 2, kind: "issue", event: "closed", title: "y", url: "u", at: "" },
+    ]));
+    expect(h).toContain("1 merged");
+    expect(h).toContain("1 closed");
+  });
+
+  it("mentions openings only when nothing landed", () => {
+    expect(deterministicHeadline(day([{ number: 3, kind: "issue", event: "opened", title: "z", url: "u", at: "" }])))
+      .toContain("1 opened");
+    const both = deterministicHeadline(day([
+      { number: 1, kind: "pr", event: "merged", title: "x", url: "u", at: "" },
+      { number: 3, kind: "issue", event: "opened", title: "z", url: "u", at: "" },
+    ]));
+    expect(both).toContain("1 merged");
+    expect(both).not.toContain("opened");
+  });
+
+  it("buckets an event into its own local day and drops an unparseable one", () => {
+    const days = usageWindow(3);
+    const out = trailDays([], days, [], [
+      { number: 1, kind: "pr", event: "merged", title: "x", url: "u", at: "2027-03-13T09:00:00Z" },
+      { number: 2, kind: "pr", event: "merged", title: "y", url: "u", at: "nonsense" },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].events.map((e) => e.number)).toEqual([1]);
+  });
+
+  it("hands the model what landed, not only what ran", () => {
+    const facts = dayFacts(day([{ number: 46, kind: "pr", event: "merged", title: "notice drift", url: "u", at: "" }]));
+    expect(facts).toContain("merged pr #46: notice drift");
+  });
+});
+
+describe("a day reads as one story, not two lists", () => {
+  const names = (k: string) => k.split("/").pop() || k;
+  const sess = (id: string, whenMs: number) =>
+    ({ id, title: id, project: "e", colorKey: "/w/e", branch: "", cwd: "/w", when: whenMs, exists: true });
+  const cmt = (sha: string, whenSecs: number): TrailCommit =>
+    ({ sha, author: "T", when: whenSecs, subject: sha, root: "/w/e" });
+
+  it("interleaves sessions and commits by time — a session is the cause of the commit", () => {
+    const t = (h: number) => at(2027, 3, 13, h).getTime();
+    const g = { colorKey: "/w/e", project: "e",
+      sessions: [sess("morning", t(9)), sess("evening", t(18))],
+      commits: [cmt("noon", Math.floor(t(12) / 1000)), cmt("late", Math.floor(t(20) / 1000))],
+      events: [] };
+    expect(dayItems(g).map((i) => (i.kind === "session" ? i.session.id : i.commit.sha)))
+      .toEqual(["late", "evening", "noon", "morning"]);
+  });
+
+  it("converts commit seconds to ms, or every commit sinks to 1970", () => {
+    // The units trap again: sorted unconverted, a 2027 commit compares as ~1970 and
+    // lands below every session no matter when it actually happened.
+    const t = at(2027, 3, 13, 12).getTime();
+    const g = { colorKey: "/w/e", project: "e",
+      sessions: [sess("s", t - 3600e3)], commits: [cmt("c", Math.floor(t / 1000))], events: [] };
+    const first = dayItems(g)[0];
+    expect(first.kind).toBe("commit");
+    expect(new Date(first.when).getFullYear()).toBe(2027);
+  });
+
+  it("is stable across repaints when timestamps tie", () => {
+    const g = { colorKey: "/w/e", project: "e",
+      sessions: [sess("b", 5000), sess("a", 5000)], commits: [cmt("z", 5)], events: [] };
+    expect(dayItems(g).map((i) => i.when)).toEqual(dayItems(g).map((i) => i.when));
+    expect(dayItems(g).map((i) => (i.kind === "session" ? i.session.id : i.commit.sha)))
+      .toEqual(dayItems(g).map((i) => (i.kind === "session" ? i.session.id : i.commit.sha)));
+  });
+});


### PR DESCRIPTION
Second of three PRs. **Design mock:** https://claude.ai/code/artifact/dee80fdb-456e-4d55-9e50-c1bdf0da0e0b · follows #50.

Left-clicking a project selected whichever session sorted first — one gesture meaning two different things depending on state — and "what is going on in this repo" lived in a right-click menu nobody opens. It now opens a dashboard. The sessions are the rows directly beneath the header.

## Shape

`dash.ts` is pure and tested · `dashview.ts` takes data and returns a string · `dashboard.ts` owns the pane, the IPC, the summary queue and the delegated events. The `graph.ts`/`graphview.ts` split again. It rides the existing `mirror` pointer (`kind: "dash"`) rather than adding a second flag every `activeId` check would have to be paired with, and **nothing runs until a project is clicked** — no probe at startup, nothing on `renderAll`'s path.

## Three gates, and they are not the same gate

| | unlocks |
| --- | --- |
| **GitHub** | issues, PRs, claims — none of it in this PR |
| **git** | the commit half of the timeline, checkouts, and *everything shared* |
| **neither** | sessions, spend, notes |

`.episko/` only means anything if it can be committed, so **sharing needs git, not GitHub** — a GitLab or self-hosted remote still shares. `parse_remote` therefore mints a slug for `github.com` and nothing else. A card with nothing to say is **absent, not empty**; `missingCard` says once what the folder can't do.

## Three things that were easy to get wrong

- **Per-project cost comes from `cc-usage-detail`, never `cc-usage`.** The plain rollup is every project's spend that day at once, so attributing it to whichever dashboard is open would invent a number. Days before the detail split legitimately have none — the strip shows a dash rather than `$0.00`, because "we didn't keep this" and "it was free" are different facts.
- **The list drops empty days and the sparkline must not.** `trailDays` omits a day nothing happened on; `densePerDay` fills them back in, or two busy days a week apart render as two adjacent bars and read as "constantly busy".
- **⌘I collapses to a 44px rail here, not to nothing** — the header gave History/Terminal/Run to the inspector, so hiding the panel would hide real verbs. On a session it still hides completely.

## The work log

`.episko/digest.md` is the one thing Episko generates and then commits. It is **read before anything is generated**, so the second person to open a week pays nothing for it. Creating it needs an explicit per-project yes (`cc-digest-ok`), like `tasks.toml` — this is the third thing Episko writes outside its own config. Only a *closed* day is written; today's line still changes, and each change would dirty a tracked file.

## Ported from the `feat/overview` spike

`trail.ts`, `notes.ts`, `summarize.rs`, `git_log_days` — rescoped to one project, tests included, unchanged otherwise. `summarize_day` gained a `root` key so two projects can't answer each other's days. `openTerminalIn` and `copyPath` moved `projmenu.ts` → `actions.ts` now that two surfaces want them.

## Verification

- **519 vitest** (+51: 17 `dash`, 22 `trail`, 12 `notes`) · **118 cargo** (+18) · clippy clean on `-D warnings` · `tsc` clean · build clean · no import cycles.
- Coverage: 89.5% over loaded modules, 20.55% over all of `src/`. `CLAUDE.md` updated in the same commit.
- **Not verified:** the pane has never been rendered — no live run. Specifically unexercised: `summarize_day` against the real CLI, the `.episko/digest.md` write against a real repo, and every hover/collapse transition. That is the click-through.

## Deliberately not here

Shared **notes** (`.episko/notes.toml`). Both remaining `.episko` writes — notes and the issue-close/claim path — land together in PR 3, so one review covers everything that writes into a user's repo.

Closes #49 as superseded when this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
