### PR TITLE
The GitHub half: open work, triage, and saying who has what

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ pnpm coverage           # the same suites with v8 coverage
 ```
 
 Coverage is a **yardstick, not a target** — there is deliberately no gate, because the
-render and DOM-owning modules are untested by design. Current: **89.5%** statements
-over the modules the suites load, **20.55%** over all of `src/`, and **71.0%** Rust
+render and DOM-owning modules are untested by design. Current: **90.05%** statements
+over the modules the suites load, **20.9%** over all of `src/`, and **71.0%** Rust
 lines (`cargo llvm-cov --summary-only` from `src-tauri/`). Both gaps are the OS edge,
 which `RELEASE.md` covers by hand. Note vitest's `text` reporter **hides any file at
 100% in all four columns**, so a fully-covered module looks absent; use
@@ -52,9 +52,9 @@ Mac has the same symlink — but it is one both legs will find at once.
 
 **Package manager: `pnpm`** for this repo (there's a `pnpm-lock.yaml`; both CI workflows use `pnpm install --frozen-lockfile`, and `packageManager` in `package.json` pins the version for corepack/CI). Use pnpm here, not npm. Windows code-signing / release-signing setup lives in `src-tauri/SIGNING.md`.
 
-Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **519 vitest + cargo (118 on macOS, 115 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
+Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **558 vitest + cargo (140 on macOS, 137 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
 
-**vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which fifteen those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
+**vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which seventeen those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
 
 What is **untested by design**: the render, view and DOM-owning modules on both sides of the app — snapshotting template literals mostly re-asserts itself. Anything touching the DOM, PTYs, or live telemetry is still verified by **running the app and exercising it** — the statusLine half of telemetry only fires in interactive mode, so it cannot be checked end to end with `claude -p`. Split that one carefully, because the split is not where it looks: whether the generated statusLine command *works* is checked headlessly and in CI (the shell runs it for real — see the constraint above). What needs a live REPL is only whether **Claude still picks the shell and payload we expect**. That costs a TTY, not tokens: a session you launch and never prompt makes no API call, and the statusLine fires on start and every `refreshInterval` seconds regardless. It's a `RELEASE.md` click-through, and a cheap one. `tsc` (strict) is the real linter. Requires `claude` on PATH, the Node in `.nvmrc` (`nvm use`; `engines` floors it at 24), and Rust stable + Tauri system deps.
 
@@ -288,6 +288,48 @@ Three things that are easy to get wrong:
   live in the inspector — so hiding the panel outright would hide real verbs. On a
   session ⌘I still hides it completely.
 
+### The GitHub half
+
+`ghwork.ts` owns the rules and is tested; `claim.ts` owns what a dispatch writes.
+`gh_threads` is two `gh` calls per repo, cached 60s, and **degrades rather than
+failing**: gh missing, logged out or pointed at a non-GitHub folder is `available:
+false` plus a reason, shown as one quiet row like a blocked runnable.
+
+- **A claim is a hint, never a lock.** Nothing refuses a dispatch; someone else's claim
+  is shown, warned about once, and then you proceed — two people may well both want a
+  go at a hard bug. Claims expire (`CLAIM_STALE_MS`), because a laptop that slept must
+  not block a colleague forever, and a `pty-exit` releases whatever that session took.
+- **Two levels decide what gets written, and the project is a ceiling**: your
+  preference, ANDed with `.episko/episko.toml`'s `[claim]`. A switch the project turned
+  off renders greyed rather than hidden — "why can't I assign?" needs an answer.
+- **`holderOf` reads three signals in one order and it is not arbitrary**: our own
+  ledger first (it knows a dispatch nothing has been pushed for yet), then the assignee
+  (the explicit human signal), then an `agent:` label (a machine, which cannot say
+  whose).
+- **Triage never offers a pull request**, never offers an assigned issue, and never
+  offers one on the project's keep list. A quiet PR needs review or a rebase, not
+  closing; the rest is a bot second-guessing a human, which is what makes a team switch
+  triage off.
+- **`gh_close_issue` is the only destructive write**, and it comments *before* it
+  closes: if the close then fails the issue carries a note explaining what was
+  attempted, which is recoverable, where the other order leaves it closed with no
+  explanation.
+- **Dispatch sends the prompt**, which breaks the app's usual "Episko prefills, the
+  human presses Enter" rule — deliberately, and only here: that rule exists so nothing
+  is sent you did not read, and a dispatch confirmed in a sheet *is* the reading. A
+  colleague's shared note is still prefilled-not-sent: that is somebody else's sentence.
+- **The viewer is cached for the process, not per repo.** `gh api user` returns the
+  same login whichever folder it runs in, so keying it by root spent a process per
+  project for an answer already in hand.
+
+**Three committed files, one rule.** `.episko/digest.md` (the work log),
+`.episko/episko.toml` (`[triage] keep`, beside `[claim]`) and `.episko/notes.toml` (a
+promoted note) are all **project facts** — decided once, by anyone, and true for the
+team. All three go through `toml_edit`/read-modify-write so a hand-written comment
+survives, all three refuse to create themselves without an explicit yes, and all three
+need **git, not GitHub**: they are files, and a file only means anything to a team if
+it can be committed.
+
 **The work log is the one thing Episko generates and then commits.** `summarize_day`
 spends money (one `claude -p` per day, Haiku), so it is cached, opt-in, and **read
 before it is generated**: `read_digest` parses `.episko/digest.md` first, which means
@@ -419,9 +461,9 @@ Lane colours are `--gl-0…7`, re-stepped for the light theme like every other p
 `styles.css`. Scope (`all refs` / `this branch`) resets on each open and is deliberately
 **not** persisted — all-refs is the answer the panel exists to give.
 
-## Backend (`src-tauri/src/`) — eleven modules
+## Backend (`src-tauri/src/`) — thirteen modules
 
-`main.rs` only calls `episko_lib::run()`. `lib.rs` is **bootstrap, not the backend**: 518 lines out of ~11,020 (the counts below are whole files, in-file `#[cfg(test)] mod tests` included — that is most of `telemetry.rs`). Dependencies point downward, `platform.rs` at the bottom.
+`main.rs` only calls `episko_lib::run()`. `lib.rs` is **bootstrap, not the backend**: 518 lines out of ~12025 (the counts below are whole files, in-file `#[cfg(test)] mod tests` included — that is most of `telemetry.rs`). Dependencies point downward, `platform.rs` at the bottom.
 
 | Module | Lines | What |
 | --- | --- | --- |
@@ -433,6 +475,8 @@ Lane colours are `--gl-0…7`, re-stepped for the light theme like every other p
 | `telemetry.rs` | 926 | `write_instrument_settings`, `run_telemetry_server`, `resolve_permission` |
 | `platform.rs` | 750 | OS leaves (top half, incl. `norm_path`/`physical_cwd`) + OS integrations (bottom half) |
 | `external.rs` | 339 | the `~/.claude/sessions` registry, `ProcTable`, terminal focus |
+| `github.rs` | 816 | `gh` — issues/PRs, the claim writes, closing, the committed keep list |
+| `notes.rs` | 175 | shared notes (`.episko/notes.toml`) |
 | `summarize.rs` | 446 | `summarize_day` (Haiku via `claude -p`) + the committed `.episko/digest.md` |
 | `icons.rs` | 184 | project favicon/logo probing |
 | `testutil.rs` | 50 | `git`, `scratch_dir`, `cfg(test)` only |
@@ -450,13 +494,13 @@ Four conventions hold across them:
 - **Telemetry server** (`run_telemetry_server`) forwards `/hook` and `/statusline` POSTs as one `telemetry` event each; `/permission` is the blocking path described above.
 - Commands are registered in the `invoke_handler![...]` list at the bottom of `run()` — add new `#[tauri::command]` fns there.
 
-## Frontend (`src/`, `index.html`, `src/styles.css`) — 44 modules
+## Frontend (`src/`, `index.html`, `src/styles.css`) — 46 modules
 
-**No framework, and no longer one file.** ~11,180 lines across 44 modules; `main.ts` is 766 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
+**No framework, and no longer one file.** ~11953 lines across 46 modules; `main.ts` is 766 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (~70 lines — it is the seam map, and belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, the window controls (see One title bar), and the seven `setInterval`s.
 
-**Tested logic modules** (fifteen — no DOM, no Tauri, no render imports; these are what the 519 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
+**Tested logic modules** (seventeen — no DOM, no Tauri, no render imports; these are what the 558 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
 
 | Module | What |
 | --- | --- |
@@ -475,6 +519,8 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 | `trail.ts` | a day of work assembled from transcripts, git and the usage rollup; `dayFacts` |
 | `notes.ts` | the one thing on the dashboard you type — capture, filing, removal |
 | `dash.ts` | the project dashboard's rules: `projectTier`, `dashDays`, `dashPulse`, `projectCost` |
+| `ghwork.ts` | issues and PRs: recency buckets, what triage dares suggest, who already has one |
+| `claim.ts` | what Episko writes when you dispatch at shared work, and who decides |
 
 **Shared**: `state.ts` (the session map, the stage pointer, every persisted preference) and `dom.ts` (`$`, `toast`, the shared scrim, `IS_MAC`/`MOD`/`chord`).
 
@@ -484,7 +530,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 
 **Behaviour** — IPC and DOM all the way down, so untested too, and therefore the thinnest ice in the app: `panes` (the three spawners + a pane's lifecycle), `terminal` (the xterm plumbing), `taskrun` (run on stop), `actions` (the app-level verbs), `icons` (the per-project glyph store).
 
-Four rules keep that graph honest. **There are no import cycles across the 44 modules; re-run a cycle check after any change that adds an import.**
+Four rules keep that graph honest. **There are no import cycles across the 46 modules; re-run a cycle check after any change that adds an import.**
 
 - **Dependency direction is state ← render ← wiring.** A logic module must not import render code or `main.ts`.
 - **When an extracted function needs something that lives further up**, resolve it in this order: (1) **move the callee down too** if it is itself leaf-shaped — that is why `icons.ts` sits below `sidebar.ts` and `usage.ts` below `phase.ts`; (2) **a settable hook defaulting to a no-op** (`setRlLogger`, `setPanesRenderAll`) when the callee genuinely belongs to the render layer; (3) **an extra parameter** only as a last resort, since it changes a signature the move was supposed to leave alone. A control panel touching many things it doesn't own may take **one host object** instead of N setters (`settings`, `palui`, `projmenu`); prefer per-callee setters below ~4.

--- a/index.html
+++ b/index.html
@@ -110,6 +110,10 @@
               </div>
             </div>
             <div class="ovl" id="dashOverlay"></div>
+            <!-- Both writes this pane can make to GitHub are public, so neither
+                 happens without a sheet showing exactly what will be written. -->
+            <div class="dsh-scrim" id="dashScrim"></div>
+            <div class="dsh" id="dashSheet"></div>
           </div>
         </div>
       </main>

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -1,0 +1,816 @@
+// GitHub, through the `gh` CLI — issues and PRs as threads, and the claim Episko
+// writes when you dispatch an agent at one.
+//
+// WHY `gh` AND NOT THE API. Auth. `gh` already holds the user's token, refreshes it,
+// honours enterprise hosts and `GH_TOKEN`, and is the thing they already trust with
+// this repo. Shipping our own OAuth flow to duplicate that would be a worse product
+// and a much larger attack surface, so Episko borrows the credential rather than
+// asking for one. The cost is a process per call, which is why reads are cached.
+//
+// DEGRADE, NEVER FAIL. `gh` may be missing, logged out, or pointed at a folder that
+// is not a GitHub repo. None of those is an error the user needs to see as breakage:
+// every read answers with `available: false` and a reason the UI can show as a single
+// quiet row, exactly like a blocked runnable. Only an explicit *write* the user asked
+// for reports failure loudly.
+//
+// The write half is deliberately small — assign, one edited-in-place comment, an
+// optional label — because a claim is a hint, never a lock. See ./claim.ts for the
+// rules that shape it.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use crate::platform::{augmented_path, sys_command};
+
+/// How long a read stays fresh. Long enough that opening a board twice costs one
+/// round trip, short enough that a colleague's push shows up on the timescale the
+/// rest of the collaborator signals do.
+const TTL: Duration = Duration::from_secs(60);
+
+/// One issue or PR, flattened to what a thread row needs. Deliberately not the whole
+/// GitHub object: the board shows a title, who has it, and how stale it is.
+#[derive(serde::Serialize, Clone, Debug, PartialEq)]
+pub(crate) struct GhThread {
+    pub number: i64,
+    pub kind: String, // "issue" | "pr"
+    pub title: String,
+    pub url: String,
+    /// Login names. Empty means nobody has claimed it.
+    pub assignees: Vec<String>,
+    pub labels: Vec<String>,
+    /// The PR's head branch — the link between a PR and a checkout we can see locally.
+    pub branch: Option<String>,
+    pub author: Option<String>,
+    pub draft: bool,
+    /// ISO-8601, straight from gh. Parsed by the frontend, which already formats time.
+    pub updated_at: String,
+}
+
+#[derive(serde::Serialize, Clone, Debug)]
+pub(crate) struct GhResult {
+    /// False when gh is absent, unauthenticated, or this folder is not a GitHub repo.
+    pub available: bool,
+    /// Why not — shown as one quiet row rather than an error dialog.
+    pub reason: Option<String>,
+    pub threads: Vec<GhThread>,
+    /// Who `gh` thinks you are, so the UI can tell your claims from a colleague's.
+    pub viewer: Option<String>,
+}
+
+impl GhResult {
+    fn unavailable(reason: impl Into<String>) -> Self {
+        Self { available: false, reason: Some(reason.into()), threads: vec![], viewer: None }
+    }
+}
+
+struct Cached { at: Instant, result: GhResult }
+
+// Keyed by repo root. A Mutex rather than a channel because every access is a short
+// map lookup, and the same reasoning as `discover_cached` in tasks.rs: the cheap thing
+// is to remember, not to coordinate.
+static CACHE: Mutex<Option<HashMap<String, Cached>>> = Mutex::new(None);
+
+/// Who `gh` thinks you are. **Cached for the life of the process, and deliberately
+/// NOT per repo**: `gh api user` returns the same login whichever folder it is run in,
+/// so keying it by root spent one extra process per project for an answer already in
+/// hand. With a dashboard per project that was a real cost — it is the same call, N
+/// times, for one string that cannot differ.
+static VIEWER: Mutex<Option<Option<String>>> = Mutex::new(None);
+
+fn viewer_login(root: &str) -> Option<String> {
+    if let Ok(g) = VIEWER.lock() {
+        if let Some(v) = g.as_ref() {
+            return v.clone();
+        }
+    }
+    let v = gh(root, &["api", "user", "--jq", ".login"])
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    // A failure is cached too: an unauthenticated gh will keep failing, and retrying
+    // it on every project click is a process per click for a known answer.
+    if let Ok(mut g) = VIEWER.lock() {
+        *g = Some(v.clone());
+    }
+    v
+}
+
+fn gh(root: &str, args: &[&str]) -> Result<String, String> {
+    let out = sys_command("gh")
+        .env("PATH", augmented_path())
+        // gh infers the repo from the working directory; there is no -C equivalent.
+        .current_dir(root)
+        .args(args)
+        // Never let gh try to open a browser or prompt: this runs with no terminal.
+        .env("GH_PROMPT_DISABLED", "1")
+        .env("GH_NO_UPDATE_NOTIFIER", "1")
+        .output()
+        .map_err(|e| format!("gh not available: {e}"))?;
+    if !out.status.success() {
+        let err = String::from_utf8_lossy(&out.stderr);
+        let first = err.lines().find(|l| !l.trim().is_empty()).unwrap_or("gh failed");
+        return Err(first.trim().to_string());
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+/// Map gh's own failure text to something a person can act on.
+///
+/// This is the one place we look at gh's stderr prose, and only to *classify* — the
+/// data paths all parse `--json`. Worth the exception because "gh: command not found"
+/// and "you are not logged in" need very different responses from the user, and gh
+/// gives no distinguishing exit code.
+fn classify(err: &str) -> String {
+    let e = err.to_lowercase();
+    if e.contains("not found") && e.contains("gh") { return "GitHub CLI (gh) is not installed".into(); }
+    if e.contains("auth") || e.contains("logged in") || e.contains("token") {
+        return "gh is not authenticated — run `gh auth login`".into();
+    }
+    if e.contains("not a git repository") || e.contains("no git remotes") || e.contains("could not determine") {
+        return "not a GitHub repository".into();
+    }
+    err.to_string()
+}
+
+// ---------- parsing ----------
+// Split out from the fetch so it can be tested against fixtures without a network,
+// a token, or a repo — the parsing is where the bugs live, not the process spawn.
+
+pub(crate) fn parse_issues(json: &str) -> Vec<GhThread> {
+    parse_list(json, "issue")
+}
+pub(crate) fn parse_prs(json: &str) -> Vec<GhThread> {
+    parse_list(json, "pr")
+}
+
+fn parse_list(json: &str, kind: &str) -> Vec<GhThread> {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(json) else { return vec![] };
+    let Some(arr) = v.as_array() else { return vec![] };
+    arr.iter()
+        .filter_map(|o| {
+            let number = o.get("number")?.as_i64()?;
+            Some(GhThread {
+                number,
+                kind: kind.to_string(),
+                title: o.get("title").and_then(|x| x.as_str()).unwrap_or("").to_string(),
+                url: o.get("url").and_then(|x| x.as_str()).unwrap_or("").to_string(),
+                assignees: o
+                    .get("assignees")
+                    .and_then(|x| x.as_array())
+                    .map(|a| a.iter().filter_map(|u| u.get("login").and_then(|l| l.as_str()).map(String::from)).collect())
+                    .unwrap_or_default(),
+                labels: o
+                    .get("labels")
+                    .and_then(|x| x.as_array())
+                    .map(|a| a.iter().filter_map(|l| l.get("name").and_then(|n| n.as_str()).map(String::from)).collect())
+                    .unwrap_or_default(),
+                branch: o.get("headRefName").and_then(|x| x.as_str()).map(String::from),
+                author: o.get("author").and_then(|a| a.get("login")).and_then(|l| l.as_str()).map(String::from),
+                draft: o.get("isDraft").and_then(|x| x.as_bool()).unwrap_or(false),
+                updated_at: o.get("updatedAt").and_then(|x| x.as_str()).unwrap_or("").to_string(),
+            })
+        })
+        .collect()
+}
+
+// ---------- reads ----------
+
+/// Open issues and PRs for the repo at `root`, cached for TTL.
+///
+/// Two `gh` calls, never one per item. `force` bypasses the cache for an explicit
+/// refresh; everything else — opening the board, switching altitude, a repaint — is
+/// served from memory, which is what stops a render loop becoming a network loop.
+#[tauri::command]
+pub(crate) async fn gh_threads(root: String, force: bool) -> GhResult {
+    tauri::async_runtime::spawn_blocking(move || {
+        if !force {
+            if let Ok(guard) = CACHE.lock() {
+                if let Some(hit) = guard.as_ref().and_then(|m| m.get(&root)) {
+                    if hit.at.elapsed() < TTL {
+                        return hit.result.clone();
+                    }
+                }
+            }
+        }
+
+        let issues = gh(&root, &[
+            "issue", "list", "--state", "open", "--limit", "60",
+            "--json", "number,title,url,assignees,labels,updatedAt",
+        ]);
+        let result = match issues {
+            Err(e) => GhResult::unavailable(classify(&e)),
+            Ok(issue_json) => {
+                let mut threads = parse_issues(&issue_json);
+                // A PR failure is not fatal: issues alone are still a useful board.
+                if let Ok(pr_json) = gh(&root, &[
+                    "pr", "list", "--state", "open", "--limit", "60",
+                    "--json", "number,title,url,assignees,labels,updatedAt,headRefName,author,isDraft",
+                ]) {
+                    threads.extend(parse_prs(&pr_json));
+                }
+                GhResult { available: true, reason: None, threads, viewer: viewer_login(&root) }
+            }
+        };
+
+        if let Ok(mut guard) = CACHE.lock() {
+            guard.get_or_insert_with(HashMap::new)
+                .insert(root.clone(), Cached { at: Instant::now(), result: result.clone() });
+        }
+        result
+    })
+    .await
+    .unwrap_or_else(|e| GhResult::unavailable(format!("gh task failed: {e}")))
+}
+
+/// Drop a repo's cached reads so the next call goes to the network.
+#[tauri::command]
+pub(crate) fn gh_invalidate(root: String) {
+    if let Ok(mut guard) = CACHE.lock() {
+        if let Some(m) = guard.as_mut() {
+            m.remove(&root);
+        }
+    }
+}
+
+// ---------- writes ----------
+
+/// The marker that makes the sticky comment ours to edit.
+///
+/// `gh issue comment --edit-last` edits the last comment *by you*, which is not
+/// necessarily this one — you may have replied since. The marker lets us check we are
+/// about to overwrite our own note rather than a real reply, and it also tells a
+/// reader on GitHub that a machine wrote it.
+const MARKER: &str = "<!-- episko:claim -->";
+
+#[derive(serde::Serialize)]
+pub(crate) struct ClaimOutcome {
+    pub assigned: bool,
+    pub commented: bool,
+    pub labeled: bool,
+    /// Everything that did not work, in the user's words rather than gh's.
+    pub problems: Vec<String>,
+}
+
+/// Claim a thread: assign yourself, and/or leave one comment that is edited in place.
+///
+/// Every part is independent and best-effort — a repo where you cannot assign (no
+/// write access) should still get the comment, and a failure of either is reported
+/// without undoing the other. Nothing here refuses: this records a claim, it does not
+/// enforce one.
+#[tauri::command]
+pub(crate) async fn gh_claim(
+    root: String,
+    number: i64,
+    kind: String,
+    assign: bool,
+    comment: bool,
+    label: String,
+    body: String,
+) -> ClaimOutcome {
+    tauri::async_runtime::spawn_blocking(move || {
+        let noun = if kind == "pr" { "pr" } else { "issue" };
+        let n = number.to_string();
+        let mut out = ClaimOutcome { assigned: false, commented: false, labeled: false, problems: vec![] };
+
+        if assign {
+            match gh(&root, &[noun, "edit", &n, "--add-assignee", "@me"]) {
+                Ok(_) => out.assigned = true,
+                Err(e) => out.problems.push(format!("assign: {}", classify(&e))),
+            }
+        }
+        if !label.is_empty() {
+            match gh(&root, &[noun, "edit", &n, "--add-label", &label]) {
+                Ok(_) => out.labeled = true,
+                Err(e) => out.problems.push(format!("label: {}", classify(&e))),
+            }
+        }
+        if comment {
+            let text = format!("{MARKER}\n{body}");
+            // --edit-last --create-if-none: ONE comment per thread, updated. Appending
+            // a new comment per dispatch is the behaviour that makes bots unwelcome.
+            let edited = gh(&root, &[noun, "comment", &n, "--edit-last", "--create-if-none", "--body", &text]);
+            match edited {
+                Ok(_) => out.commented = true,
+                Err(e) => {
+                    // Older gh has no --create-if-none; fall back to a plain comment so
+                    // the claim still lands rather than being silently skipped.
+                    match gh(&root, &[noun, "comment", &n, "--body", &text]) {
+                        Ok(_) => out.commented = true,
+                        Err(_) => out.problems.push(format!("comment: {}", classify(&e))),
+                    }
+                }
+            }
+        }
+
+        gh_invalidate(root);
+        out
+    })
+    .await
+    .unwrap_or(ClaimOutcome { assigned: false, commented: false, labeled: false, problems: vec!["claim task failed".into()] })
+}
+
+/// Release a claim — the agent ended without pushing, so the thread is free again.
+///
+/// The failure mode this exists to prevent is a graveyard of dead claims: a claim that
+/// is never released is worse than no claim, because it tells a colleague someone is
+/// working on something nobody is.
+#[tauri::command]
+pub(crate) async fn gh_release(
+    root: String,
+    number: i64,
+    kind: String,
+    label: String,
+    body: String,
+) -> ClaimOutcome {
+    tauri::async_runtime::spawn_blocking(move || {
+        let noun = if kind == "pr" { "pr" } else { "issue" };
+        let n = number.to_string();
+        let mut out = ClaimOutcome { assigned: false, commented: false, labeled: false, problems: vec![] };
+
+        if let Err(e) = gh(&root, &[noun, "edit", &n, "--remove-assignee", "@me"]) {
+            out.problems.push(format!("unassign: {}", classify(&e)));
+        }
+        if !label.is_empty() {
+            if let Err(e) = gh(&root, &[noun, "edit", &n, "--remove-label", &label]) {
+                out.problems.push(format!("label: {}", classify(&e)));
+            }
+        }
+        if !body.is_empty() {
+            let text = format!("{MARKER}\n{body}");
+            let _ = gh(&root, &[noun, "comment", &n, "--edit-last", "--create-if-none", "--body", &text]);
+        }
+        gh_invalidate(root);
+        out
+    })
+    .await
+    .unwrap_or(ClaimOutcome { assigned: false, commented: false, labeled: false, problems: vec!["release task failed".into()] })
+}
+
+// ---------- what happened, and when ----------
+
+/// One thing that happened to an issue or PR on a given day. The Trail buckets these
+/// by date, so what a day *closed* reads as clearly as what it started.
+#[derive(serde::Serialize, Clone, Debug, PartialEq)]
+pub(crate) struct GhEvent {
+    pub number: i64,
+    pub kind: String,  // "issue" | "pr"
+    pub event: String, // "opened" | "closed" | "merged"
+    pub title: String,
+    pub url: String,
+    /// ISO-8601 — the frontend already owns calendar-day bucketing (`dayKeyOf`), and
+    /// doing it here would risk the two disagreeing about where midnight falls.
+    pub at: String,
+}
+
+/// Derive events from a list that carries `createdAt`, `closedAt` and (for PRs)
+/// `mergedAt`.
+///
+/// One item can produce two events — opened on Monday, merged on Thursday — and both
+/// matter, so this fans out rather than reducing to a current state. `mergedAt` wins
+/// over `closedAt`: GitHub sets both when a PR merges, and "merged" is the true story.
+pub(crate) fn parse_events(json: &str, kind: &str) -> Vec<GhEvent> {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(json) else { return vec![] };
+    let Some(arr) = v.as_array() else { return vec![] };
+    let mut out = Vec::new();
+    for o in arr {
+        let Some(number) = o.get("number").and_then(|x| x.as_i64()) else { continue };
+        let title = o.get("title").and_then(|x| x.as_str()).unwrap_or("").to_string();
+        let url = o.get("url").and_then(|x| x.as_str()).unwrap_or("").to_string();
+        let at = |k: &str| o.get(k).and_then(|x| x.as_str()).filter(|s| !s.is_empty()).map(String::from);
+        let mk = |event: &str, when: String| GhEvent {
+            number, kind: kind.to_string(), event: event.to_string(),
+            title: title.clone(), url: url.clone(), at: when,
+        };
+        if let Some(w) = at("createdAt") { out.push(mk("opened", w)); }
+        if let Some(w) = at("mergedAt") {
+            out.push(mk("merged", w));
+        } else if let Some(w) = at("closedAt") {
+            out.push(mk("closed", w));
+        }
+    }
+    out
+}
+
+struct CachedEvents { at: Instant, events: Vec<GhEvent> }
+static EVENT_CACHE: Mutex<Option<HashMap<String, CachedEvents>>> = Mutex::new(None);
+
+/// Everything that opened, closed or merged in this repo recently.
+///
+/// `--state all` in two calls rather than one per state: gh has no "changed since"
+/// filter for these, so the window is applied by the caller after bucketing. The limit
+/// is what bounds the work — 120 covers a very busy month and costs two requests.
+#[tauri::command]
+pub(crate) async fn gh_day_activity(root: String, force: bool) -> Vec<GhEvent> {
+    tauri::async_runtime::spawn_blocking(move || {
+        if !force {
+            if let Ok(guard) = EVENT_CACHE.lock() {
+                if let Some(hit) = guard.as_ref().and_then(|m| m.get(&root)) {
+                    if hit.at.elapsed() < TTL {
+                        return hit.events.clone();
+                    }
+                }
+            }
+        }
+        let mut out = Vec::new();
+        if let Ok(j) = gh(&root, &[
+            "issue", "list", "--state", "all", "--limit", "120",
+            "--json", "number,title,url,createdAt,closedAt",
+        ]) {
+            out.extend(parse_events(&j, "issue"));
+        }
+        if let Ok(j) = gh(&root, &[
+            "pr", "list", "--state", "all", "--limit", "120",
+            "--json", "number,title,url,createdAt,closedAt,mergedAt",
+        ]) {
+            out.extend(parse_events(&j, "pr"));
+        }
+        if let Ok(mut guard) = EVENT_CACHE.lock() {
+            guard.get_or_insert_with(HashMap::new)
+                .insert(root.clone(), CachedEvents { at: Instant::now(), events: out.clone() });
+        }
+        out
+    })
+    .await
+    .unwrap_or_default()
+}
+
+/// Close an issue, with a comment saying why.
+///
+/// **The only destructive write Episko makes to GitHub**, and the reason the UI never
+/// does it on one click: it is public, it notifies every watcher, and "close" is not a
+/// thing you can quietly undo for other people who already read the notification. The
+/// comment is required rather than optional — a stale-close with no reason is the kind
+/// of bot behaviour that makes a team turn the whole feature off.
+///
+/// The comment goes first: if the close then fails, the issue has a note explaining
+/// what was attempted, which is recoverable. The other order can leave an issue closed
+/// with no explanation at all.
+#[tauri::command]
+pub(crate) async fn gh_close_issue(root: String, number: i64, comment: String) -> Result<(), String> {
+    let body = comment.trim().to_string();
+    if body.is_empty() {
+        return Err("a closing comment is required".into());
+    }
+    tauri::async_runtime::spawn_blocking(move || {
+        let n = number.to_string();
+        gh(&root, &["issue", "comment", &n, "--body", &body]).map_err(|e| classify(&e))?;
+        gh(&root, &["issue", "close", &n]).map_err(|e| classify(&e))?;
+        gh_invalidate(root.clone());
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("gh task failed: {e}"))?
+}
+
+// ---------- the project's own policy ----------
+
+/// What a project permits, from `.episko/episko.toml`:
+///
+/// ```toml
+/// [claim]
+/// assign = false     # this team uses assignment for planning
+/// comment = true
+/// ```
+///
+/// **Absent means everything is allowed.** A repo that has never heard of Episko must
+/// not silently disable features, and a missing file is not a policy. Only keys that
+/// are present and `false` take anything away — the file is a ceiling, never a default.
+#[derive(serde::Serialize, Debug, PartialEq)]
+pub(crate) struct ClaimAllow {
+    pub assign: bool,
+    pub comment: bool,
+    pub push_branch: bool,
+    pub label: bool,
+}
+
+impl Default for ClaimAllow {
+    fn default() -> Self {
+        Self { assign: true, comment: true, push_branch: true, label: true }
+    }
+}
+
+/// Every field is `Option`, and that is the whole design: absent must mean "allowed",
+/// not "false". A serde `Default` on a bool would silently deny everything the file
+/// forgot to mention, turning an incomplete policy into a total lockout.
+#[derive(serde::Deserialize, Default)]
+struct RawFile { claim: Option<RawClaim> }
+#[derive(serde::Deserialize, Default)]
+struct RawClaim {
+    assign: Option<bool>,
+    comment: Option<bool>,
+    push_branch: Option<bool>,
+    label: Option<bool>,
+}
+
+pub(crate) fn parse_allow(toml_text: &str) -> ClaimAllow {
+    let mut a = ClaimAllow::default();
+    // A malformed file must not lock a team out of their own claims — the same
+    // forgiving-on-read stance tasks.rs takes with a broken tasks.toml.
+    let Ok(file) = toml::from_str::<RawFile>(toml_text) else { return a };
+    let Some(c) = file.claim else { return a };
+    if let Some(x) = c.assign { a.assign = x; }
+    if let Some(x) = c.comment { a.comment = x; }
+    if let Some(x) = c.push_branch { a.push_branch = x; }
+    if let Some(x) = c.label { a.label = x; }
+    a
+}
+
+/// The project's claim policy. Reads `<root>/.episko/episko.toml`; a missing or
+/// unreadable file is "everything allowed", not an error.
+#[tauri::command]
+pub(crate) fn claim_policy(root: String) -> ClaimAllow {
+    std::path::Path::new(&root)
+        .join(".episko")
+        .join("episko.toml")
+        .pipe_read()
+        .map(|t| parse_allow(&t))
+        .unwrap_or_default()
+}
+
+// ---------- the keep list ----------
+// "We decided #24 stays open" is a project fact, not a personal preference, so it is
+// committed: decide once and nobody on the team is asked about that issue again. The
+// cost of that choice is that it has to be *auditable* — a committed decision nobody
+// can see is worse than no decision — which is why the UI shows the list with who
+// added each entry and an undo, and why this stores a `who` alongside the number.
+//
+// `toml_edit`, not a serialize-the-whole-struct round trip: the file may carry a
+// hand-written `[claim]` block with comments, and rewriting it wholesale would eat
+// them. Same rule tasks.rs follows for tasks.toml.
+
+fn episko_toml(root: &str) -> std::path::PathBuf {
+    std::path::Path::new(root).join(".episko").join("episko.toml")
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+pub(crate) struct KeptIssue {
+    pub number: i64,
+    /// Who decided, so the list reads as a record rather than an anonymous blocklist.
+    pub who: String,
+    /// ISO-8601 date, day resolution — the hour adds nothing and churns the diff.
+    pub at: String,
+}
+
+/// Issues this project has decided to keep, so triage stops suggesting them.
+#[tauri::command]
+pub(crate) fn list_kept(root: String) -> Vec<KeptIssue> {
+    let Ok(text) = std::fs::read_to_string(episko_toml(&root)) else { return vec![] };
+    let Ok(doc) = text.parse::<toml_edit::DocumentMut>() else { return vec![] };
+    let Some(arr) = doc.get("triage").and_then(|t| t.get("keep")).and_then(|k| k.as_array()) else {
+        return vec![];
+    };
+    arr.iter()
+        .filter_map(|v| {
+            let t = v.as_inline_table()?;
+            Some(KeptIssue {
+                number: t.get("number")?.as_integer()?,
+                who: t.get("who").and_then(|x| x.as_str()).unwrap_or("").to_string(),
+                at: t.get("at").and_then(|x| x.as_str()).unwrap_or("").to_string(),
+            })
+        })
+        .collect()
+}
+
+/// Add or remove one. `create` gates the very first write for the same reason the
+/// digest's does: a new committable file in someone's repo is a real side effect.
+#[tauri::command]
+pub(crate) fn set_kept(
+    root: String, number: i64, who: String, at: String, keep: bool, create: bool,
+) -> Result<(), String> {
+    let path = episko_toml(&root);
+    if !path.is_file() && !create {
+        return Err("no .episko/episko.toml yet".into());
+    }
+    let text = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut doc = text.parse::<toml_edit::DocumentMut>().map_err(|e| e.to_string())?;
+    if doc.get("triage").is_none() {
+        doc["triage"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    let tri = doc["triage"].as_table_mut().ok_or("triage is not a table")?;
+    if tri.get("keep").is_none() {
+        tri["keep"] = toml_edit::value(toml_edit::Array::new());
+    }
+    let arr = tri["keep"].as_array_mut().ok_or("triage.keep is not an array")?;
+    // Remove any existing entry for this number first, so a re-keep updates rather
+    // than duplicating and an un-keep is simply the removal.
+    arr.retain(|v| v.as_inline_table().and_then(|t| t.get("number")).and_then(|n| n.as_integer()) != Some(number));
+    if keep {
+        let mut t = toml_edit::InlineTable::new();
+        t.insert("number", number.into());
+        t.insert("who", who.into());
+        t.insert("at", at.into());
+        arr.push(toml_edit::Value::InlineTable(t));
+    }
+    // One entry per line: a single-line array of ten inline tables is unreadable in a
+    // diff, and a diff is the whole point of committing this.
+    for item in arr.iter_mut() {
+        item.decor_mut().set_prefix("\n  ");
+    }
+    arr.set_trailing("\n");
+    if arr.is_empty() {
+        // An empty `keep = []` is noise; drop the table when the last one goes.
+        tri.remove("keep");
+        if tri.is_empty() {
+            doc.remove("triage");
+        }
+    }
+    let dir = path.parent().ok_or("bad root")?;
+    std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+    let tmp = path.with_extension("toml.tmp");
+    std::fs::write(&tmp, doc.to_string()).map_err(|e| e.to_string())?;
+    std::fs::rename(&tmp, &path).map_err(|e| e.to_string())
+}
+
+/// Tiny helper so the command above reads as one expression.
+trait PipeRead { fn pipe_read(&self) -> Option<String>; }
+impl PipeRead for std::path::PathBuf {
+    fn pipe_read(&self) -> Option<String> { std::fs::read_to_string(self).ok() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testutil::scratch_dir;
+
+    #[test]
+    fn keep_list_round_trips_and_records_who_decided() {
+        // The list is committed, so it has to be auditable: an anonymous blocklist
+        // raises "who decided this?" on every read.
+        let d = scratch_dir();
+        let r = d.to_string_lossy().to_string();
+        assert!(set_kept(r.clone(), 24, "Tim".into(), "2026-07-31".into(), true, false).is_err());
+        set_kept(r.clone(), 24, "Tim".into(), "2026-07-31".into(), true, true).unwrap();
+        let l = list_kept(r.clone());
+        assert_eq!(l.len(), 1);
+        assert_eq!(l[0], KeptIssue { number: 24, who: "Tim".into(), at: "2026-07-31".into() });
+
+        // Un-keeping removes it, and the last removal takes the table with it.
+        set_kept(r.clone(), 24, String::new(), String::new(), false, false).unwrap();
+        assert!(list_kept(r.clone()).is_empty());
+        let text = std::fs::read_to_string(d.join(".episko").join("episko.toml")).unwrap();
+        assert!(!text.contains("keep"), "an empty keep list is noise: {text}");
+    }
+
+    #[test]
+    fn keeping_the_same_issue_twice_updates_rather_than_duplicating() {
+        let d = scratch_dir();
+        let r = d.to_string_lossy().to_string();
+        set_kept(r.clone(), 24, "Tim".into(), "2026-07-01".into(), true, true).unwrap();
+        set_kept(r.clone(), 24, "Frederic".into(), "2026-07-31".into(), true, false).unwrap();
+        let l = list_kept(r);
+        assert_eq!(l.len(), 1);
+        assert_eq!(l[0].who, "Frederic");
+    }
+
+    #[test]
+    fn a_hand_written_claim_policy_survives_a_keep() {
+        // episko.toml is shared with [claim], which a team may have hand-written with
+        // comments. toml_edit is what keeps that true.
+        let d = scratch_dir();
+        let r = d.to_string_lossy().to_string();
+        std::fs::create_dir_all(d.join(".episko")).unwrap();
+        std::fs::write(d.join(".episko").join("episko.toml"),
+            "# we use assignment for planning\n[claim]\nassign = false\n").unwrap();
+        set_kept(r.clone(), 12, "Tim".into(), "2026-07-31".into(), true, false).unwrap();
+        let text = std::fs::read_to_string(d.join(".episko").join("episko.toml")).unwrap();
+        assert!(text.contains("# we use assignment for planning"), "comment eaten: {text}");
+        assert!(!parse_allow(&text).assign, "the policy must still parse: {text}");
+        assert_eq!(list_kept(r).len(), 1);
+    }
+
+    #[test]
+    fn a_malformed_file_reads_as_an_empty_keep_list() {
+        let d = scratch_dir();
+        std::fs::create_dir_all(d.join(".episko")).unwrap();
+        std::fs::write(d.join(".episko").join("episko.toml"), "not [ valid").unwrap();
+        assert!(list_kept(d.to_string_lossy().to_string()).is_empty());
+    }
+
+
+    // Captured from `gh issue list --json …` against respeak-io/episko, trimmed.
+    const ISSUES: &str = r#"[
+      {"assignees":[],"labels":[{"name":"performance"},{"name":"prio: high"}],
+       "number":33,"title":"renderAll() runs per telemetry event","updatedAt":"2026-07-30T07:48:37Z",
+       "url":"https://github.com/respeak-io/episko/issues/33"},
+      {"assignees":[{"login":"FAbrahamDev"}],"labels":[],
+       "number":24,"title":"RFC: project board","updatedAt":"2026-07-27T12:26:45Z",
+       "url":"https://github.com/respeak-io/episko/issues/24"}
+    ]"#;
+
+    const PRS: &str = r#"[
+      {"assignees":[],"labels":[],"number":42,"title":"sidebar: a + on each worktree cluster header",
+       "updatedAt":"2026-07-30T13:39:37Z","url":"https://github.com/respeak-io/episko/pull/42",
+       "headRefName":"feat/worktree-quick-launch","author":{"login":"FAbrahamDev"},"isDraft":false}
+    ]"#;
+
+    #[test]
+    fn parses_issues_including_who_already_has_them() {
+        let t = parse_issues(ISSUES);
+        assert_eq!(t.len(), 2);
+        assert_eq!(t[0].number, 33);
+        assert_eq!(t[0].kind, "issue");
+        assert_eq!(t[0].labels, vec!["performance", "prio: high"]);
+        assert!(t[0].assignees.is_empty());
+        // The whole point of reading assignees: knowing a colleague already has it.
+        assert_eq!(t[1].assignees, vec!["FAbrahamDev"]);
+    }
+
+    #[test]
+    fn parses_prs_with_the_branch_that_links_them_to_a_local_checkout() {
+        let t = parse_prs(PRS);
+        assert_eq!(t[0].kind, "pr");
+        assert_eq!(t[0].branch.as_deref(), Some("feat/worktree-quick-launch"));
+        assert_eq!(t[0].author.as_deref(), Some("FAbrahamDev"));
+        assert!(!t[0].draft);
+    }
+
+    #[test]
+    fn malformed_output_yields_nothing_rather_than_panicking() {
+        // gh can print a warning, an empty body, or HTML from a proxy. None of those
+        // may take the board down — they degrade to "no threads".
+        for bad in ["", "not json", "{}", "null", "[{\"no\":\"number\"}]", "<html>"] {
+            assert!(parse_issues(bad).is_empty(), "should be empty for {bad:?}");
+        }
+    }
+
+    #[test]
+    fn tolerates_missing_optional_fields() {
+        // Fields differ between issue and pr payloads, and between gh versions; a row
+        // must survive on `number` alone.
+        let t = parse_issues(r#"[{"number":7}]"#);
+        assert_eq!(t.len(), 1);
+        assert_eq!(t[0].title, "");
+        assert!(t[0].branch.is_none());
+        assert!(!t[0].draft);
+    }
+
+    #[test]
+    fn one_item_can_produce_two_events_on_different_days() {
+        // Opened Monday, merged Thursday — both matter to the day they happened on, so
+        // this fans out rather than reducing to a current state.
+        let e = parse_events(r#"[{"number":46,"title":"a pr","url":"u",
+            "createdAt":"2026-07-31T12:09:32Z","closedAt":"2026-07-31T13:37:35Z","mergedAt":"2026-07-31T13:37:35Z"}]"#, "pr");
+        assert_eq!(e.len(), 2);
+        assert_eq!(e[0].event, "opened");
+        // mergedAt wins: GitHub sets closedAt too when a PR merges, and "merged" is the
+        // true story — reporting it as merely closed would misread the day.
+        assert_eq!(e[1].event, "merged");
+    }
+
+    #[test]
+    fn a_closed_but_unmerged_pr_is_closed_not_merged() {
+        let e = parse_events(r#"[{"number":9,"title":"x","url":"u",
+            "createdAt":"2026-07-01T00:00:00Z","closedAt":"2026-07-02T00:00:00Z","mergedAt":null}]"#, "pr");
+        assert_eq!(e.iter().map(|x| x.event.as_str()).collect::<Vec<_>>(), vec!["opened", "closed"]);
+    }
+
+    #[test]
+    fn an_open_issue_reports_only_its_opening() {
+        let e = parse_events(r#"[{"number":47,"title":"x","url":"u",
+            "createdAt":"2026-07-31T13:30:17Z","closedAt":null}]"#, "issue");
+        assert_eq!(e.len(), 1);
+        assert_eq!(e[0].event, "opened");
+        assert_eq!(e[0].kind, "issue");
+    }
+
+    #[test]
+    fn malformed_event_output_is_empty_rather_than_a_panic() {
+        for bad in ["", "null", "{}", "[{\"no\":\"number\"}]"] {
+            assert!(parse_events(bad, "issue").is_empty(), "{bad:?}");
+        }
+    }
+
+    #[test]
+    fn a_project_with_no_policy_permits_everything() {
+        // The load-bearing default: a repo that never heard of Episko must not
+        // silently disable features.
+        assert_eq!(parse_allow(""), ClaimAllow::default());
+        assert_eq!(parse_allow("[other]\nkey = 1"), ClaimAllow::default());
+        assert_eq!(parse_allow("not { valid toml"), ClaimAllow::default());
+    }
+
+    #[test]
+    fn a_project_can_withhold_one_thing_without_withholding_the_rest() {
+        // Tim's case exactly: "we don't use assignments for planning, but people might".
+        let a = parse_allow("[claim]\nassign = false\n");
+        assert!(!a.assign);
+        assert!(a.comment && a.push_branch && a.label);
+    }
+
+    #[test]
+    fn present_and_true_is_still_allowed() {
+        let a = parse_allow("[claim]\nassign = true\ncomment = false\n");
+        assert!(a.assign);
+        assert!(!a.comment);
+    }
+
+    #[test]
+    fn classifies_the_failures_that_need_different_answers() {
+        assert!(classify("gh: command not found").contains("not installed"));
+        assert!(classify("error: not logged in to any GitHub hosts").contains("gh auth login"));
+        assert!(classify("fatal: not a git repository").contains("not a GitHub repository"));
+        // Anything unrecognised is passed through rather than mangled into a guess.
+        assert_eq!(classify("API rate limit exceeded"), "API rate limit exceeded");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,9 @@
 
 mod external;
 mod git;
+mod github;
 mod icons;
+mod notes;
 mod platform;
 mod pty;
 mod summarize;
@@ -466,6 +468,17 @@ pub fn run() {
             git::git_commit_info,
             git::git_log_days,
             git::project_facts,
+            github::gh_threads,
+            github::gh_invalidate,
+            github::gh_claim,
+            github::gh_release,
+            github::gh_close_issue,
+            github::gh_day_activity,
+            github::claim_policy,
+            github::list_kept,
+            github::set_kept,
+            notes::list_shared_notes,
+            notes::set_shared_note,
             pty::spawn_ghostty,
             pty::spawn_shell,
             pty::spawn_task,

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -1,0 +1,175 @@
+// Shared notes — `.episko/notes.toml`, the committable half of the dashboard's jot box.
+//
+// WHY BOTH HALVES EXIST. A note starts as a half-formed thought, and half-formed
+// thoughts are not a teammate's business — so capture is personal (`localStorage`, see
+// ./notes.ts) and stays that way until you decide otherwise. Promoting one writes it
+// here, where it is committed, diffable, and readable by a colleague who never opens
+// Episko. That is the same split the app draws everywhere else: **personal preference
+// in `cc-*`, project fact in `.episko/`.**
+//
+// Sharing needs *git*, not GitHub — this is a file, and a file only means anything to
+// a team if it can be committed. A repo with a GitLab remote, or no remote at all,
+// shares exactly as well as one on GitHub.
+//
+// `toml_edit` rather than a serialize-the-whole-file round trip, like `tasks.rs`: the
+// file is meant to be hand-editable, and a colleague's comment or ordering must
+// survive Episko touching it.
+
+use std::path::{Path, PathBuf};
+
+/// One shared note. `id` is the frontend's own id, so promoting and demoting the same
+/// note is idempotent rather than producing a duplicate on the second try.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+pub(crate) struct SharedNote {
+    pub id: String,
+    pub text: String,
+    /// Who wrote it. The list is a team artifact, so an unattributed row would raise
+    /// "whose is this?" on every read.
+    pub who: String,
+    /// ISO-8601, day resolution — an hour adds nothing and churns the diff.
+    pub at: String,
+}
+
+fn notes_path(root: &str) -> PathBuf {
+    Path::new(root).join(".episko").join("notes.toml")
+}
+
+/// Everything in the project's shared list. A missing or malformed file is an empty
+/// list, never an error: the same forgiving-on-read stance `tasks.rs` takes with a
+/// broken `tasks.toml`, and for the same reason — one bad edit must not take a
+/// feature away from the whole team.
+#[tauri::command]
+pub(crate) fn list_shared_notes(root: String) -> Vec<SharedNote> {
+    let Ok(text) = std::fs::read_to_string(notes_path(&root)) else { return vec![] };
+    let Ok(doc) = text.parse::<toml_edit::DocumentMut>() else { return vec![] };
+    let Some(arr) = doc.get("note").and_then(|n| n.as_array_of_tables()) else { return vec![] };
+    arr.iter()
+        .filter_map(|t| {
+            let text = t.get("text")?.as_str()?.trim();
+            if text.is_empty() {
+                return None;
+            }
+            Some(SharedNote {
+                id: t.get("id").and_then(|x| x.as_str()).unwrap_or("").to_string(),
+                text: text.to_string(),
+                who: t.get("who").and_then(|x| x.as_str()).unwrap_or("").to_string(),
+                at: t.get("at").and_then(|x| x.as_str()).unwrap_or("").to_string(),
+            })
+        })
+        .collect()
+}
+
+/// Promote a note into the project (`share = true`) or take it back out.
+///
+/// `create` gates the very first write, because a new committable file in someone's
+/// repo is a real side effect — the same stance `tasks.rs` takes with `tasks.toml` and
+/// `summarize.rs` with `digest.md`.
+#[tauri::command]
+pub(crate) fn set_shared_note(
+    root: String, id: String, text: String, who: String, at: String, share: bool, create: bool,
+) -> Result<(), String> {
+    let path = notes_path(&root);
+    if !path.is_file() && !create {
+        return Err("no .episko/notes.toml yet".into());
+    }
+    if share && text.trim().is_empty() {
+        return Err("an empty note is not worth sharing".into());
+    }
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut doc = existing.parse::<toml_edit::DocumentMut>().map_err(|e| e.to_string())?;
+    if doc.get("note").is_none() {
+        doc["note"] = toml_edit::Item::ArrayOfTables(toml_edit::ArrayOfTables::new());
+    }
+    let arr = doc["note"].as_array_of_tables_mut().ok_or("note is not an array of tables")?;
+    // Drop any existing entry for this id first: sharing twice must update rather than
+    // duplicate, and un-sharing is simply the removal.
+    arr.retain(|t| t.get("id").and_then(|x| x.as_str()) != Some(id.as_str()));
+    if share {
+        let mut t = toml_edit::Table::new();
+        t["id"] = toml_edit::value(id);
+        t["text"] = toml_edit::value(text.trim());
+        t["who"] = toml_edit::value(who);
+        t["at"] = toml_edit::value(at);
+        arr.push(t);
+    }
+    if arr.is_empty() {
+        doc.remove("note");
+    }
+    let dir = path.parent().ok_or("bad root")?;
+    std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+    // Temp-then-rename: a crash mid-write must not truncate a file under version
+    // control.
+    let tmp = path.with_extension("toml.tmp");
+    std::fs::write(&tmp, doc.to_string()).map_err(|e| e.to_string())?;
+    std::fs::rename(&tmp, &path).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testutil::scratch_dir;
+
+    fn root_of(d: &Path) -> String { d.to_string_lossy().to_string() }
+
+    #[test]
+    fn refuses_to_create_the_file_until_it_is_allowed_to() {
+        let d = scratch_dir();
+        let r = root_of(&d);
+        assert!(set_shared_note(r.clone(), "n1".into(), "hi".into(), "Tim".into(), "2026-07-31".into(), true, false).is_err());
+        assert!(!d.join(".episko").join("notes.toml").exists());
+        set_shared_note(r.clone(), "n1".into(), "hi".into(), "Tim".into(), "2026-07-31".into(), true, true).unwrap();
+        assert_eq!(list_shared_notes(r).len(), 1);
+    }
+
+    #[test]
+    fn sharing_the_same_note_twice_updates_rather_than_duplicating() {
+        let d = scratch_dir();
+        let r = root_of(&d);
+        set_shared_note(r.clone(), "n1".into(), "first".into(), "Tim".into(), "2026-07-31".into(), true, true).unwrap();
+        set_shared_note(r.clone(), "n1".into(), "second".into(), "Tim".into(), "2026-07-31".into(), true, false).unwrap();
+        let l = list_shared_notes(r);
+        assert_eq!(l.len(), 1);
+        assert_eq!(l[0].text, "second");
+    }
+
+    #[test]
+    fn unsharing_removes_it_and_empties_the_table() {
+        let d = scratch_dir();
+        let r = root_of(&d);
+        set_shared_note(r.clone(), "n1".into(), "hi".into(), "Tim".into(), "2026-07-31".into(), true, true).unwrap();
+        set_shared_note(r.clone(), "n1".into(), String::new(), String::new(), String::new(), false, false).unwrap();
+        assert!(list_shared_notes(r).is_empty());
+        let text = std::fs::read_to_string(d.join(".episko").join("notes.toml")).unwrap();
+        assert!(!text.contains("[[note]]"), "an empty table is noise: {text}");
+    }
+
+    #[test]
+    fn a_hand_written_comment_survives_a_write() {
+        // The file is meant to be hand-editable. toml_edit is what keeps that true —
+        // a serialize-the-whole-struct round trip would eat this.
+        let d = scratch_dir();
+        let r = root_of(&d);
+        std::fs::create_dir_all(d.join(".episko")).unwrap();
+        std::fs::write(d.join(".episko").join("notes.toml"),
+            "# team notes — keep these short\n\n[[note]]\nid = \"a\"\ntext = \"existing\"\nwho = \"Frederic\"\nat = \"2026-07-20\"\n").unwrap();
+        set_shared_note(r.clone(), "b".into(), "added".into(), "Tim".into(), "2026-07-31".into(), true, false).unwrap();
+        let text = std::fs::read_to_string(d.join(".episko").join("notes.toml")).unwrap();
+        assert!(text.contains("# team notes — keep these short"), "comment was eaten: {text}");
+        assert_eq!(list_shared_notes(r).len(), 2);
+    }
+
+    #[test]
+    fn a_malformed_file_reads_as_empty_rather_than_taking_the_feature_away() {
+        let d = scratch_dir();
+        std::fs::create_dir_all(d.join(".episko")).unwrap();
+        std::fs::write(d.join(".episko").join("notes.toml"), "this is not [ valid toml").unwrap();
+        assert!(list_shared_notes(root_of(&d)).is_empty());
+    }
+
+    #[test]
+    fn an_empty_note_is_refused_rather_than_written() {
+        let d = scratch_dir();
+        let r = root_of(&d);
+        assert!(set_shared_note(r, "n1".into(), "   ".into(), "Tim".into(), "2026-07-31".into(), true, true).is_err());
+    }
+}

--- a/src/claim.ts
+++ b/src/claim.ts
@@ -1,0 +1,165 @@
+// Claiming — what Episko writes down when you dispatch an agent at shared work, and
+// who gets to decide. No DOM and no Tauri, so it unit-tests like ./thread and ./trail.
+//
+// THE PROBLEM IT SOLVES. A colleague dispatching an agent is invisible to you and has
+// to be: Episko's telemetry server binds to localhost, live pane state is deliberately
+// never committed, and git only knows what has been *pushed*. So between "Frederic
+// dispatched" and "Frederic pushed" there is a blind window of minutes to hours — and
+// that window is exactly when two people pick up the same issue. A claim collapses it
+// to one fetch interval by writing the dispatch somewhere shared.
+//
+// THREE RULES, and they are what keep this from becoming the annoying-bot problem:
+//
+//   1. **A claim is a hint, never a lock.** Nothing here refuses a dispatch. Someone
+//      else's claim is shown, warned about once, and then you proceed — two people
+//      may well both want a go at a hard bug. Same instinct as `blocked: Some(reason)`
+//      rendering greyed instead of vanishing.
+//   2. **Claims expire.** A claim carries a timestamp and reads as stale after
+//      CLAIM_STALE_MS. A laptop that went to sleep must not block a colleague forever;
+//      skip this and the feature rots into a graveyard of dead claims.
+//   3. **Two levels decide, and the project is a ceiling.** What *you* do on dispatch
+//      is personal (`cc-claim-prefs`). What the *project* permits is committed
+//      (`.episko/episko.toml`). Assignment in particular is a human planning signal in
+//      plenty of teams, so a project must be able to switch it off for everyone while
+//      leaving the rest on — the effective setting is the AND of the two.
+
+/// What Episko can write when you dispatch. Each is independent: a team may want a
+/// comment and no assignment, or a label and nothing else.
+export interface ClaimPolicy {
+  /// `gh issue edit N --add-assignee @me`. The native "I'm on this".
+  assign: boolean;
+  /// One comment per thread, EDITED in place (`--edit-last --create-if-none`), never
+  /// appended. The difference between a useful bot and an annoying one.
+  comment: boolean;
+  /// Push the dispatch branch immediately, so the claim and the presence signal become
+  /// the same mechanism — `for-each-ref` already reads it. Off by default: whether a
+  /// bare branch push starts CI is repo-dependent.
+  pushBranch: boolean;
+  /// A label like `agent: running`. Empty means off. Distinct from `assign` on purpose:
+  /// assignment says a *human* owns this, a label says a *machine* is on it right now.
+  label: string;
+}
+
+export const DEFAULT_POLICY: ClaimPolicy = {
+  assign: true,      // one API call, reversible, and the clearest signal there is
+  comment: false,    // expressive but social — opt in
+  pushBranch: false, // repo-dependent (CI triggers)
+  label: "",
+};
+
+/// What a project permits, from `.episko/episko.toml`. **Absent means everything is
+/// allowed** — a project that has never heard of Episko must not silently disable
+/// features, and a missing file is not a policy.
+export interface ClaimAllow {
+  assign: boolean;
+  comment: boolean;
+  pushBranch: boolean;
+  label: boolean;
+}
+export const ALLOW_ALL: ClaimAllow = { assign: true, comment: true, pushBranch: true, label: true };
+
+/// Where an effective value came from — so the settings tab can say *why* something is
+/// off, rather than showing a switch that silently does nothing when you flip it.
+export type PolicySource = "personal" | "project";
+export interface Resolved<T> { value: T; source: PolicySource }
+export interface ResolvedPolicy {
+  assign: Resolved<boolean>;
+  comment: Resolved<boolean>;
+  pushBranch: Resolved<boolean>;
+  label: Resolved<string>;
+}
+
+/**
+ * The effective policy: your preference, bounded by what the project permits.
+ *
+ * `source` is "project" only when the project is the reason a value is off — i.e. when
+ * you asked for it and were refused. A value you simply left off is yours.
+ */
+export function resolveClaim(personal: ClaimPolicy, allow: ClaimAllow = ALLOW_ALL): ResolvedPolicy {
+  const bool = (want: boolean, permitted: boolean): Resolved<boolean> =>
+    want && !permitted ? { value: false, source: "project" } : { value: want, source: "personal" };
+  return {
+    assign: bool(personal.assign, allow.assign),
+    comment: bool(personal.comment, allow.comment),
+    pushBranch: bool(personal.pushBranch, allow.pushBranch),
+    label: personal.label && !allow.label
+      ? { value: "", source: "project" }
+      : { value: personal.label, source: "personal" },
+  };
+}
+
+/** Does the effective policy write anything at all? */
+export function policyWritesAnything(r: ResolvedPolicy): boolean {
+  return r.assign.value || r.comment.value || r.pushBranch.value || !!r.label.value;
+}
+
+// ---------- staleness ----------
+
+/// After this long with no refresh a claim is advisory only. Thirty minutes is longer
+/// than a normal turn and far shorter than a working day, which is the window that
+/// makes "someone is on this" true rather than merely recorded.
+export const CLAIM_STALE_MS = 30 * 60_000;
+
+export function claimIsStale(claimedAt: number, now = Date.now()): boolean {
+  return now - claimedAt > CLAIM_STALE_MS;
+}
+
+/// How a claim reads on a row. A stale claim says so — presenting a dead claim as live
+/// is the failure that makes people stop trusting the signal.
+export function claimText(who: string, claimedAt: number, now = Date.now()): string {
+  const mins = Math.max(0, Math.round((now - claimedAt) / 60_000));
+  const ago = mins < 1 ? "just now" : mins < 60 ? `${mins}m ago` : `${Math.round(mins / 60)}h ago`;
+  return claimIsStale(claimedAt, now) ? `${who} claimed this ${ago} — probably stale` : `${who} is on this · ${ago}`;
+}
+
+// ---------- the local ledger ----------
+// What *we* claimed, so it can be released when the agent ends. Machine-local by
+// definition — it is a list of this machine's outstanding promises, meaningless to a
+// teammate — so it lives in localStorage rather than in any committed file.
+
+export interface ClaimRecord {
+  /// The thread this claim belongs to, so releasing needs no re-derivation.
+  threadId: string;
+  root: string;
+  number: number;
+  kind: "issue" | "pr";
+  /// The session that took it, so an exit can release exactly the right claim.
+  sessionId: string;
+  at: number;
+}
+
+const LEDGER = "cc-claims";
+
+function readLedger(): ClaimRecord[] {
+  try {
+    const raw = JSON.parse(localStorage.getItem(LEDGER) || "[]");
+    return Array.isArray(raw) ? raw.filter((r): r is ClaimRecord => !!r && typeof r.threadId === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+export let claims: ClaimRecord[] = readLedger();
+function save() { localStorage.setItem(LEDGER, JSON.stringify(claims)); }
+
+export function recordClaim(rec: ClaimRecord): void {
+  claims = claims.filter((c) => c.threadId !== rec.threadId);
+  claims.push(rec);
+  save();
+}
+
+/** The claim a session took, if any — what an exit needs in order to release it. */
+export function claimForSession(sessionId: string): ClaimRecord | null {
+  return claims.find((c) => c.sessionId === sessionId) ?? null;
+}
+
+export function dropClaim(threadId: string): ClaimRecord | null {
+  const i = claims.findIndex((c) => c.threadId === threadId);
+  if (i < 0) return null;
+  const [c] = claims.splice(i, 1);
+  save();
+  return c;
+}
+
+/// Test seam, matching ./notes: the store is read once at import like its neighbours.
+export function reloadClaims(): void { claims = readLedger(); }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -16,6 +16,7 @@
 // would tax every session in the app for a view most ticks never show.
 
 import { invoke } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { $, toast } from "./dom";
 import { dlog } from "./debug";
 import {
@@ -23,17 +24,26 @@ import {
   projectCost, projectTier, type ProjectFacts, type ProjectTier,
 } from "./dash";
 import {
-  checkoutsCard, checkoutsOverlay, dashInspector, dashStrip, dayHtml, missingCard,
-  notesCard, notesOverlay, pulseHtml,
+  checkoutsCard, checkoutsOverlay, closeSheet, dashInspector, dashStrip, dayHtml,
+  dispatchSheet, ghUnavailable, missingCard, notesCard, notesOverlay, pulseHtml,
+  triageCard, triageOverlay, workCard, workOverlay,
 } from "./dashview";
+import {
+  ALLOW_ALL, claims, claimForSession, DEFAULT_POLICY, dropClaim, recordClaim,
+  resolveClaim, type ClaimAllow, type ClaimPolicy,
+} from "./claim";
+import {
+  bucketed, cardRows, closeComment, holderOf, isoDay, quietFor, staleCandidates,
+  type GhResult, type GhThread, type KeptIssue,
+} from "./ghwork";
 import type { HistEntry } from "./history";
-import { addNote, noteList, removeNote } from "./notes";
+import { addNote, noteList, removeNote, type SharedNote } from "./notes";
 import { GLYPH, GCLASS } from "./sidebarview";
 import { deterministicHeadline, dayFacts, dayIsClosed, type TrailCommit, type TrailDay } from "./trail";
 import { statusKey, type WtHead } from "./types";
 import { usageDetail, usageWindow } from "./usage";
 import {
-  accentFor, dashMirror, folderDirty, sessions, setActiveId, setMirror,
+  accentFor, dashMirror, folderDirty, permMode, sessions, setActiveId, setMirror,
 } from "./state";
 
 // What this pane does but does not own. Same host-object shape as ./settings and
@@ -90,6 +100,19 @@ let days: TrailDay[] = [];
 let heads: WtHead[] = [];
 let hasDigest = false;
 let loading = false;
+/// The GitHub half. `gh` is allowed to be missing, logged out, or pointed at a folder
+/// that is not a GitHub repo — every one of those is `available: false` and a reason,
+/// shown as one quiet row rather than as breakage.
+let gh: GhResult = { available: false, reason: null, threads: [], viewer: null };
+let kept: KeptIssue[] = [];
+let allow: ClaimAllow = ALLOW_ALL;
+/// The project's committed notes, and which of ours are in it.
+let shared: SharedNote[] = [];
+/// The confirm sheet currently up, if any. Both writes here are public, so neither
+/// happens without showing exactly what will be written.
+let sheet: { kind: "close" | "dispatch"; t: GhThread } | null = null;
+/// What this dispatch would write, editable in the sheet before it is sent.
+let policy: ClaimPolicy = { ...DEFAULT_POLICY, comment: true, label: "agent: running" };
 /// Generated summaries for the open project, keyed by day. Separate from `days` so a
 /// reload doesn't drop sentences already paid for in this session.
 const summaries = new Map<string, string>();
@@ -97,7 +120,7 @@ const summaries = new Map<string, string>();
 /// by element — the pane rebuilds its innerHTML on every repaint.
 const openDays = new Set<string>();
 /// Which enlarge overlay is up, if any.
-let openView: "checkouts" | "notes" | null = null;
+let openView: "checkouts" | "notes" | "work" | "triage" | null = null;
 
 const root = () => dashMirror()?.root ?? "";
 const name = () => dashMirror()?.name ?? "";
@@ -115,7 +138,7 @@ async function loadDash(): Promise<void> {
     facts = await invoke<ProjectFacts>("project_facts", { dir: r }).catch(() => null);
     tier = projectTier(facts);
     const wantGit = tier !== "none";
-    const [hist, commits, wt, digest] = await Promise.all([
+    const [hist, commits, wt, digest, sn] = await Promise.all([
       invoke<HistEntry[]>("list_session_history", { limit: 400 }).catch((e) => {
         dlog("warn", `dash: history scan failed — ${e}`);
         return [] as HistEntry[];
@@ -128,8 +151,20 @@ async function loadDash(): Promise<void> {
       // to open a week pays nothing for it.
       wantGit ? invoke<Record<string, string>>("read_digest", { root: r }).catch(() => ({}))
               : Promise.resolve({} as Record<string, string>),
+      wantGit ? invoke<SharedNote[]>("list_shared_notes", { root: r }).catch(() => [] as SharedNote[])
+              : Promise.resolve([] as SharedNote[]),
     ]);
+    shared = sn;
     heads = wt.filter((w) => w.exists);
+    // The GitHub half, only for a repo that has a GitHub remote. Fired after the
+    // cheap local reads rather than alongside them: `gh` is a process per call and
+    // the timeline should paint without waiting for the network.
+    if (tier === "github") {
+      void loadGh(r);
+    } else {
+      gh = { available: false, reason: null, threads: [], viewer: null };
+      kept = [];
+    }
     for (const [k, v] of Object.entries(digest)) if (v) summaries.set(k, v);
     hasDigest = Object.keys(digest).length > 0
       || (wantGit && await invoke<boolean>("has_digest", { root: r }).catch(() => false));
@@ -139,6 +174,21 @@ async function loadDash(): Promise<void> {
   }
   renderDash();
   if (dashSummaries) void runSummaryQueue();
+}
+
+/// Issues, PRs, the project's keep list and its claim ceiling. Separate from
+/// `loadDash` so a slow or absent `gh` never delays the timeline.
+async function loadGh(r: string, force = false): Promise<void> {
+  const [res, k, a] = await Promise.all([
+    invoke<GhResult>("gh_threads", { root: r, force }).catch((e) => ({
+      available: false, reason: String(e), threads: [], viewer: null,
+    } as GhResult)),
+    invoke<KeptIssue[]>("list_kept", { root: r }).catch(() => [] as KeptIssue[]),
+    invoke<ClaimAllow>("claim_policy", { root: r }).catch(() => ALLOW_ALL),
+  ]);
+  if (root() !== r) return;   // the user moved on while this was in flight
+  gh = res; kept = k; allow = a;
+  renderDash();
 }
 
 /**
@@ -205,15 +255,39 @@ export function renderDash(): void {
       dayHtml(d, summaries.get(d.key) ?? null, deterministicHeadline(d), openDays.has(d.key))).join("");
   }
 
+  const now = Date.now();
+  const holder = (t: GhThread) => holderOf(t, gh.viewer, claims.filter((c) => c.root === root()), now);
+  const stale = staleCandidates(gh.threads, kept, now).map((t) => ({ t, why: quietFor(t.updated_at, now) }));
+  const prs = gh.threads.filter((t) => t.kind === "pr").length;
+
   $("dashAside").innerHTML =
-    checkoutsCard(heads, liveIn, folderDirty)
+    (gh.available ? workCard(cardRows(gh.threads), gh.threads.length, prs, holder) : "")
+    + (gh.available ? triageCard(stale, gh.threads.filter((t) => t.kind === "issue").length) : "")
+    + checkoutsCard(heads, liveIn, folderDirty)
     + notesCard(noteList(root()))
+    + (tier === "github" && !gh.available && gh.reason ? ghUnavailable(gh.reason) : "")
     + missingCard(tier, facts);
 
   const ovl = $("dashOverlay");
   ovl.classList.toggle("show", openView !== null);
+  ovl.dataset.view = openView ?? "";
   if (openView === "checkouts") ovl.innerHTML = checkoutsOverlay(heads, liveIn, folderDirty);
-  else if (openView === "notes") ovl.innerHTML = notesOverlay(noteList(root()), canShare(tier));
+  else if (openView === "notes") {
+    const mineShared = new Set(shared.map((n) => n.id));
+    // A colleague's note is theirs; ours are the ones we can promote or withdraw.
+    const theirs = shared.filter((n) => !noteList(root()).some((x) => x.id === n.id));
+    ovl.innerHTML = notesOverlay(noteList(root()), theirs, mineShared, canShare(tier));
+  }
+  else if (openView === "work") ovl.innerHTML = workOverlay(bucketed(gh.threads, now), facts?.slug ?? name(), gh.threads.length, holder);
+  else if (openView === "triage") ovl.innerHTML = triageOverlay(stale, kept, canShare(tier));
+
+  const sh = $("dashSheet");
+  sh.classList.toggle("show", sheet !== null);
+  $("dashScrim").classList.toggle("show", sheet !== null);
+  if (sheet?.kind === "close") sh.innerHTML = closeSheet(sheet.t, closeComment(sheet.t, now), facts?.slug ?? name());
+  else if (sheet?.kind === "dispatch") {
+    sh.innerHTML = dispatchSheet(sheet.t, policy, allow, permMode, holder(sheet.t));
+  }
 }
 
 /// Header for the dashboard. Name and location only — no branch chip and no session
@@ -275,6 +349,7 @@ export function closeDashboard(): void {
 /// than closeDashboard.
 export function dashEscape(): boolean {
   if (!dashMirror()) return false;
+  if (sheet) { sheet = null; renderDash(); return true; }
   if (openView) { openView = null; renderDash(); return true; }
   closeDashboard();
   host.renderAll();
@@ -311,7 +386,47 @@ export function wireDashboard(): void {
     if (wtadd) { void host.launch(name(), wtadd.dataset.dashwtadd!, { colorKey: root() }); return; }
     const wtterm = t.closest<HTMLElement>("[data-dashwtterm]");
     if (wtterm) { host.openTerminal(wtterm.dataset.dashwtterm!); return; }
+
+    // ---- the GitHub half ----
+    const work = t.closest<HTMLElement>("[data-dashwork]");
+    if (work) {
+      const th = gh.threads.find((x) => x.number === +work.dataset.dashwork!);
+      // Never straight to a dispatch: it sends a prompt AND writes to a public repo.
+      if (th) { sheet = { kind: "dispatch", t: th }; renderDash(); }
+      return;
+    }
+    const close = t.closest<HTMLElement>("[data-dashclose]");
+    if (close) {
+      const th = gh.threads.find((x) => x.number === +close.dataset.dashclose!);
+      if (th) { sheet = { kind: "close", t: th }; renderDash(); }
+      return;
+    }
+    const keep = t.closest<HTMLElement>("[data-dashkeep]");
+    if (keep) { void setKept(+keep.dataset.dashkeep!, true); return; }
+    const unkeep = t.closest<HTMLElement>("[data-dashunkeep]");
+    if (unkeep) { void setKept(+unkeep.dataset.dashunkeep!, false); return; }
+    const share = t.closest<HTMLElement>("[data-dashshare]");
+    if (share) { void toggleShare(share.dataset.dashshare!); return; }
+    const dtext = t.closest<HTMLElement>("[data-dashdispatchtext]");
+    if (dtext) { void dispatchText(dtext.dataset.dashdispatchtext!); return; }
+    const claimSw = t.closest<HTMLElement>("[data-dashclaim]");
+    if (claimSw) { togglePolicy(claimSw.dataset.dashclaim!); return; }
+    // A row's title opens it on GitHub — Episko mirrors a little of it, never all.
+    const url = t.closest<HTMLElement>("[data-dashurl]");
+    if (url?.dataset.dashurl) { void openUrl(url.dataset.dashurl).catch(() => {}); return; }
   });
+
+  // The sheets live outside #dashPane (they sit over the whole stage), so they get
+  // their own delegated handler.
+  $("dashSheet").addEventListener("click", (e) => {
+    const b = (e.target as HTMLElement).closest<HTMLElement>("[data-dashsheet]");
+    if (!b) return;
+    const act = b.dataset.dashsheet!;
+    if (act === "cancel") { sheet = null; renderDash(); return; }
+    if (act === "close") { void doClose(); return; }
+    if (act === "dispatch") { void doDispatch(); return; }
+  });
+  $("dashScrim").addEventListener("click", () => { sheet = null; renderDash(); });
 
   ($("dashJotHost") as HTMLElement).addEventListener("submit", (e) => {
     const form = (e.target as HTMLElement).closest("#dashJot");
@@ -358,6 +473,133 @@ async function dispatchNote(id: string): Promise<void> {
   // harmless: the session is open and the note text is in the toast.
   setTimeout(() => {
     void invoke("write_pty", { sessionId: sid, data: n.text.replace(/\n/g, " ") }).catch(() => {});
+  }, 1400);
+  toast("Dispatched — prefilled, press Enter to send");
+}
+
+/// One switch in the dispatch sheet. The project's ceiling wins: a switch the project
+/// has turned off is shown greyed and does nothing, rather than being hidden — "why
+/// can't I assign?" needs an answer, and an absent control gives none.
+function togglePolicy(k: string): void {
+  const r = resolveClaim(policy, allow);
+  if (k === "assign" && r.assign.source !== "project") policy = { ...policy, assign: !policy.assign };
+  else if (k === "comment" && r.comment.source !== "project") policy = { ...policy, comment: !policy.comment };
+  else if (k === "pushBranch" && r.pushBranch.source !== "project") policy = { ...policy, pushBranch: !policy.pushBranch };
+  else if (k === "label" && r.label.source !== "project") {
+    policy = { ...policy, label: policy.label ? "" : "agent: running" };
+  }
+  renderDash();
+}
+
+/// Close an issue: comment, then close. **The only destructive write Episko makes to
+/// GitHub**, which is why it has a permanent confirm sheet and an editable comment —
+/// a stale-close with no reason is the bot behaviour that gets a feature switched off.
+async function doClose(): Promise<void> {
+  if (sheet?.kind !== "close") return;
+  const t = sheet.t, r = root();
+  const comment = ($("dashCloseText") as HTMLTextAreaElement | null)?.value ?? "";
+  sheet = null;
+  renderDash();
+  try {
+    await invoke("gh_close_issue", { root: r, number: t.number, comment });
+    toast(`#${t.number} closed`);
+    await loadGh(r, true);
+  } catch (e) {
+    toast(`Could not close #${t.number}: ${e}`);
+  }
+}
+
+/// Keep an issue, or take it back off the list. Committed, so it needs the same
+/// create-gate as the digest — and it is reviewable and undoable in the ⤢ view because
+/// a committed decision nobody can see is worse than no decision.
+async function setKept(number: number, keep: boolean): Promise<void> {
+  const r = root();
+  const who = gh.viewer || "someone";
+  try {
+    await invoke("set_kept", { root: r, number, who, at: isoDay(Date.now()), keep, create: true });
+    kept = await invoke<KeptIssue[]>("list_kept", { root: r }).catch(() => kept);
+    toast(keep ? `#${number} kept — nobody on the team is asked again` : `#${number} back in triage`);
+    renderDash();
+  } catch (e) {
+    toast(`Could not write .episko/episko.toml: ${e}`);
+  }
+}
+
+/// Start an agent on a thread, and say so where colleagues can see it.
+///
+/// **The prompt is sent**, which breaks the app's usual "Episko prefills, the human
+/// presses Enter" rule — deliberately, and only here: that rule exists so nothing is
+/// sent you did not read, and a dispatch you confirmed in a sheet *is* the reading.
+///
+/// The claim is written after the session exists, never before: a claim for an agent
+/// that failed to start is worse than no claim, because it stops a colleague picking
+/// the work up.
+async function doDispatch(): Promise<void> {
+  if (sheet?.kind !== "dispatch") return;
+  const t = sheet.t, r = root(), n = name();
+  sheet = null;
+  renderDash();
+  const sid = await host.launch(n, r, { colorKey: r });
+  if (typeof sid !== "string") { toast("Could not start a session"); return; }
+
+  const eff = resolveClaim(policy, allow);
+  if (eff.assign.value || eff.comment.value || eff.label.value || eff.pushBranch.value) {
+    void invoke("gh_claim", {
+      root: r, number: t.number, kind: t.kind === "pr" ? "pr" : "issue",
+      assign: eff.assign.value, comment: eff.comment.value,
+      label: eff.label.value, pushBranch: eff.pushBranch.value,
+    }).then(() => {
+      recordClaim({ threadId: `${r}#${t.number}`, root: r, number: t.number,
+        kind: t.kind === "pr" ? "pr" : "issue", sessionId: sid, at: Date.now() });
+      void loadGh(r, true);
+    }).catch((e) => { dlog("warn", `claim #${t.number} failed — ${e}`); });
+  }
+
+  // Sent, not prefilled — see the note above.
+  setTimeout(() => {
+    const prompt = `Work on ${t.kind === "pr" ? "PR" : "issue"} #${t.number}: ${t.title}\n${t.url}`;
+    void invoke("write_pty", { sessionId: sid, data: prompt.replace(/\n/g, " ") + "\r" }).catch(() => {});
+  }, 1400);
+  toast(`Started on #${t.number}`);
+}
+
+/// A session that took a claim has ended — hand the work back, so a colleague is not
+/// looking at a claim for an agent that stopped hours ago.
+export function releaseClaimFor(sessionId: string): void {
+  const rec = claimForSession(sessionId);
+  if (!rec) return;
+  dropClaim(rec.threadId);
+  void invoke("gh_release", { root: rec.root, number: rec.number, kind: rec.kind }).catch(() => {});
+}
+
+/// Promote a note into the project, or take it back out. Sharing needs *git*, not
+/// GitHub — this is a file, and a file only means anything to a team if it can be
+/// committed.
+async function toggleShare(id: string): Promise<void> {
+  const r = root();
+  const n = noteList(r).find((x) => x.id === id);
+  if (!n) return;
+  const on = shared.some((x) => x.id === id);
+  try {
+    await invoke("set_shared_note", {
+      root: r, id, text: n.text, who: gh.viewer || "someone",
+      at: isoDay(Date.now()), share: !on, create: true,
+    });
+    shared = await invoke<SharedNote[]>("list_shared_notes", { root: r }).catch(() => shared);
+    toast(on ? "Note is yours again" : "Shared — commit .episko/notes.toml to send it");
+    renderDash();
+  } catch (e) {
+    toast(`Could not write .episko/notes.toml: ${e}`);
+  }
+}
+
+/// Start an agent on a colleague's shared note. Prefilled, NOT sent — this is somebody
+/// else's sentence, so the person dispatching it reads it before it goes.
+async function dispatchText(text: string): Promise<void> {
+  const sid = await host.launch(name(), root(), { colorKey: root() });
+  if (typeof sid !== "string") return;
+  setTimeout(() => {
+    void invoke("write_pty", { sessionId: sid, data: text.replace(/\n/g, " ") }).catch(() => {});
   }, 1400);
   toast("Dispatched — prefilled, press Enter to send");
 }

--- a/src/dashview.ts
+++ b/src/dashview.ts
@@ -7,9 +7,11 @@
 
 import { basename, esc, relTime, sparkline, tilde, uUsd2 } from "./format";
 import type { Pulse, ProjectFacts, ProjectTier } from "./dash";
-import type { Note } from "./notes";
+import type { Note, SharedNote } from "./notes";
 import type { TrailCommit, TrailDay, TrailSession } from "./trail";
 import type { WtHead } from "./types";
+import type { ClaimAllow, ClaimPolicy } from "./claim";
+import type { GhThread, Holder, KeptIssue } from "./ghwork";
 
 const WEEKDAY = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
@@ -277,16 +279,202 @@ export function checkoutsOverlay(
     `Creating a worktree, pruning a stale one and every warning about a locked or detached checkout stay in the <b>⑃ dialog</b>, which already does all of that. This is a status board.`);
 }
 
-export function notesOverlay(notes: Note[], shared: boolean): string {
-  const body = notes.length
+export function notesOverlay(
+  notes: Note[], shared: SharedNote[], sharedIds: Set<string>, canShare: boolean,
+): string {
+  const mine = notes.length
     ? `<div class="ncol">${notes.map((n) => `<div class="ncard" data-dashnote="${esc(n.id)}">
         <span class="tx">${esc(n.text)}</span>
         <span class="mt"><span>${esc(relTime(n.created))}</span></span>
         <span class="bar"><button class="act" data-dashdispatch="${esc(n.id)}">▶ Start an agent</button>
-          <button class="act" data-dashdrop="${esc(n.id)}">✕</button></span></div>`).join("")}</div>`
+          <button class="act" data-dashdrop="${esc(n.id)}">✕</button>
+          ${canShare ? `<span class="sw${sharedIds.has(n.id) ? " on" : ""}" data-dashshare="${esc(n.id)}"
+            title="Write this into .episko/notes.toml so the team can read it"><i></i>shared</span>` : ""}
+        </span></div>`).join("")}</div>`
     : `<div class="ac-empty">Nothing queued yet.</div>`;
-  return overlayHtml("Notes", `${notes.length} on this project`, body,
-    shared
-      ? `Notes are yours alone. The committed half of <code>.episko/</code> is the work log; sharing a note is a separate switch and is not in this build yet.`
+  // A colleague's note is theirs: dispatchable, but not editable or deletable from
+  // here — this is a read of their file, not a shared mutable list.
+  const theirs = shared.length
+    ? `<div class="bk"><div class="bk-h"><span class="t">From the repo</span><span class="n">${shared.length}</span></div>
+        <div class="ncol">${shared.map((n) => `<div class="ncard">
+          <span class="tx">${esc(n.text)}</span>
+          <span class="mt"><span class="clm">◍ ${esc(n.who || "someone")}</span><span>${esc(n.at)}</span></span>
+          <span class="bar"><button class="act" data-dashdispatchtext="${esc(n.text)}">▶ Start an agent</button></span>
+        </div>`).join("")}</div></div>`
+    : "";
+  const body = `<div class="bk"><div class="bk-h"><span class="t">Yours</span><span class="n">${notes.length}</span></div>${mine}</div>${theirs}`;
+  return overlayHtml("Notes", `${notes.length} yours · ${shared.length} from the repo`, body,
+    canShare
+      ? `A note is yours alone until you flip <b>shared</b>, which writes it to <code>.episko/notes.toml</code> — committable, and readable by a colleague who never opens Episko. Flipping it back removes it from the file.`
       : `Notes stay on this machine — there is no repository to commit them into.`);
+}
+
+// ---------- the GitHub half ----------
+// Issues and pull requests in one list: they were competing for the same four rows,
+// the enlarged view already showed them together, and a kind chip separates them more
+// cheaply than a heading does.
+
+const KIND = (t: GhThread) => (t.kind === "pr" ? "pr" : "iss");
+
+/// A claimed row turns its ▶ into a green ◍ **in the same slot**. Putting the name in
+/// the row is what made this column ragged: the compact card says *that* it is taken,
+/// the enlarged view says who and for how long.
+function workRow(t: GhThread, h: Holder | null): string {
+  const act = h
+    ? `<button class="go held${h.stale ? " stale" : ""}" data-dashwork="${t.number}"
+        title="${esc(`${h.who}${h.mine ? " (you)" : ""} — ${h.stale ? "claimed a while ago, probably stale" : "is on this"}. Start one anyway?`)}">◍</button>`
+    : `<button class="go" data-dashwork="${t.number}" title="Start an agent on this">▶</button>`;
+  return `<div class="cr${h ? " claimed" : ""}" data-dashurl="${esc(t.url)}" title="${esc(t.title)}">
+    <span class="k ${KIND(t)}">${KIND(t)}</span>
+    <span class="ti">${esc(t.title)}</span>
+    <span class="rt"><span class="age">${esc(shortAge(t.updated_at))}</span>${act}</span></div>`;
+}
+
+/// Compact ages, tabular so the column lines up: 2h, 3d, 5w.
+function shortAge(iso: string): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return "—";
+  const m = Math.max(0, Date.now() - t) / 60_000;
+  if (m < 60) return `${Math.round(m)}m`;
+  if (m < 1440) return `${Math.round(m / 60)}h`;
+  const d = Math.round(m / 1440);
+  return d < 14 ? `${d}d` : `${Math.round(d / 7)}w`;
+}
+
+export function workCard(rows: GhThread[], total: number, prs: number, holder: (t: GhThread) => Holder | null): string {
+  if (!rows.length) return "";
+  return `<div class="ac"><div class="ac-h"><span class="t">Open work</span>
+      <span class="n">${total - prs} · ${prs} PR</span>
+      <button class="xb" data-dashopen-view="work" title="See all issues and pull requests">⤢</button></div>
+    <div class="ac-b">${rows.map((t) => workRow(t, holder(t))).join("")}</div></div>`;
+}
+
+/// gh missing, logged out, or pointed at a non-GitHub folder. One quiet row, never an
+/// error dialog — the same stance a blocked runnable takes.
+export function ghUnavailable(reason: string): string {
+  return `<div class="miss"><span class="t">GitHub</span><p>${esc(reason)}.</p>
+    <p>Everything else on this dashboard still works.</p></div>`;
+}
+
+// ---------- the enlarged views ----------
+// One fixed column geometry per view, declared once in CSS and inherited by every row:
+// an `auto` trailing track lets each row size to its own button label and the columns
+// stagger, which is the trap the commit graph's row grid documents.
+
+const BUCKET_LABEL: Record<string, string> = { today: "Today", week: "This week", older: "Older" };
+
+function workBigRow(t: GhThread, h: Holder | null): string {
+  const labels = t.labels.slice(0, 3).map((l) =>
+    `<span class="lbl" style="--lc:${labelHue(l)}">${esc(l)}</span>`).join("");
+  const claim = h
+    ? `<span class="clm${h.mine ? " mine" : ""}${h.stale ? " stale" : ""}">◍ ${esc(h.mine ? "you" : h.who)}</span>` : "";
+  const verb = h ? (h.mine ? "◍ Yours" : "▶ Anyway") : t.kind === "pr" ? "▶ Review" : "▶ Start";
+  return `<div class="br" data-dashurl="${esc(t.url)}">
+    <span class="k ${KIND(t)}">${t.kind === "pr" ? "pr" : "issue"}</span>
+    <span class="num">${t.number}</span>
+    <span class="mid"><span class="ti">${esc(t.title)}</span>
+      ${labels || claim ? `<span class="sub">${labels}${claim}</span>` : ""}</span>
+    <span class="age">${esc(shortAge(t.updated_at))}</span>
+    <span class="go-slot"><button class="go${h ? " busy" : ""}" data-dashwork="${t.number}">${verb}</button></span>
+  </div>`;
+}
+
+/// A stable hue per label name. GitHub's own colour is not in the payload we ask for,
+/// and asking for it would cost a wider query for decoration.
+function labelHue(name: string): string {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
+  return `hsl(${h % 360} 62% 68%)`;
+}
+
+export function workOverlay(
+  groups: { bucket: string; rows: GhThread[] }[], slug: string, total: number,
+  holder: (t: GhThread) => Holder | null,
+): string {
+  const body = `<div class="lst-hd"><span>Kind</span><span class="r">#</span><span>Title</span>
+      <span class="r">Age</span><span class="r">Action</span></div>`
+    + groups.map((g) => `<div class="bk">
+        <div class="bk-h"><span class="t">${esc(BUCKET_LABEL[g.bucket] ?? g.bucket)}</span><span class="n">${g.rows.length}</span></div>
+        ${g.rows.map((t) => workBigRow(t, holder(t))).join("")}</div>`).join("");
+  return overlayHtml("Open work", `${esc(slug)} · ${total} open`, body,
+    `<b>◍</b> is a claim — somebody dispatched an agent at it. A hint, never a lock: you can always start anyway, and a claim older than 30 minutes reads as stale.`);
+}
+
+// ---------- triage ----------
+
+export function triageCard(rows: { t: GhThread; why: string }[], total: number): string {
+  if (!rows.length) return "";
+  const body = rows.map(({ t, why }) => `<div class="tr" data-dashurl="${esc(t.url)}">
+    <span class="mid"><span class="ti">${esc(t.title)}</span>
+      <span class="sub">#${t.number} · ${esc(why)}</span></span>
+    <span class="tr-b">
+      <button class="tb yes" data-dashclose="${t.number}" title="Close it on GitHub, with a comment">✓</button>
+      <button class="tb no" data-dashkeep="${t.number}" title="Keep it — nobody on the team is asked again">✕</button>
+    </span></div>`).join("");
+  return `<div class="ac"><div class="ac-h"><span class="t">Still needed?</span>
+      <span class="n">${rows.length} of ${total}</span>
+      <button class="xb" data-dashopen-view="triage" title="Review every quiet issue">⤢</button></div>
+    <div class="ac-b">${body}</div></div>`;
+}
+
+export function triageOverlay(
+  rows: { t: GhThread; why: string }[], kept: KeptIssue[], canWrite: boolean,
+): string {
+  const body = `<div class="lst-hd"><span class="r">#</span><span>Title &amp; why it's suggested</span><span class="r">Decide</span></div>`
+    + `<div class="bk"><div class="bk-h"><span class="t">Suggested for closing</span><span class="n">${rows.length}</span></div>`
+    + (rows.length ? rows.map(({ t, why }) => `<div class="tg" data-dashurl="${esc(t.url)}">
+        <span class="num">${t.number}</span>
+        <span class="mid"><span class="ti">${esc(t.title)}</span><span class="sub"><span>${esc(why)}</span></span></span>
+        <span class="tg-b"><button class="act go-close" data-dashclose="${t.number}">✓ Close</button>
+          <button class="act go-keep" data-dashkeep="${t.number}">✕ Keep</button></span></div>`).join("")
+        : `<div class="ac-empty">Nothing has gone quiet. Triage has nothing to ask about.</div>`)
+    + `</div>`
+    // The keep list is committed, so it has to be reviewable: a decision nobody can
+    // see is worse than no decision.
+    + (kept.length ? `<div class="bk"><div class="bk-h"><span class="t">Kept — never suggested again</span>
+        <span class="n">${kept.length}</span></div>`
+      + kept.map((k) => `<div class="kept"><span class="num">${k.number}</span>
+          <span class="ti">kept by ${esc(k.who || "someone")}</span>
+          <span class="who">${esc(k.at)} <a href="#" data-dashunkeep="${k.number}">undo</a></span></div>`).join("")
+      + `</div>` : "");
+  return overlayHtml("Still needed?", `${rows.length} quiet · ${kept.length} kept`, body,
+    canWrite
+      ? `The keep list lives in <code>.episko/episko.toml</code> and is <b>committed</b>, so a colleague is never asked about an issue you both already decided to keep. That is also why it is reviewable and undoable here.`
+      : `Keeping an issue needs a repository to commit the decision into.`);
+}
+
+// ---------- the confirm sheets ----------
+// Closing an issue and claiming one are both public writes, one click from a dashboard
+// you open constantly. Neither happens without showing exactly what will be written.
+
+export function closeSheet(t: GhThread, comment: string, slug: string): string {
+  return `<h4>Close #${t.number} on GitHub?</h4>
+    <div class="body">
+      <p>This posts a comment and closes the issue in <b>${esc(slug)}</b>. Everyone watching the repo sees it.</p>
+      <p class="sheet-ti">${esc(t.title)}</p>
+      <textarea id="dashCloseText" rows="4">${esc(comment)}</textarea>
+    </div>
+    <div class="foot"><button class="act" data-dashsheet="cancel">Cancel</button><span class="sp"></span>
+      <button class="act primary" data-dashsheet="close">✓ Comment &amp; close</button></div>`;
+}
+
+export function dispatchSheet(t: GhThread, p: ClaimPolicy, allow: ClaimAllow, mode: string, holder: Holder | null): string {
+  const sw = (k: string, on: boolean, permitted: boolean, label: string) =>
+    `<span class="sw${on && permitted ? " on" : ""}${permitted ? "" : " off"}" data-dashclaim="${k}"
+      ${permitted ? "" : `title="This project's .episko/episko.toml switches it off for everyone"`}><i></i>${label}</span>`;
+  return `<h4>Start an agent on #${t.number}</h4>
+    <div class="body">
+      <p class="sheet-ti">${esc(t.title)}</p>
+      ${holder ? `<p class="warn-line">◍ ${esc(holder.who)} ${holder.stale ? "claimed this a while ago — probably stale" : "is already on this"}. Starting a second agent is allowed; a claim is a hint, not a lock.</p>` : ""}
+      <p>A new worktree, a session in it, and <b>the prompt is sent</b> — the agent starts working without waiting for you.</p>
+      <div class="opts">
+        ${sw("assign", p.assign, allow.assign, "assign the issue to me")}
+        ${sw("comment", p.comment, allow.comment, "comment that my agent is on it")}
+        ${sw("label", !!p.label, allow.label, `label <code>${esc(p.label || "agent: running")}</code>`)}
+        ${sw("pushBranch", p.pushBranch, allow.pushBranch, "push the branch now")}
+      </div>
+      <p class="dim-line">Permission mode: <b>${esc(mode)}</b>. Anything that doesn't ask before acting will act unattended.</p>
+    </div>
+    <div class="foot"><button class="act" data-dashsheet="cancel">Cancel</button><span class="sp"></span>
+      <button class="act primary" data-dashsheet="dispatch">▶ Claim &amp; start</button></div>`;
 }

--- a/src/ghwork.ts
+++ b/src/ghwork.ts
@@ -1,0 +1,173 @@
+// The GitHub half of the dashboard's rules — how open work is ordered, which issues
+// triage dares suggest closing, and who already has one.
+//
+// No DOM and no Tauri, so it unit-tests in isolation like ./dash and ./claim;
+// ./dashview owns the markup and ./dashboard the fetch. See test/ghwork.test.ts.
+
+import { claimIsStale, type ClaimRecord } from "./claim";
+
+/// One issue or PR, as `gh_threads` returns it. Mirrors the Rust struct.
+export interface GhThread {
+  number: number;
+  kind: "issue" | "pr" | string;
+  title: string;
+  url: string;
+  assignees: string[];
+  labels: string[];
+  branch: string | null;
+  author: string | null;
+  draft: boolean;
+  updated_at: string;
+}
+
+export interface GhResult {
+  available: boolean;
+  reason: string | null;
+  threads: GhThread[];
+  viewer: string | null;
+}
+
+/// An issue the project has decided to keep, from `.episko/episko.toml`.
+export interface KeptIssue { number: number; who: string; at: string }
+
+// ---------- ordering ----------
+
+/// When something last moved, as a bucket. The overlay groups by these because "how
+/// recent" is the only ordering that survives a repo with sixty open issues — a flat
+/// list sorted by number tells you nothing about what is alive.
+export type Bucket = "today" | "week" | "older";
+
+const DAY = 86_400_000;
+
+export function bucketOf(updatedAt: string, now: number): Bucket {
+  const t = Date.parse(updatedAt);
+  // An unparseable timestamp sorts oldest rather than newest: a row that quietly
+  // claims to be from today would be the one thing you act on first.
+  if (!Number.isFinite(t)) return "older";
+  const age = now - t;
+  if (age < DAY) return "today";
+  if (age < 7 * DAY) return "week";
+  return "older";
+}
+
+/** Newest first, ties by number descending so a repaint never reorders. */
+export function byRecency(a: GhThread, b: GhThread): number {
+  const ta = Date.parse(a.updated_at), tb = Date.parse(b.updated_at);
+  const va = Number.isFinite(ta) ? ta : 0, vb = Number.isFinite(tb) ? tb : 0;
+  return vb - va || b.number - a.number;
+}
+
+/** The buckets in reading order, empty ones dropped. */
+export function bucketed(threads: GhThread[], now: number): { bucket: Bucket; rows: GhThread[] }[] {
+  const order: Bucket[] = ["today", "week", "older"];
+  const by = new Map<Bucket, GhThread[]>(order.map((b) => [b, []]));
+  for (const t of [...threads].sort(byRecency)) by.get(bucketOf(t.updated_at, now))!.push(t);
+  return order.map((bucket) => ({ bucket, rows: by.get(bucket)! })).filter((g) => g.rows.length);
+}
+
+/// The compact card shows this many, most recently active first. Issues and PRs
+/// together: they were competing for the same rows, the enlarged view already showed
+/// them as one list, and a kind chip separates them more cheaply than a heading.
+export const CARD_ROWS = 4;
+export function cardRows(threads: GhThread[]): GhThread[] {
+  return [...threads].sort(byRecency).slice(0, CARD_ROWS);
+}
+
+// ---------- triage ----------
+
+/// How quiet an issue has to be before it is worth asking about. Four days is longer
+/// than a weekend and shorter than a sprint — below it, triage would nag about work
+/// somebody put down on Friday.
+export const STALE_DAYS = 4;
+
+/// How many the card offers at once. Three, because triage is a side task: a list of
+/// twenty is a chore, and a chore gets dismissed wholesale rather than considered.
+export const TRIAGE_ROWS = 3;
+
+/**
+ * The quietest open issues worth asking about, quietest first.
+ *
+ * **Issues only, never pull requests.** A PR that has gone quiet needs review or a
+ * rebase, not closing, and offering to close it would be actively wrong.
+ *
+ * **Drafts and assigned issues are left alone**: somebody has said they are on it,
+ * and a bot second-guessing that is exactly the behaviour that makes a team switch
+ * triage off. `kept` is the project's committed decision list — the whole point is
+ * that a decision is made once, by anyone, and never surfaces again.
+ */
+export function staleCandidates(
+  threads: GhThread[], kept: KeptIssue[], now: number, limit = TRIAGE_ROWS,
+): GhThread[] {
+  const skip = new Set(kept.map((k) => k.number));
+  return threads
+    .filter((t) => t.kind === "issue" && !skip.has(t.number) && !t.assignees.length)
+    .filter((t) => {
+      const at = Date.parse(t.updated_at);
+      return Number.isFinite(at) && now - at >= STALE_DAYS * DAY;
+    })
+    // Quietest first — the oldest is the one most likely to be genuinely done with.
+    .sort((a, b) => Date.parse(a.updated_at) - Date.parse(b.updated_at) || a.number - b.number)
+    .slice(0, limit);
+}
+
+/// How long an issue has been quiet, for the row's subtitle. Days, because an hour is
+/// noise at this timescale and "quiet 3 weeks" is the fact that matters.
+export function quietFor(updatedAt: string, now: number): string {
+  const t = Date.parse(updatedAt);
+  if (!Number.isFinite(t)) return "never touched";
+  const d = Math.floor((now - t) / DAY);
+  if (d < 1) return "quiet today";
+  if (d < 30) return `quiet ${d} day${d === 1 ? "" : "s"}`;
+  const m = Math.round(d / 30);
+  return `quiet ${m} month${m === 1 ? "" : "s"}`;
+}
+
+// ---------- who has it ----------
+
+/// What the row shows instead of a ▶. A claim is a hint, never a lock — see ./claim —
+/// so this only ever *describes*; nothing here refuses a dispatch.
+export interface Holder {
+  who: string;
+  /// Yours, so the row can offer to jump to the pane rather than start a second agent.
+  mine: boolean;
+  /// A claim older than CLAIM_STALE_MS. Presenting a dead claim as live is the failure
+  /// that makes people stop trusting the signal.
+  stale: boolean;
+}
+
+/**
+ * Who is on this, from the three signals that can say so.
+ *
+ * Order matters and is not arbitrary: **our own local ledger wins**, because it knows
+ * a dispatch that has not been pushed anywhere yet; then an assignee, which is the
+ * explicit human signal; then the `agent:` label, which only says *a machine* is on
+ * it and cannot say whose. An assignee that is you still reads as yours.
+ */
+export function holderOf(
+  t: GhThread, viewer: string | null, claims: ClaimRecord[], now: number,
+): Holder | null {
+  const mineRec = claims.find((c) => c.number === t.number && c.kind === (t.kind === "pr" ? "pr" : "issue"));
+  if (mineRec) return { who: viewer || "you", mine: true, stale: claimIsStale(mineRec.at, now) };
+  const who = t.assignees[0];
+  if (who) return { who, mine: !!viewer && who === viewer, stale: false };
+  if (t.labels.some((l) => l.toLowerCase().startsWith("agent:"))) {
+    return { who: "an agent", mine: false, stale: false };
+  }
+  return null;
+}
+
+/// The comment Episko posts when closing a stale issue. Prefilled and editable — the
+/// user sends it, so it has to read as something a person would write, and it has to
+/// say what would make closing it wrong.
+export function closeComment(t: GhThread, now: number): string {
+  return `Closing as stale — ${quietFor(t.updated_at, now)}, and nothing seems to be waiting on it. `
+    + `Reopen if that's wrong.`;
+}
+
+/// Today, as `YYYY-MM-DD` local — what the keep list and shared notes record. Day
+/// resolution on purpose: an hour adds nothing and churns the committed diff.
+export function isoDay(now: number): string {
+  const d = new Date(now);
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,8 +66,8 @@ import { closeDiff, diffOpen, openDiff, setDiffCloseFootMenus } from "./diffview
 // with the shared scrim and Esc, like every other dialog.
 import { closeGraph, graphEscape, graphOpen, openGraph as openGraphFor } from "./graphview";
 import {
-  closeDashboard, dashEscape, openDashboard, renderDash, renderDashHeader,
-  renderDashInspector, setDashHost, wireDashboard,
+  closeDashboard, dashEscape, openDashboard, releaseClaimFor, renderDash,
+  renderDashHeader, renderDashInspector, setDashHost, wireDashboard,
 } from "./dashboard";
 import {
   closeInputPrompt, closeRunPicker, closeTaskManager, mgrEdit, openRunPicker,
@@ -421,6 +421,10 @@ listen<{ sessionId: string; code: number }>("pty-exit", (e) => {
   // dependency chain can never deadlock on a session that vanished.
   const waiter = exitWaiters.get(e.payload.sessionId);
   if (waiter) { exitWaiters.delete(e.payload.sessionId); waiter(e.payload.code); }
+  // Hand a claimed issue back. Before the early return for the same reason as the
+  // waiter above: a colleague looking at a claim for an agent that stopped hours ago
+  // is exactly the "graveyard of dead claims" the feature is built to avoid.
+  releaseClaimFor(e.payload.sessionId);
   const s = sessions.get(e.payload.sessionId); if (!s) return;
   const code = e.payload.code;
   s.attention = null;

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -28,6 +28,10 @@ export interface Note {
   created: number;
 }
 
+/// One note as the project's committed `.episko/notes.toml` carries it. Mirrors the
+/// Rust struct. Read-only from here: a colleague's note is theirs.
+export interface SharedNote { id: string; text: string; who: string; at: string }
+
 const KEY = "cc-notes";
 
 /// Ids only have to be unique within one machine's `localStorage`, so this is a

--- a/src/styles.css
+++ b/src/styles.css
@@ -1697,3 +1697,101 @@ select.in-ctl { cursor: pointer; }
   .db-aside { border-left: 0; border-top: 1px solid var(--hair); }
 }
 @media (prefers-reduced-motion: reduce) { .db-detail, .ovl { transition: none; } }
+
+/* ═══ the dashboard's GitHub half ══════════════════════════════════════════════ */
+/* One fixed column geometry per enlarged view, declared once and inherited by every
+   row. An `auto` trailing track lets each row size to its own button label and the
+   columns stagger — the same trap the commit graph's row grid documents. */
+.ovl[data-view="work"]   { --cols: 46px 40px minmax(0, 1fr) 50px 112px; }
+.ovl[data-view="triage"] { --cols: 40px minmax(0, 1fr) 172px; }
+.br, .tg, .kept, .lst-hd { grid-template-columns: var(--cols); }
+.lst-hd { display: grid; gap: 10px; align-items: center; padding: 0 9px 6px; font: 700 8.5px var(--font-ui); letter-spacing: .11em; text-transform: uppercase; color: var(--muted-2); }
+.lst-hd .r { text-align: right; }
+.bk { margin-bottom: 14px; }
+.bk-h { display: flex; align-items: center; gap: 9px; margin-bottom: 4px; position: sticky; top: -10px; z-index: 1; padding: 6px 0 5px; background: color-mix(in srgb, var(--panel) 94%, transparent); backdrop-filter: blur(8px); }
+.bk-h .t { font: 700 9.5px var(--font-ui); letter-spacing: .11em; text-transform: uppercase; color: var(--muted); white-space: nowrap; }
+.bk-h .n { font: 9.5px var(--font-mono); color: var(--muted-2); }
+.bk-h::after { content: ""; flex: 1; height: 1px; background: var(--hair); }
+
+.br { display: grid; gap: 10px; align-items: center; min-height: 42px; padding: 5px 9px; border-radius: 8px; cursor: pointer; min-width: 0; }
+.br:hover { background: var(--surface); }
+.br .k, .cr .k.iss, .cr .k.pr { width: 100%; text-align: center; }
+.br .k { font: 8.5px var(--font-mono); text-transform: uppercase; letter-spacing: .05em; padding: 1px 0; border-radius: 4px; border: 1px solid var(--hair); color: var(--muted-2); background: var(--bg-2); }
+.k.pr { color: #c3b0ff; border-color: color-mix(in srgb, #c3b0ff 30%, transparent); }
+.k.iss { color: #7cc7ff; border-color: color-mix(in srgb, #7cc7ff 28%, transparent); }
+.br .num, .tg .num, .kept .num { font: 600 10px var(--font-mono); font-variant-numeric: tabular-nums; color: var(--muted-2); text-align: right; }
+.br .mid, .tg .mid { min-width: 0; }
+.br .ti { display: block; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--muted); }
+.br:hover .ti { color: var(--text); }
+/* nowrap, not wrap: a chip dropping to a second line changes the row height and the
+   table stops being a table. What doesn't fit is clipped; the title carries the rest. */
+.br .sub, .tg .sub { display: flex; align-items: center; gap: 5px; margin-top: 3px; flex-wrap: nowrap; overflow: hidden; min-width: 0; }
+.br .sub > *, .tg .sub > * { flex: none; }
+.br .age { font: 9.5px var(--font-mono); font-variant-numeric: tabular-nums; color: var(--muted-2); text-align: right; }
+.lbl { font: 8.5px var(--font-mono); padding: 0 5px; border-radius: 4px; line-height: 15px; white-space: nowrap; border: 1px solid color-mix(in srgb, var(--lc) 34%, transparent); color: var(--lc); background: color-mix(in srgb, var(--lc) 11%, transparent); }
+/* ONE action slot, one width, whatever the verb — a button that sizes to its own label
+   is what moves every column downstream of it. */
+.go-slot { display: flex; justify-content: flex-end; }
+.br .go { width: 100%; height: 23px; padding: 0 8px; overflow: hidden; border-radius: 6px; cursor: pointer; font: 600 9.5px var(--font-mono); display: inline-flex; align-items: center; justify-content: center; gap: 4px; white-space: nowrap; border: 1px solid var(--hair); background: var(--bg-2); color: var(--muted-2); transition: color .14s, border-color .14s, background .14s; }
+.br:hover .go { color: var(--accent-ink); border-color: var(--accent-line); background: var(--accent-wash); }
+.br .go.busy, .br:hover .go.busy { color: var(--muted-2); border-color: var(--hair); background: var(--bg-2); }
+.br .go.busy:hover { color: var(--text); border-color: var(--hair-strong); }
+/* A claim marker — a hint, never a lock. */
+.clm { display: inline-flex; align-items: center; gap: 3px; font: 8.5px var(--font-mono); padding: 0 5px; line-height: 15px; border-radius: 4px; white-space: nowrap; color: #6ad0b0; border: 1px solid color-mix(in srgb, #6ad0b0 32%, transparent); background: color-mix(in srgb, #6ad0b0 11%, transparent); }
+.clm.mine { color: var(--accent-ink); border-color: var(--accent-line); background: var(--accent-wash); }
+.clm.stale { color: var(--muted-2); border-color: var(--hair); background: var(--bg-2); }
+.cr .go.held { opacity: 1; color: #6ad0b0; border-color: color-mix(in srgb, #6ad0b0 34%, transparent); background: color-mix(in srgb, #6ad0b0 12%, transparent); }
+.cr .go.held.stale { color: var(--muted-2); border-color: var(--hair); background: var(--bg-2); }
+.cr.claimed .ti { color: var(--muted-2); }
+
+/* triage — both its tables share one geometry */
+.tr { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; align-items: center; padding: 6px; border-radius: 7px; }
+.tr:hover { background: var(--surface-2); }
+.tr .ti { display: block; font-size: 11.5px; line-height: 1.3; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--muted); }
+.tr .sub { margin-top: 2px; font: 9px var(--font-mono); color: var(--muted-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tr-b { display: flex; gap: 4px; flex: none; }
+.tb { width: 21px; height: 21px; border-radius: 6px; cursor: pointer; display: grid; place-items: center; font-size: 10px; border: 1px solid var(--hair); background: var(--bg-2); color: var(--muted-2); flex: none; }
+.tb.yes:hover { color: var(--st-done); border-color: color-mix(in srgb, var(--st-done) 40%, transparent); background: color-mix(in srgb, var(--st-done) 12%, transparent); }
+.tb.no:hover { color: var(--text); border-color: var(--hair-strong); background: var(--surface-2); }
+.tg { display: grid; gap: 10px; align-items: center; min-height: 46px; padding: 5px 9px; border-radius: 8px; border-bottom: 1px solid var(--hair); cursor: pointer; }
+.tg:hover { background: var(--surface); }
+.tg .ti { display: block; font-size: 12px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tg:hover .ti { color: var(--text); }
+.tg-b { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
+.tg-b .act { height: 23px; padding: 0; justify-content: center; font: 600 9.5px var(--font-mono); }
+.tg-b .act.go-close:hover { color: var(--st-done); border-color: color-mix(in srgb, var(--st-done) 38%, transparent); background: color-mix(in srgb, var(--st-done) 12%, transparent); }
+.kept { display: grid; gap: 10px; align-items: center; min-height: 34px; padding: 4px 9px; border-radius: 8px; }
+.kept:hover { background: var(--surface); }
+.kept .ti { font-size: 11.5px; color: var(--muted-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.kept .who { display: flex; align-items: center; justify-content: flex-end; gap: 7px; font: 9.5px var(--font-mono); color: var(--muted-2); white-space: nowrap; }
+.kept .who a { color: var(--accent-ink); text-decoration: none; }
+.kept .who a:hover { text-decoration: underline; }
+
+/* the confirm sheets */
+.dsh-scrim { position: absolute; inset: 0; z-index: 45; background: rgba(6,5,10,.55); backdrop-filter: blur(3px); opacity: 0; pointer-events: none; transition: opacity .16s; }
+.dsh-scrim.show { opacity: 1; pointer-events: auto; }
+.dsh { position: absolute; top: 14%; left: 50%; transform: translateX(-50%) translateY(-8px) scale(.98); width: min(470px, 90%); z-index: 46; border-radius: var(--radius-lg); overflow: hidden; opacity: 0; pointer-events: none; transition: opacity .16s, transform .16s cubic-bezier(.32,.72,0,1); background: linear-gradient(180deg, rgba(255,255,255,.06), transparent 40%), color-mix(in srgb, var(--panel) 92%, transparent); backdrop-filter: blur(24px) saturate(1.4); border: 1px solid var(--hair-strong); box-shadow: 0 40px 100px -30px rgba(0,0,0,.85); }
+.dsh.show { opacity: 1; pointer-events: auto; transform: translateX(-50%) translateY(0) scale(1); }
+.dsh h4 { margin: 0; padding: 13px 15px 0; font-size: 13.5px; font-weight: 750; letter-spacing: -.01em; }
+.dsh .body { padding: 9px 15px 13px; display: flex; flex-direction: column; gap: 10px; }
+.dsh p { margin: 0; font-size: 12px; line-height: 1.55; color: var(--muted); }
+.dsh .sheet-ti { font-size: 12.5px; color: var(--text); font-weight: 600; }
+.dsh .warn-line { color: var(--st-working); }
+.dsh .dim-line { color: var(--muted-2); font-size: 11px; }
+.dsh textarea { width: 100%; resize: vertical; padding: 8px 10px; border-radius: 8px; font: 11.5px var(--font-mono); line-height: 1.5; color: var(--text); background: var(--bg-2); border: 1px solid var(--hair); }
+.dsh textarea:focus { outline: none; border-color: var(--accent-line); }
+.dsh .opts { display: flex; flex-direction: column; gap: 7px; padding: 9px 10px; border-radius: 8px; background: var(--bg-2); border: 1px solid var(--hair); }
+.dsh .foot { display: flex; gap: 7px; padding: 11px 15px; border-top: 1px solid var(--hair); background: color-mix(in srgb, var(--bg-2) 60%, transparent); }
+.dsh .foot .sp { margin-left: auto; }
+/* the claim switches */
+.sw { display: inline-flex; align-items: center; gap: 8px; cursor: pointer; font: 10.5px var(--font-mono); color: var(--muted-2); }
+.sw i { width: 24px; height: 14px; border-radius: 999px; background: var(--bg-2); border: 1px solid var(--hair-strong); position: relative; transition: background .18s, border-color .18s; flex: none; }
+.sw i::after { content: ""; position: absolute; top: 1px; left: 1px; width: 10px; height: 10px; border-radius: 50%; background: var(--muted-2); transition: transform .18s cubic-bezier(.32,.72,0,1), background .18s; }
+.sw.on i { background: var(--accent-wash); border-color: var(--accent-line); }
+.sw.on i::after { transform: translateX(10px); background: var(--accent-ink); }
+.sw.on { color: var(--accent-ink); }
+/* A switch the project has turned off is shown greyed, never hidden: "why can't I
+   assign?" needs an answer, and an absent control gives none. */
+.sw.off { opacity: .4; cursor: not-allowed; }
+.dsh code { font: 10px var(--font-mono); color: var(--accent-ink); }
+@media (prefers-reduced-motion: reduce) { .dsh, .dsh-scrim, .sw i, .sw i::after { transition: none; } }

--- a/test/claim.test.ts
+++ b/test/claim.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { store } from "./localstorage"; // must precede the subject import
+import {
+  ALLOW_ALL, CLAIM_STALE_MS, claimForSession, claimIsStale, claims, claimText,
+  DEFAULT_POLICY, dropClaim, policyWritesAnything, recordClaim, reloadClaims,
+  resolveClaim, type ClaimAllow, type ClaimPolicy,
+} from "../src/claim";
+
+const policy = (over: Partial<ClaimPolicy> = {}): ClaimPolicy => ({ ...DEFAULT_POLICY, ...over });
+const allow = (over: Partial<ClaimAllow> = {}): ClaimAllow => ({ ...ALLOW_ALL, ...over });
+
+beforeEach(() => {
+  store.clear();
+  reloadClaims();
+  claims.length = 0;
+});
+
+describe("the project is a ceiling, not a default", () => {
+  it("lets a project switch assignment off for everyone, keeping the rest", () => {
+    // The case that motivated the two levels: plenty of teams use assignment as a
+    // human planning signal, and an agent stomping it on every speculative run is a
+    // real cost — but they may still want the comment.
+    const r = resolveClaim(policy({ assign: true, comment: true }), allow({ assign: false }));
+    expect(r.assign.value).toBe(false);
+    expect(r.assign.source).toBe("project");
+    expect(r.comment.value).toBe(true);
+    expect(r.comment.source).toBe("personal");
+  });
+
+  it("cannot turn anything ON that you did not ask for", () => {
+    // A ceiling only ever lowers. A project must not be able to make your machine
+    // start commenting on issues because it said so.
+    const r = resolveClaim(policy({ assign: false, comment: false, pushBranch: false }), ALLOW_ALL);
+    expect([r.assign.value, r.comment.value, r.pushBranch.value]).toEqual([false, false, false]);
+  });
+
+  it("blames the project only when the project is actually the reason", () => {
+    // Off because you left it off is yours; off because you were refused is theirs.
+    // The settings tab shows this, so getting it backwards would lie to the user.
+    expect(resolveClaim(policy({ comment: false }), allow({ comment: false })).comment.source).toBe("personal");
+    expect(resolveClaim(policy({ comment: true }), allow({ comment: false })).comment.source).toBe("project");
+  });
+
+  it("treats a project with no policy as permitting everything", () => {
+    // A repo that never heard of Episko must not silently disable features.
+    const r = resolveClaim(policy({ assign: true, comment: true, pushBranch: true, label: "agent: running" }));
+    expect(policyWritesAnything(r)).toBe(true);
+    expect(r.label.value).toBe("agent: running");
+  });
+
+  it("gates the label like the booleans", () => {
+    const r = resolveClaim(policy({ label: "agent: running" }), allow({ label: false }));
+    expect(r.label.value).toBe("");
+    expect(r.label.source).toBe("project");
+  });
+
+  it("knows when a policy would write nothing at all", () => {
+    const silent = resolveClaim(policy({ assign: false, comment: false, pushBranch: false, label: "" }));
+    expect(policyWritesAnything(silent)).toBe(false);
+  });
+
+  it("defaults to assignment only — one call, reversible, no comment spam", () => {
+    expect(DEFAULT_POLICY.assign).toBe(true);
+    expect(DEFAULT_POLICY.comment).toBe(false);
+    expect(DEFAULT_POLICY.pushBranch).toBe(false);
+  });
+});
+
+describe("claims expire", () => {
+  const now = 1_000_000_000;
+
+  it("is live inside the window and stale outside it", () => {
+    expect(claimIsStale(now - 1000, now)).toBe(false);
+    expect(claimIsStale(now - CLAIM_STALE_MS - 1, now)).toBe(true);
+  });
+
+  it("says so in the text, rather than presenting a dead claim as live", () => {
+    expect(claimText("Frederic", now - 5 * 60_000, now)).toBe("Frederic is on this · 5m ago");
+    expect(claimText("Frederic", now - 3 * 3600_000, now)).toMatch(/probably stale/);
+  });
+
+  it("reads sensibly at the boundaries", () => {
+    expect(claimText("FA", now, now)).toContain("just now");
+    expect(claimText("FA", now - 90 * 60_000, now)).toContain("2h ago");
+  });
+});
+
+describe("the ledger of what we claimed", () => {
+  const rec = (over: Partial<Parameters<typeof recordClaim>[0]> = {}) => ({
+    threadId: "issue:33", root: "/w/episko", number: 33, kind: "issue" as const,
+    sessionId: "s1", at: 1000, ...over,
+  });
+
+  it("remembers a claim so an exit can release exactly the right one", () => {
+    recordClaim(rec());
+    expect(claimForSession("s1")?.number).toBe(33);
+    expect(claimForSession("nope")).toBeNull();
+  });
+
+  it("keeps one record per thread — re-claiming replaces, never duplicates", () => {
+    recordClaim(rec());
+    recordClaim(rec({ sessionId: "s2" }));
+    expect(claims).toHaveLength(1);
+    expect(claimForSession("s2")?.number).toBe(33);
+    expect(claimForSession("s1")).toBeNull();
+  });
+
+  it("returns what it dropped, so the release call knows the repo and number", () => {
+    recordClaim(rec());
+    const gone = dropClaim("issue:33");
+    expect(gone).toMatchObject({ root: "/w/episko", number: 33, kind: "issue" });
+    expect(dropClaim("issue:33")).toBeNull();
+  });
+
+  it("persists, because a claim outlives the window that made it", () => {
+    recordClaim(rec());
+    expect(JSON.parse(store.get("cc-claims")!)).toHaveLength(1);
+  });
+
+  it("survives a corrupt store rather than taking the app down at import", () => {
+    store.set("cc-claims", "{not json");
+    reloadClaims();
+    expect(claims).toEqual([]);
+  });
+});

--- a/test/ghwork.test.ts
+++ b/test/ghwork.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import "./localstorage"; // must precede the subject imports
+import { CLAIM_STALE_MS, type ClaimRecord } from "../src/claim";
+import {
+  bucketOf, bucketed, byRecency, cardRows, closeComment, holderOf, isoDay, quietFor,
+  staleCandidates, STALE_DAYS, type GhThread, type KeptIssue,
+} from "../src/ghwork";
+
+const NOW = new Date(2026, 6, 31, 14, 0, 0).getTime();
+const ago = (days: number) => new Date(NOW - days * 86_400_000).toISOString();
+
+const th = (o: Partial<GhThread> = {}): GhThread => ({
+  number: 1, kind: "issue", title: "a thing", url: "", assignees: [], labels: [],
+  branch: null, author: null, draft: false, updated_at: ago(0), ...o,
+});
+const rec = (o: Partial<ClaimRecord> = {}): ClaimRecord => ({
+  threadId: "t", root: "/w/epi", number: 1, kind: "issue", sessionId: "s", at: NOW, ...o,
+});
+
+describe("bucketOf", () => {
+  it("splits by recency, which is the only ordering that survives 60 open issues", () => {
+    expect(bucketOf(ago(0), NOW)).toBe("today");
+    expect(bucketOf(ago(3), NOW)).toBe("week");
+    expect(bucketOf(ago(20), NOW)).toBe("older");
+  });
+  it("sorts an unparseable timestamp oldest, never newest", () => {
+    // A row quietly claiming to be from today is the one you would act on first.
+    expect(bucketOf("", NOW)).toBe("older");
+    expect(bucketOf("not a date", NOW)).toBe("older");
+  });
+});
+
+describe("bucketed", () => {
+  it("groups in reading order and drops the empty groups", () => {
+    const g = bucketed([th({ number: 1, updated_at: ago(0) }), th({ number: 2, updated_at: ago(40) })], NOW);
+    expect(g.map((x) => x.bucket)).toEqual(["today", "older"]);
+  });
+  it("orders newest first within a group, ties by number so a repaint never reorders", () => {
+    const same = ago(2);
+    const g = bucketed([th({ number: 5, updated_at: same }), th({ number: 9, updated_at: same })], NOW);
+    expect(g[0].rows.map((r) => r.number)).toEqual([9, 5]);
+  });
+  it("keeps issues and PRs in one list — they compete for the same rows", () => {
+    const g = bucketed([th({ number: 1, kind: "pr" }), th({ number: 2, kind: "issue" })], NOW);
+    expect(g[0].rows).toHaveLength(2);
+  });
+});
+
+describe("cardRows", () => {
+  it("takes the four most recently active", () => {
+    const rows = cardRows(Array.from({ length: 9 }, (_, i) => th({ number: i, updated_at: ago(i) })));
+    expect(rows.map((r) => r.number)).toEqual([0, 1, 2, 3]);
+  });
+  it("does not mutate its input", () => {
+    const list = [th({ number: 1, updated_at: ago(5) }), th({ number: 2, updated_at: ago(0) })];
+    cardRows(list);
+    expect(list.map((t) => t.number)).toEqual([1, 2]);
+  });
+});
+
+describe("staleCandidates — what triage dares suggest", () => {
+  const kept: KeptIssue[] = [];
+  it("offers the quietest first", () => {
+    const out = staleCandidates(
+      [th({ number: 1, updated_at: ago(5) }), th({ number: 2, updated_at: ago(30) }), th({ number: 3, updated_at: ago(9) })],
+      kept, NOW);
+    expect(out.map((t) => t.number)).toEqual([2, 3, 1]);
+  });
+
+  it("NEVER offers a pull request", () => {
+    // A quiet PR needs review or a rebase; offering to close it would be wrong.
+    const out = staleCandidates([th({ number: 1, kind: "pr", updated_at: ago(40) })], kept, NOW);
+    expect(out).toEqual([]);
+  });
+
+  it("leaves an assigned issue alone — somebody said they are on it", () => {
+    const out = staleCandidates([th({ number: 1, updated_at: ago(40), assignees: ["FAbrahamDev"] })], kept, NOW);
+    expect(out).toEqual([]);
+  });
+
+  it("respects the project's committed keep list, whoever added it", () => {
+    const out = staleCandidates([th({ number: 24, updated_at: ago(40) })], [{ number: 24, who: "Frederic", at: "2026-07-01" }], NOW);
+    expect(out).toEqual([]);
+  });
+
+  it("ignores anything touched inside the quiet threshold", () => {
+    expect(staleCandidates([th({ updated_at: ago(STALE_DAYS - 1) })], kept, NOW)).toEqual([]);
+    expect(staleCandidates([th({ updated_at: ago(STALE_DAYS) })], kept, NOW)).toHaveLength(1);
+  });
+
+  it("caps the list, because triage is a side task and a chore gets dismissed wholesale", () => {
+    const many = Array.from({ length: 20 }, (_, i) => th({ number: i, updated_at: ago(10 + i) }));
+    expect(staleCandidates(many, kept, NOW)).toHaveLength(3);
+  });
+
+  it("drops an unparseable timestamp rather than treating it as ancient", () => {
+    // "Never touched" would otherwise top the list and be the first thing suggested.
+    expect(staleCandidates([th({ updated_at: "" })], kept, NOW)).toEqual([]);
+  });
+});
+
+describe("quietFor", () => {
+  it("speaks days, then months", () => {
+    expect(quietFor(ago(0), NOW)).toBe("quiet today");
+    expect(quietFor(ago(1), NOW)).toBe("quiet 1 day");
+    expect(quietFor(ago(9), NOW)).toBe("quiet 9 days");
+    expect(quietFor(ago(60), NOW)).toBe("quiet 2 months");
+  });
+  it("says so plainly when there is no timestamp", () => {
+    expect(quietFor("", NOW)).toBe("never touched");
+  });
+});
+
+describe("holderOf — a hint, never a lock", () => {
+  it("prefers our own ledger: it knows a dispatch nothing has been pushed for yet", () => {
+    const h = holderOf(th({ number: 7 }), "tim", [rec({ number: 7 })], NOW);
+    expect(h).toMatchObject({ mine: true, stale: false });
+  });
+  it("marks our own claim stale once it has aged out", () => {
+    const h = holderOf(th({ number: 7 }), "tim", [rec({ number: 7, at: NOW - CLAIM_STALE_MS - 1 })], NOW);
+    expect(h?.stale).toBe(true);
+  });
+  it("falls back to the assignee, and knows when that is you", () => {
+    expect(holderOf(th({ assignees: ["fred"] }), "tim", [], NOW)).toMatchObject({ who: "fred", mine: false });
+    expect(holderOf(th({ assignees: ["tim"] }), "tim", [], NOW)).toMatchObject({ who: "tim", mine: true });
+  });
+  it("reads an agent label as a machine, which cannot say whose", () => {
+    expect(holderOf(th({ labels: ["agent: running"] }), "tim", [], NOW)).toMatchObject({ who: "an agent", mine: false });
+  });
+  it("is null when nobody has it", () => {
+    expect(holderOf(th(), "tim", [], NOW)).toBeNull();
+    expect(holderOf(th({ labels: ["bug"] }), "tim", [], NOW)).toBeNull();
+  });
+  it("does not confuse an issue with a PR of the same number", () => {
+    expect(holderOf(th({ number: 7, kind: "pr" }), "tim", [rec({ number: 7, kind: "issue" })], NOW)).toBeNull();
+  });
+});
+
+describe("closeComment", () => {
+  it("says why, and says what would make it wrong", () => {
+    const c = closeComment(th({ updated_at: ago(9) }), NOW);
+    expect(c).toContain("quiet 9 days");
+    expect(c.toLowerCase()).toContain("reopen");
+  });
+});
+
+describe("isoDay", () => {
+  it("is day resolution — an hour churns a committed diff for nothing", () => {
+    expect(isoDay(new Date(2026, 6, 31, 23, 59).getTime())).toBe("2026-07-31");
+    expect(isoDay(new Date(2026, 0, 5, 0, 1).getTime())).toBe("2026-01-05");
+  });
+});


### PR DESCRIPTION
Third of three. **Stacked on #51** — base is `feat/project-dashboard`, so review that first and this retargets to `dev` when it merges. **Design mock:** https://claude.ai/code/artifact/dee80fdb-456e-4d55-9e50-c1bdf0da0e0b

The dashboard could tell you what happened; it could not tell you what is open, and two people picking up the same issue was invisible to both. This adds issues and PRs, the triage that asks whether the quiet ones are still needed, and the claim that makes a dispatch visible to a colleague.

`ghwork.ts` owns the rules and is tested (27) · `claim.ts` owns what a dispatch writes (12, ported from the spike) · `gh_threads` is two `gh` calls per repo, cached 60s, and **degrades rather than failing** — gh missing, logged out, or pointed at a non-GitHub folder is `available: false` plus a reason, shown as one quiet row like a blocked runnable.

## What it refuses to do — which is most of the design

- **A claim is a hint, never a lock.** Nothing refuses a dispatch; someone else's claim is shown, warned about once, then you proceed. Two people may well both want a go at a hard bug. Claims expire, and a `pty-exit` releases whatever that session took — a graveyard of dead claims is how this rots.
- **Triage never offers a pull request.** A quiet PR needs review or a rebase, not closing, and offering it would be actively wrong. It also never offers an assigned issue, or one on the project's keep list.
- **`gh_close_issue` comments *before* it closes.** If the close then fails, the issue carries a note explaining what was attempted — recoverable. The other order leaves an issue closed with no explanation.
- **A switch the project's `[claim]` policy turns off renders greyed, not hidden.** "Why can't I assign?" needs an answer; an absent control gives none.

`holderOf` reads three signals in one deliberate order: our own ledger first (it knows a dispatch nothing has been pushed for yet), then the assignee (the explicit human signal), then an `agent:` label (a machine, which cannot say whose).

## Dispatch sends the prompt

Per your call. This breaks the app's "Episko prefills, the human presses Enter" rule — deliberately, and only here: that rule exists so nothing is sent you didn't read, and a dispatch you confirmed in a sheet *is* the reading. The sheet shows exactly what will be written and which permission mode it starts in. A colleague's **shared note** is still prefilled-not-sent, because that is somebody else's sentence.

## Three committed files, one rule

`.episko/digest.md`, `.episko/episko.toml` (`[triage] keep`, beside `[claim]`) and `.episko/notes.toml` are all **project facts** — decided once, by anyone, true for the team. All three go through `toml_edit` read-modify-write so a hand-written comment survives, all three refuse to create themselves without an explicit yes, and all three need **git, not GitHub**.

The keep list records *who* decided and *when*, and the ⤢ view lists it with an undo — a committed decision nobody can audit is worse than no decision.

## Fixes a defect noted on #49

The `gh` fan-out: the viewer is now cached **for the process**, not re-fetched per repo. `gh api user` returns the same login whichever folder it runs in, so keying it by root spent a process per project for an answer already in hand. Per-project scoping does the rest — this never fans out across every project the way Threads did.

## Verification

- **558 vitest** (+39) · **140 cargo** (+22) · clippy clean on `-D warnings` · `tsc` clean · build clean · no import cycles.
- Coverage 90.05% over loaded modules, 20.9% over all of `src/`. `CLAUDE.md` updated in the same commit.
- **Not verified, and this is the important one:** the `gh` **write** path has still never run against a live repo. `gh_claim`/`gh_release` came from the spike unexercised, and `gh_close_issue` is new. Everything is unit-tested and every write is behind a confirm sheet, but the first real `assign`/`comment`/`close` will happen on someone's actual repo. I'd test it against a throwaway repo before trusting it.
- Also unrendered: no live run of any of this UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
