### PR TITLE
What's new: an update that says what it did

### DIFF
--- a/.github/release-install.md
+++ b/.github/release-install.md
@@ -1,0 +1,21 @@
+## Install
+
+**macOS (Apple Silicon)**
+
+1. Download **Episko_*_aarch64.dmg** from the assets below.
+2. Episko is self-signed (not notarized by Apple), so macOS Gatekeeper blocks the first launch. Clear the quarantine flag once:
+   ```sh
+   xattr -dr com.apple.quarantine ~/Downloads/Episko_*.dmg
+   ```
+3. Open the `.dmg`, drag **Episko** into Applications, and launch it. If it's still blocked:
+   ```sh
+   xattr -dr com.apple.quarantine /Applications/Episko.app
+   ```
+Apple Silicon (M-series) only — Intel Macs aren't supported by this build.
+
+**Windows (x64)**
+
+1. Download **Episko_*_x64-setup.exe** (or the **.msi**) from the assets below.
+2. Episko isn't code-signed, so Windows SmartScreen may warn on first run — click **More info → Run anyway**.
+
+Requires `claude` on your `PATH`. Episko keeps itself up to date after install (checks the latest release on launch; never auto-installs).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,20 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Every release describes itself. The gate is on the dev → main pull request rather
+  # than on the tag, because a tag that fails has already had the decision to ship made
+  # behind it — this fails while the fix is still one command.
+  changelog:
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+      - name: CHANGELOG.md has an Unreleased section
+        run: node scripts/changelog.mjs check
+
   build-check:
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,23 @@ jobs:
         if: steps.sign.outputs.enabled == 'true'
         run: cargo install trusted-signing-cli
 
+      # Install instructions ride in every release body so the top-of-list (latest)
+      # release always carries them — GitHub cannot pin a release, so "always in the
+      # newest one" is the equivalent. A tag with no changelog section still releases:
+      # the notes say so rather than the build failing after the decision to ship.
+      - name: Build the release body
+        id: notes
+        shell: bash
+        run: |
+          {
+            echo 'body<<EPISKO_BODY_EOF'
+            node scripts/changelog.mjs section "${{ github.ref_name }}" \
+              || echo "_This release has no changelog section._"
+            echo
+            cat .github/release-install.md
+            echo 'EPISKO_BODY_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build, sign, and publish release
         uses: tauri-apps/tauri-action@v0
         env:
@@ -92,33 +109,12 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "Episko ${{ github.ref_name }}"
-          # Install instructions are embedded in every release body so the
-          # top-of-list (latest) release always carries them — GitHub can't pin
-          # a release, so "always in the newest one" is the equivalent. The first
-          # matrix job to run creates the release with this body; later jobs append
-          # their assets, so it must cover every platform.
-          releaseBody: |
-            ## Install
-
-            **macOS (Apple Silicon)**
-
-            1. Download **Episko_*_aarch64.dmg** from the assets below.
-            2. Episko is self-signed (not notarized by Apple), so macOS Gatekeeper blocks the first launch. Clear the quarantine flag once:
-               ```sh
-               xattr -dr com.apple.quarantine ~/Downloads/Episko_*.dmg
-               ```
-            3. Open the `.dmg`, drag **Episko** into Applications, and launch it. If it's still blocked:
-               ```sh
-               xattr -dr com.apple.quarantine /Applications/Episko.app
-               ```
-            Apple Silicon (M-series) only — Intel Macs aren't supported by this build.
-
-            **Windows (x64)**
-
-            1. Download **Episko_*_x64-setup.exe** (or the **.msi**) from the assets below.
-            2. Episko isn't code-signed, so Windows SmartScreen may warn on first run — click **More info → Run anyway**.
-
-            Requires `claude` on your `PATH`. Episko keeps itself up to date after install (checks the latest release on launch; never auto-installs).
+          # What changed comes from CHANGELOG.md — the SAME lines the app's What's new
+          # screen shows, so a release and the app can never disagree about what a
+          # version did. The install block is concatenated in the step below rather than
+          # inlined here: a multi-line ${{ }} inside a YAML literal block indents only
+          # its first line, which silently mangles the rest of the body.
+          releaseBody: ${{ steps.notes.outputs.body }}
           releaseDraft: false
           prerelease: false
           # tauri-action generates and uploads latest.json when the updater is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,129 @@
+# Changelog
+
+Every release, newest first. This file is the **only** place release notes are written:
+the app ships it and shows it in *What's new*, `release.yml` lifts the matching section
+into the GitHub release, and CI refuses a `dev → main` pull request whose `Unreleased`
+section is empty.
+
+`pnpm changelog` drafts `Unreleased` from the commits since the last tag. It writes a
+draft and stops — nothing here is generated at release time, so what ships is what
+somebody read.
+
+Markers: `+` new · `~` changed · `!` fixed
+
+## Unreleased
+
+A project is a place you arrive at now, not a session you fall into.
+
++ **Clicking a project opens a dashboard.** The last week of that project's commits and
+  sessions, summarised a day at a time, with every commit one keystroke away.
++ **Issues and pull requests**, with triage for the ones that have gone quiet and a
+  *claim* so a colleague's agent doesn't start the same work twice. Starting an agent on
+  an issue creates a worktree, sends the prompt, and says so on GitHub.
++ **A shared work log.** `.episko/digest.md` is committed, so the team reads one history
+  instead of each paying to re-derive it. Notes can be shared the same way.
++ **What's new** — this screen. It opens once after an update, and the ✦ beside the
+  version number in the footer reopens it.
+~ **The sidebar only lists checkouts something is running in.** Rest on a project for a
+  moment to see the rest; the timings are yours to set in Settings › Worktrees.
+~ The project header's ⌘I collapses the inspector to an icon rail rather than hiding it,
+  because on the dashboard it holds the only copy of History, Terminal and Run.
+
+## 0.12.0 — 2026-07-31
+
+Six branches landed at once, and the window finally has one title bar.
+
++ The app draws its own title bar on both platforms — the native one is gone.
++ A session notices when an agent leaves the checkout it was launched in, and offers to
+  follow it there or move the conversation.
++ **Commit graph** — a project's history, one page at a time, from the project menu.
++ Choose the permission mode a session starts in.
++ Right-click a ⑃ cluster header for its own menu; ＋ launches straight into that checkout.
+~ The ＋ Session picker offers branches that exist only on a remote.
+~ The main checkout stops dressing as a worktree — it wears ⌂ and the project's own accent.
+! Ctrl+Shift+C / Ctrl+Shift+V copy and paste in shell and task panes.
+! A turn the API killed no longer turns green a minute later.
+! Windows: one canonical path spelling, so a repo stops rendering as two.
+
+## 0.11.1 — 2026-07-28
+
+A one-line fix for something that made a whole feature look broken.
+
+! A symlinked working directory found no past sessions at all. The transcript folder is
+  keyed by the *physical* path, so encoding the spelling you typed found nothing — which
+  read as "no history" rather than as a failure.
+
+## 0.11.0 — 2026-07-27
+
+**Runnables** — Episko runs the task definitions your project already ships.
+
++ Run tasks from `package.json`, `justfile`, `Makefile`, `Taskfile.yml`, `mise.toml`,
+  `Cargo.toml`, and VS Code's `tasks.json` / `launch.json`. A run is just another pane,
+  so it gets the phase glyphs, the tray and ⌘1–9 for free.
++ **Run after a session stops**: when an agent finishes a turn in a project, verify it.
++ A project task panel for pinning, hiding, editing and overriding — writing only ever
+  to `.episko/tasks.toml`, never to another tool's file.
++ The episko.dev site, and a README written around what Episko actually does.
+! Ctrl+C interrupts an embedded Claude pane; it never exits it.
+! Ctrl+V pastes images correctly.
+
+## 0.10.1 — 2026-07-23
+
+Cleanup after the rename.
+
+! Recover settings stranded by the Muster → Episko rename. macOS keys localStorage to
+  the bundle id, so a renamed bundle looked like a factory reset.
+
+## 0.10.0 — 2026-07-23
+
+**Muster is now Episko.** Same app, better name.
+
+~ Renamed throughout, including the bundle id — see 0.10.1 for the settings this stranded.
+! Windows: one canonical path spelling, so external sessions merge into their project.
+! Embedded-terminal ghost cells — resize is debounced and forces a repaint.
+
+## 0.9.0 — 2026-07-22
+
+Released as Muster.
+
++ Worktree grouping in the sidebar: several checkouts of one repo read as one project.
++ Session history — reopen a session you closed.
+
+## 0.8.0 — 2026-07-21
+
+Released as Muster.
+
++ Usage analytics: spend per day, per model and per project, with a token ledger read
+  from Claude's own transcripts.
+
+## 0.7.0 — 2026-07-21
+
+Released as Muster.
+
++ External sessions — Claude sessions started outside the app are listed, mirrored
+  read-only, and can be jumped to in their own terminal.
+
+## 0.6.0 — 2026-07-21
+
+Released as Muster.
+
++ The permission cockpit: a blocking permission request is answered in the app, without
+  switching to the pane that asked.
+
+## 0.5.1 — 2026-07-20
+
+Released as Muster.
+
+! The tray title no longer lags a phase behind the sidebar.
+
+## 0.5.0 — 2026-07-20
+
+Released as Muster.
+
++ The ⑃ worktree dialog: create, switch and prune checkouts without leaving the app.
+
+## 0.4.3 — 2026-07-18
+
+Released as Muster. The first build worth installing.
+
++ Auto-update, so this is the last one you install by hand.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ pnpm coverage           # the same suites with v8 coverage
 ```
 
 Coverage is a **yardstick, not a target** — there is deliberately no gate, because the
-render and DOM-owning modules are untested by design. Current: **90.2%** statements
-over the modules the suites load, **20.9%** over all of `src/`, and **71.0%** Rust
+render and DOM-owning modules are untested by design. Current: **90.47%** statements
+over the modules the suites load, **21.3%** over all of `src/`, and **71.0%** Rust
 lines (`cargo llvm-cov --summary-only` from `src-tauri/`). Both gaps are the OS edge,
 which `RELEASE.md` covers by hand. Note vitest's `text` reporter **hides any file at
 100% in all four columns**, so a fully-covered module looks absent; use
@@ -52,9 +52,9 @@ Mac has the same symlink — but it is one both legs will find at once.
 
 **Package manager: `pnpm`** for this repo (there's a `pnpm-lock.yaml`; both CI workflows use `pnpm install --frozen-lockfile`, and `packageManager` in `package.json` pins the version for corepack/CI). Use pnpm here, not npm. Windows code-signing / release-signing setup lives in `src-tauri/SIGNING.md`.
 
-Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **580 vitest + cargo (140 on macOS, 137 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
+Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **604 vitest + cargo (140 on macOS, 137 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
 
-**vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which eighteen those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
+**vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which nineteen those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
 
 What is **untested by design**: the render, view and DOM-owning modules on both sides of the app — snapshotting template literals mostly re-asserts itself. Anything touching the DOM, PTYs, or live telemetry is still verified by **running the app and exercising it** — the statusLine half of telemetry only fires in interactive mode, so it cannot be checked end to end with `claude -p`. Split that one carefully, because the split is not where it looks: whether the generated statusLine command *works* is checked headlessly and in CI (the shell runs it for real — see the constraint above). What needs a live REPL is only whether **Claude still picks the shell and payload we expect**. That costs a TTY, not tokens: a session you launch and never prompt makes no API call, and the statusLine fires on start and every `refreshInterval` seconds regardless. It's a `RELEASE.md` click-through, and a cheap one. `tsc` (strict) is the real linter. Requires `claude` on PATH, the Node in `.nvmrc` (`nvm use`; `engines` floors it at 24), and Rust stable + Tauri system deps.
 
@@ -247,6 +247,36 @@ Four smaller P4 affordances, all in the frontend:
 - **⟳ Rescan** — `rescan_runnables` drops the project's cache entries; the panel
   button and the picker's ⌘⇧R both route through it. The escape hatch for the one
   thing the stamp can't see: a file an introspector imports itself.
+
+## Releases and the changelog (`CHANGELOG.md`, `scripts/changelog.mjs`)
+
+**`CHANGELOG.md` is the only place release notes are written**, and it has three
+consumers that must never disagree: the app's *What's new* screen parses it
+(`changelog.ts` → `changelogui.ts`), `release.yml` lifts the tag's section into the
+GitHub release body, and `ci.yml` refuses a `dev → main` pull request whose
+`## Unreleased` section has no entries.
+
+- **The app ships the file, it does not fetch it.** A `?raw` import bundles it at build
+  time, so the screen works offline and **a build can only ever describe itself** —
+  fetching the releases API would let a newer entry describe a version the user is not
+  running, which is worse than showing nothing.
+- **The gate is on the PR, not the tag.** A tag that fails has already had the decision
+  to ship made behind it; a PR check fails while the fix is one command. `pnpm changelog
+  draft` writes the section through Haiku and **stops** — it never commits, and the gate
+  checks only that the section is non-empty, never that a model wrote it. A gate
+  demanding generated prose would make writing your own notes a CI failure.
+- **Three markers, not six headings**: `+` new, `~` changed, `!` fixed. Keep-a-Changelog's
+  sections force a judgement call per line and leave headings with one bullet under them.
+- **`shouldAnnounce` is deliberately narrow.** It opens only when the running version
+  differs from `cc-seen-version` *and* the file has a section for it — so a fresh install,
+  a downgrade and a local dev build are all silent. Opening a changelog over an app
+  somebody has never run is noise before it is information.
+- **The release body is assembled in a step, not inlined in YAML.** A multi-line `${{ }}`
+  inside a literal block indents only its first line and silently mangles the rest, which
+  is why the install text lives in `.github/release-install.md` and is concatenated.
+- A tag with no matching section still releases — the notes say so. Failing the build
+  after the decision to ship is the thing the PR gate exists to prevent, and doing it
+  anyway at tag time would just move the problem.
 
 ## The project dashboard (`dash.ts`, `dashview.ts`, `dashboard.ts`)
 
@@ -502,13 +532,13 @@ Four conventions hold across them:
 - **Telemetry server** (`run_telemetry_server`) forwards `/hook` and `/statusline` POSTs as one `telemetry` event each; `/permission` is the blocking path described above.
 - Commands are registered in the `invoke_handler![...]` list at the bottom of `run()` — add new `#[tauri::command]` fns there.
 
-## Frontend (`src/`, `index.html`, `src/styles.css`) — 47 modules
+## Frontend (`src/`, `index.html`, `src/styles.css`) — 49 modules
 
-**No framework, and no longer one file.** ~12,370 lines across 47 modules; `main.ts` is 774 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
+**No framework, and no longer one file.** ~12623 lines across 49 modules; `main.ts` is 777 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (~70 lines — it is the seam map, and belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, the window controls (see One title bar), and the seven `setInterval`s.
 
-**Tested logic modules** (eighteen — no DOM, no Tauri, no render imports; these are what the 580 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
+**Tested logic modules** (nineteen — no DOM, no Tauri, no render imports; these are what the 604 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
 
 | Module | What |
 | --- | --- |
@@ -529,6 +559,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 | `notes.ts` | the one thing on the dashboard you type — capture, filing, removal |
 | `dash.ts` | the project dashboard's rules: `projectTier`, `dashDays`, `dashPulse`, `projectCost` |
 | `ghwork.ts` | issues and PRs: recency buckets, what triage dares suggest, who already has one |
+| `changelog.ts` | CHANGELOG.md → releases, and the one moment *What's new* opens by itself |
 | `claim.ts` | what Episko writes when you dispatch at shared work, and who decides |
 
 **Shared**: `state.ts` (the session map, the stage pointer, every persisted preference) and `dom.ts` (`$`, `toast`, the shared scrim, `IS_MAC`/`MOD`/`chord`).
@@ -539,7 +570,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 
 **Behaviour** — IPC and DOM all the way down, so untested too, and therefore the thinnest ice in the app: `panes` (the three spawners + a pane's lifecycle), `terminal` (the xterm plumbing), `taskrun` (run on stop), `actions` (the app-level verbs), `icons` (the per-project glyph store).
 
-Four rules keep that graph honest. **There are no import cycles across the 47 modules; re-run a cycle check after any change that adds an import.**
+Four rules keep that graph honest. **There are no import cycles across the 49 modules; re-run a cycle check after any change that adds an import.**
 
 - **Dependency direction is state ← render ← wiring.** A logic module must not import render code or `main.ts`.
 - **When an extracted function needs something that lives further up**, resolve it in this order: (1) **move the callee down too** if it is itself leaf-shaped — that is why `icons.ts` sits below `sidebar.ts` and `usage.ts` below `phase.ts`; (2) **a settable hook defaulting to a no-op** (`setRlLogger`, `setPanesRenderAll`) when the callee genuinely belongs to the render layer; (3) **an extra parameter** only as a last resort, since it changes a signature the move was supposed to leave alone. A control panel touching many things it doesn't own may take **one host object** instead of N setters (`settings`, `palui`, `projmenu`); prefer per-callee setters below ~4.

--- a/index.html
+++ b/index.html
@@ -129,6 +129,7 @@
 
       <footer class="foot">
         <a class="frepo" id="fRepo" href="https://github.com/respeak-io/episko" title="respeak-io/episko — open on GitHub">respeak-io/episko<span class="fcaret">↗</span></a>
+        <button class="clbtn" id="clBtn" title="What's new"><span class="spark">✦</span></button>
         <span class="fver" id="fVer" title="Installed Episko version · click to check for updates"></span>
         <button class="fupdate" id="fUpdate" title="Download the new version and restart Episko" hidden></button>
         <span class="fseg"><span id="fSessions">0</span> sessions</span>
@@ -329,5 +330,21 @@
          Lives out here with its siblings, not inside #wtDlg: that dialog is
          overflow:hidden, so an in-dialog popover would be clipped. -->
     <div class="menupop bpop" id="bPop"></div>
+  <!-- What's new. Content comes from CHANGELOG.md, bundled at build time — this
+       reaches no network, and a build can only ever describe itself. -->
+  <div class="cl-dlg" id="clDlg">
+    <div class="cl-head">
+      <h3>What's new</h3><span class="cl-sub" id="clSub"></span>
+      <span class="rt"><button class="act icon" id="clClose" title="Close (Esc)">✕</button></span>
+    </div>
+    <div class="cl-body">
+      <div class="cl-rail" id="clRail"></div>
+      <div class="cl-main" id="clMain"></div>
+    </div>
+    <div class="cl-foot">
+      <span>Shipped with this build — no network needed.</span>
+      <span class="rt"><button class="act" id="clGh">↗ On GitHub</button></span>
+    </div>
+  </div>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "episko",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "packageManager": "pnpm@10.33.2",
   "engines": {
@@ -15,7 +15,8 @@
     "coverage": "vitest run --coverage",
     "tauri": "tauri",
     "site:stamp": "node scripts/stamp-site-version.mjs",
-    "site:deploy": "node scripts/stamp-site-version.mjs && wrangler deploy"
+    "site:deploy": "node scripts/stamp-site-version.mjs && wrangler deploy",
+    "changelog": "node scripts/changelog.mjs"
   },
   "dependencies": {
     "@tauri-apps/api": "^2",

--- a/scripts/changelog.mjs
+++ b/scripts/changelog.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+// CHANGELOG.md's three consumers, in one file.
+//
+//   draft            — write the Unreleased section from the commits since the last tag,
+//                      through `claude -p`. Writes a draft and stops; never commits.
+//   check            — the CI gate: fail if Unreleased is missing or empty.
+//   section <ver>    — print one release's markdown, for release.yml's body.
+//   release <ver>    — rename Unreleased to <ver> and stamp today's date.
+//
+// No dependencies: this runs on a CI runner before `pnpm install` has necessarily
+// produced anything, and a release script that can fail on a registry hiccup is a
+// release script that will.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const FILE = path.join(ROOT, "CHANGELOG.md");
+
+const read = () => readFileSync(FILE, "utf8");
+
+/// Split the file into its `## …` sections, keeping the preamble separate. Deliberately
+/// the same heading grammar as src/changelog.ts — a prose heading is not a release.
+function sections(md) {
+  const lines = md.split(/\r?\n/);
+  const out = [];
+  let cur = null;
+  let preamble = [];
+  for (const line of lines) {
+    const m = /^##\s+(.+?)\s*$/.exec(line);
+    const ver = m ? headingVersion(m[1]) : null;
+    if (ver) {
+      cur = { version: ver, heading: line, body: [] };
+      out.push(cur);
+    } else if (cur) {
+      cur.body.push(line);
+    } else {
+      preamble.push(line);
+    }
+  }
+  return { preamble, out };
+}
+
+function headingVersion(h) {
+  const m = /^v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\s*(?:[—–-].*)?$/.exec(h);
+  if (m) return m[1];
+  return /^unreleased$/i.test(h) ? "Unreleased" : null;
+}
+
+const bodyText = (s) => s.body.join("\n").trim();
+/// A section "has content" only if it carries at least one marker line. A lede alone is
+/// somebody starting to write and stopping, which is exactly what the gate is for.
+const hasEntries = (s) => s.body.some((l) => /^\s*[+~!]\s+\S/.test(l));
+
+// ---------- draft ----------
+
+function lastTag() {
+  try {
+    return execFileSync("git", ["describe", "--tags", "--abbrev=0"], { cwd: ROOT, encoding: "utf8" }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function facts(since) {
+  const range = since ? `${since}..HEAD` : "HEAD";
+  const git = (args) => execFileSync("git", args, { cwd: ROOT, encoding: "utf8" }).trim();
+  // Merge commits carry the PR title, which is usually the best one-line summary of a
+  // change; the non-merge subjects carry the detail. Both, deduped by the reader.
+  const merges = git(["log", "--merges", "--pretty=%s%n%b", range]);
+  const subjects = git(["log", "--no-merges", "--pretty=%s", range]);
+  return `MERGED PULL REQUESTS\n${merges}\n\nCOMMIT SUBJECTS\n${subjects}`.slice(0, 24000);
+}
+
+const PROMPT = `You are writing the Unreleased section of a changelog for Episko, a desktop app
+that runs many Claude Code sessions at once.
+
+Below are the merged pull requests and commit subjects since the last release. Write the
+section body — do NOT write the "## Unreleased" heading itself.
+
+Format:
+- One short opening sentence saying what this release is ABOUT. No bullet, no heading.
+- Then one line per user-visible change, each starting with a marker:
+    +  something new
+    ~  something that changed
+    !  something fixed
+- Use **bold** for the name of a feature, and \`code\` for a file or flag.
+- Wrap lines at about 88 characters; continuation lines are indented two spaces.
+
+Rules:
+- Write for someone who uses the app, not someone who wrote it. "The sidebar only lists
+  checkouts something is running in" — not "refactored groupBody".
+- Omit anything with no user-visible effect: refactors, tests, CI, docs, dependency bumps.
+- Do not invent anything that is not in the facts below.
+- At most 12 lines. If there are more changes than that, merge the small ones.
+- Output only the section body. No preamble, no code fence.
+
+FACTS
+`;
+
+function draft() {
+  const tag = lastTag();
+  const f = facts(tag);
+  process.stderr.write(`drafting from ${tag || "the beginning"}…\n`);
+  let text;
+  try {
+    text = execFileSync("claude", ["-p", PROMPT + f, "--model", "haiku"], {
+      cwd: ROOT, encoding: "utf8", stdio: ["ignore", "pipe", "inherit"], timeout: 120_000,
+    }).trim();
+  } catch (e) {
+    console.error("claude failed — write the section by hand:", e.message);
+    process.exit(1);
+  }
+  // Strip a code fence if the model added one despite being told not to.
+  text = text.replace(/^```[a-z]*\n?/i, "").replace(/\n?```$/, "").trim();
+  if (!text) {
+    console.error("claude returned nothing — write the section by hand");
+    process.exit(1);
+  }
+
+  const md = read();
+  const { preamble, out } = sections(md);
+  const unrel = out.find((s) => s.version === "Unreleased");
+  if (unrel && hasEntries(unrel)) {
+    console.error("Unreleased already has entries — edit them, or clear the section first.");
+    process.exit(1);
+  }
+  const rest = out.filter((s) => s.version !== "Unreleased");
+  const rebuilt =
+    preamble.join("\n").replace(/\s+$/, "") +
+    `\n\n## Unreleased\n\n${text}\n\n` +
+    rest.map((s) => `${s.heading}\n${bodyText(s)}\n`).join("\n");
+  writeFileSync(FILE, rebuilt.replace(/\n{3,}/g, "\n\n").trimEnd() + "\n");
+  process.stderr.write("wrote CHANGELOG.md — read it before committing.\n");
+}
+
+// ---------- check ----------
+
+function check() {
+  const { out } = sections(read());
+  const unrel = out.find((s) => s.version === "Unreleased");
+  if (!unrel) {
+    fail("CHANGELOG.md has no `## Unreleased` section.");
+  }
+  if (!hasEntries(unrel)) {
+    fail("`## Unreleased` in CHANGELOG.md has no entries.");
+  }
+  console.log(`CHANGELOG.md: Unreleased has ${unrel.body.filter((l) => /^\s*[+~!]\s/.test(l)).length} entries.`);
+}
+
+function fail(msg) {
+  // The gate exists to be *actionable*: say what is wrong and exactly how to fix it,
+  // because the person who hits it is trying to ship and has no interest in archaeology.
+  console.error(`\n✗ ${msg}\n`);
+  console.error("Every release describes itself. Add the section, then push:\n");
+  console.error("    pnpm changelog draft     # draft it from the commits since the last tag");
+  console.error("    $EDITOR CHANGELOG.md     # read it — this is what users will see\n");
+  console.error("Markers: + new · ~ changed · ! fixed\n");
+  process.exit(1);
+}
+
+// ---------- section / release ----------
+
+function section(version) {
+  const v = String(version || "").replace(/^v/, "");
+  const { out } = sections(read());
+  const s = out.find((x) => x.version === v);
+  if (!s) {
+    console.error(`CHANGELOG.md has no section for ${v}`);
+    process.exit(1);
+  }
+  process.stdout.write(bodyText(s) + "\n");
+}
+
+function release(version) {
+  const v = String(version || "").replace(/^v/, "");
+  if (!/^\d+\.\d+\.\d+/.test(v)) {
+    console.error(`not a version: ${version}`);
+    process.exit(1);
+  }
+  const md = read();
+  const { preamble, out } = sections(md);
+  const unrel = out.find((s) => s.version === "Unreleased");
+  if (!unrel || !hasEntries(unrel)) fail("`## Unreleased` is empty — nothing to release.");
+  if (out.some((s) => s.version === v)) {
+    console.error(`CHANGELOG.md already has a section for ${v}`);
+    process.exit(1);
+  }
+  const today = new Date().toISOString().slice(0, 10);
+  const rest = out.filter((s) => s.version !== "Unreleased");
+  const rebuilt =
+    preamble.join("\n").replace(/\s+$/, "") +
+    `\n\n## Unreleased\n\n` +
+    `## ${v} — ${today}\n${bodyText(unrel)}\n\n` +
+    rest.map((s) => `${s.heading}\n${bodyText(s)}\n`).join("\n");
+  writeFileSync(FILE, rebuilt.replace(/\n{3,}/g, "\n\n").trimEnd() + "\n");
+  process.stderr.write(`CHANGELOG.md: Unreleased → ${v} (${today})\n`);
+}
+
+// ---------- main ----------
+const [cmd, arg] = process.argv.slice(2);
+if (cmd === "draft") draft();
+else if (cmd === "check") check();
+else if (cmd === "section") section(arg);
+else if (cmd === "release") release(arg);
+else {
+  console.error("usage: changelog.mjs draft | check | section <version> | release <version>");
+  process.exit(2);
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Episko",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "identifier": "io.respeak.episko",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -1,0 +1,123 @@
+// The changelog: parsing CHANGELOG.md, and deciding when to put it on screen.
+//
+// WHY THE APP SHIPS ITS OWN. `CHANGELOG.md` is bundled at build time (a `?raw` import),
+// not fetched from GitHub at runtime. Two reasons, and the second is the real one:
+// it works with no network, and **a build can only ever describe itself**. Fetching the
+// releases API would let a newer entry describe a version the user is not running, which
+// is worse than showing nothing.
+//
+// No DOM and no Tauri, so it unit-tests in isolation; ./changelogui owns the dialog.
+// See test/changelog.test.ts.
+
+/// One line of a release. The marker is the whole taxonomy: Keep-a-Changelog's six
+/// headings force a judgement call per line and leave sections with one bullet in them.
+export type Mark = "new" | "changed" | "fixed";
+
+export interface Entry { mark: Mark; text: string }
+
+export interface Release {
+  /// `0.12.0`, or `Unreleased` for the section that has not shipped.
+  version: string;
+  /// As written — `2026-07-31`, or "" for Unreleased.
+  date: string;
+  /// The first paragraph: what the release was *about*, in one sentence.
+  lede: string;
+  entries: Entry[];
+  released: boolean;
+}
+
+const MARKS: Record<string, Mark> = { "+": "new", "~": "changed", "!": "fixed" };
+
+/**
+ * Parse the file. Forgiving by design: a hand-written section that doesn't match the
+ * shape degrades to a lede rather than vanishing, because a changelog nobody can
+ * hand-edit is a changelog that stops being written.
+ *
+ * A heading is only a release if it looks like one — `## 1.2.3` or `## Unreleased`.
+ * Anything else is prose somebody added and must not become a version.
+ */
+export function parseChangelog(md: string): Release[] {
+  const out: Release[] = [];
+  let cur: Release | null = null;
+  let lede: string[] = [];
+  const flushLede = () => {
+    if (cur && !cur.lede) cur.lede = lede.join(" ").trim();
+    lede = [];
+  };
+
+  for (const raw of md.split(/\r?\n/)) {
+    const line = raw.trim();
+    const head = /^##\s+(.+?)\s*$/.exec(line);
+    if (head) {
+      flushLede();
+      const [version, date] = splitHeading(head[1]);
+      if (!version) { cur = null; continue; }   // prose heading — not a release
+      cur = { version, date, lede: "", entries: [], released: version.toLowerCase() !== "unreleased" };
+      out.push(cur);
+      continue;
+    }
+    if (!cur) continue;
+    const item = /^([+~!])\s+(.+)$/.exec(line);
+    if (item) {
+      flushLede();
+      cur.entries.push({ mark: MARKS[item[1]], text: item[2].trim() });
+      continue;
+    }
+    // A continuation of the previous entry: entries wrap, and a wrapped second line
+    // must not become a lede or be dropped.
+    if (line && cur.entries.length && !lede.length) {
+      cur.entries[cur.entries.length - 1].text += " " + line;
+      continue;
+    }
+    if (line) lede.push(line);
+  }
+  flushLede();
+  return out;
+}
+
+/// `1.2.3 — 2026-07-31` → `["1.2.3", "2026-07-31"]`. Returns no version for a heading
+/// that isn't one, which is how prose headings are rejected.
+function splitHeading(h: string): [string, string] {
+  const m = /^v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\s*(?:[—–-]\s*(.*))?$/.exec(h);
+  if (m) return [m[1], (m[2] || "").trim()];
+  if (/^unreleased$/i.test(h)) return ["Unreleased", ""];
+  return ["", ""];
+}
+
+// ---------- when to show it ----------
+
+/**
+ * Should *What's new* open by itself?
+ *
+ * Only when the running version differs from the last one this machine acknowledged —
+ * i.e. you just updated. Three cases are deliberately silent:
+ *
+ * - **A fresh install** (`seen` is null). There is nothing new to someone who has never
+ *   run it; opening a changelog over an empty app is noise before it is information.
+ * - **A version with no section.** The screen would open on nothing.
+ * - **A downgrade or a dev build.** Only a version we can find in the file counts, so
+ *   running a local build with an unpublished version stays quiet.
+ */
+export function shouldAnnounce(current: string, seen: string | null, log: Release[]): boolean {
+  if (!current || !seen || seen === current) return false;
+  return log.some((r) => r.released && r.version === current);
+}
+
+/// The release to open on: the running version if the file knows it, else the newest
+/// released one, else whatever is first (an Unreleased-only file on a dev build).
+export function releaseFor(current: string, log: Release[]): Release | null {
+  if (!log.length) return null;
+  return log.find((r) => r.version === current) ?? log.find((r) => r.released) ?? log[0];
+}
+
+/// Entries grouped for display, in a fixed order so two releases never disagree about
+/// where "fixed" goes. Empty groups are dropped rather than rendered as a bare heading.
+export const MARK_ORDER: Mark[] = ["new", "changed", "fixed"];
+export const MARK_LABEL: Record<Mark, string> = { new: "New", changed: "Changed", fixed: "Fixed" };
+export const MARK_GLYPH: Record<Mark, string> = { new: "+", changed: "~", fixed: "!" };
+
+export function grouped(r: Release): { mark: Mark; entries: Entry[] }[] {
+  return MARK_ORDER
+    .map((mark) => ({ mark, entries: r.entries.filter((e) => e.mark === mark) }))
+    .filter((g) => g.entries.length);
+}

--- a/src/changelogui.ts
+++ b/src/changelogui.ts
@@ -1,0 +1,131 @@
+// *What's new* — the release history, and the one moment it opens by itself.
+//
+// ./changelog owns the parsing and the "should this open" rule and is tested; this owns
+// the dialog, its markup and its events. The file itself is bundled at build time
+// (`?raw`), so this reaches no network and a build can only ever describe itself.
+//
+// Deliberately NOT on renderAll's path: it is opened by a click or once after an
+// update, and nothing about it changes while it is shut.
+
+import { getVersion } from "@tauri-apps/api/app";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import raw from "../CHANGELOG.md?raw";
+import { $, dropScrim } from "./dom";
+import { dlog } from "./debug";
+import { esc } from "./format";
+import {
+  grouped, MARK_GLYPH, MARK_LABEL, parseChangelog, releaseFor, shouldAnnounce,
+  type Release,
+} from "./changelog";
+
+const LOG: Release[] = parseChangelog(raw);
+/// The last version this machine acknowledged. Absent on a fresh install, which is
+/// what keeps the screen shut for someone who has never run Episko.
+const SEEN = "cc-seen-version";
+
+let version = "";
+let sel = 0;
+
+export const changelogOpen = () => $("clDlg").classList.contains("show");
+
+/// The footer handle stays lit until the running version has been read once. It is the
+/// only signal that there is something new — which is why it sits ON the version
+/// number rather than in the top bar: that number is the thing it explains.
+function syncHandle() {
+  const unread = !!version && localStorage.getItem(SEEN) !== version;
+  $("clBtn").classList.toggle("fresh", unread);
+  $("clBtn").title = unread ? `What's new in ${version}` : "What's new";
+}
+
+/// Mark the running version read. Called on open, not on close: opening it *is* the
+/// reading, and a user who closes with Esc has still seen it.
+function markSeen() {
+  if (version) localStorage.setItem(SEEN, version);
+  syncHandle();
+}
+
+export function openChangelog(atVersion?: string) {
+  if (!LOG.length) return;                    // nothing to show; the handle stays hidden
+  // `releaseFor` owns which one to land on, including the dev-build fallback — it is
+  // tested, and re-deriving it here is how the two would drift.
+  const target = releaseFor(atVersion ?? version, LOG);
+  sel = Math.max(0, LOG.indexOf(target!));
+  $("scrim").classList.add("show");
+  $("clDlg").classList.add("show");
+  render();
+  markSeen();
+}
+
+export function closeChangelog() {
+  $("clDlg").classList.remove("show");
+  dropScrim();
+}
+
+function render() {
+  const r = LOG[sel];
+  if (!r) return;
+  $("clSub").textContent = version ? `you're on ${version}` : "";
+
+  $("clRail").innerHTML = `<div class="cl-railh">Releases</div>` + LOG.map((x, i) => {
+    const running = x.released && x.version === version;
+    return `<div class="cl-v${i === sel ? " on" : ""}${running ? " running" : ""}${x.released ? "" : " unrel"}"
+        data-clv="${i}" title="${esc(x.released ? `Episko ${x.version}` : "Not released yet")}">
+      <span class="dot"></span>
+      <span class="n">${esc(x.released ? x.version : "next")}</span>
+      <span class="d">${esc(shortDate(x.date))}</span></div>`;
+  }).join("");
+
+  const running = r.released && r.version === version;
+  $("clMain").innerHTML =
+    `<div class="cl-vh"><h4>${esc(r.released ? `Episko ${r.version}` : "Next release")}</h4>
+      ${r.date ? `<span class="when">${esc(r.date)}</span>` : `<span class="when">not released yet</span>`}
+      ${running ? `<span class="chip ok">you're running this</span>` : ""}</div>`
+    + (r.lede ? `<p class="cl-lede">${esc(r.lede)}</p>` : "")
+    + grouped(r).map((g) => `<div class="cl-group">
+        <div class="cl-gh"><span class="t">${esc(MARK_LABEL[g.mark])}</span></div>
+        ${g.entries.map((e) => `<div class="cl-item ${g.mark}">
+          <span class="m">${MARK_GLYPH[g.mark]}</span>
+          <span class="tx">${inline(e.text)}</span></div>`).join("")}
+      </div>`).join("");
+
+  ($("clGh") as HTMLButtonElement).hidden = !r.released;
+}
+
+/// The only markup an entry may carry: `**bold**` and `` `code` ``. Escaped first, so
+/// this can never inject — the file is in our repo, but it is also the thing a
+/// contributor edits, and a changelog is not a place to trust input.
+function inline(s: string): string {
+  return esc(s)
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\*\*([^*]+)\*\*/g, "<b>$1</b>");
+}
+
+const shortDate = (d: string) => (d ? d.slice(5).replace("-", "/") : "—");
+
+// ---------- wiring ----------
+export function initChangelog() {
+  getVersion().then((v) => {
+    version = v;
+    syncHandle();
+    // The one moment it opens by itself. Deliberately after the version resolves
+    // rather than on a timer: opening over a half-painted app reads as a glitch.
+    if (shouldAnnounce(v, localStorage.getItem(SEEN), LOG)) {
+      dlog("info", `changelog: first run of v${v}`);
+      openChangelog(v);
+    }
+  }).catch(() => { /* not in Tauri (vite dev in a browser) — the handle stays quiet */ });
+
+  $("clBtn").addEventListener("click", () => (changelogOpen() ? closeChangelog() : openChangelog()));
+  $("clClose").addEventListener("click", closeChangelog);
+  $("clRail").addEventListener("click", (e) => {
+    const v = (e.target as HTMLElement).closest<HTMLElement>("[data-clv]");
+    if (!v) return;
+    sel = +v.dataset.clv!;
+    render();
+  });
+  $("clGh").addEventListener("click", () => {
+    const r = LOG[sel];
+    if (!r?.released) return;
+    void openUrl(`https://github.com/respeak-io/episko/releases/tag/v${r.version}`).catch(() => {});
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,6 +65,7 @@ import { closeDiff, diffOpen, openDiff, setDiffCloseFootMenus } from "./diffview
 // context menu (./projmenu) and owns its own handlers; this file only has to close it
 // with the shared scrim and Esc, like every other dialog.
 import { closeGraph, graphEscape, graphOpen, openGraph as openGraphFor } from "./graphview";
+import { changelogOpen, closeChangelog, initChangelog } from "./changelogui";
 import {
   closeDashboard, dashEscape, openDashboard, releaseClaimFor, renderDash,
   renderDashHeader, renderDashInspector, setDashHost, wireDashboard,
@@ -598,7 +599,7 @@ $("btnClose").addEventListener("click", () => {
   if (activeId) closeSession(activeId);
 });
 
-$("scrim").addEventListener("click", () => { closePalette(); closeWt(); closeDiff(); closeGraph(); closeSettings(); closeRunPicker(); closeInputPrompt(); closeTaskManager(); closeHistory(); });
+$("scrim").addEventListener("click", () => { closePalette(); closeWt(); closeDiff(); closeGraph(); closeSettings(); closeRunPicker(); closeInputPrompt(); closeTaskManager(); closeHistory(); closeChangelog(); });
 window.addEventListener("keydown", (e) => {
   const meta = e.metaKey || e.ctrlKey;
   if (meta && e.key.toLowerCase() === "k") { e.preventDefault(); $("palette").classList.contains("show") ? closePalette() : openPalette(); }
@@ -619,6 +620,7 @@ window.addEventListener("keydown", (e) => {
   // step out of that first.
   else if (e.key === "Escape" && graphOpen) { e.preventDefault(); graphEscape(); }
   else if (e.key === "Escape" && settingsOpen()) { e.preventDefault(); closeSettings(); }
+  else if (e.key === "Escape" && changelogOpen()) { e.preventDefault(); closeChangelog(); }
   // dashEscape, not closeDashboard: an enlarge overlay can be up over the pane and
   // Esc has to take that first. Same rule as graphEscape above.
   else if (e.key === "Escape" && dashMirror()) { e.preventDefault(); dashEscape(); }
@@ -766,6 +768,7 @@ void refreshGitViews(); // seed the roster so the first paint isn't a checkout s
 setSort(sortMode, false); // paint the sort button's glyph/title for the persisted mode
 initProjectDnD();
 initSidebarPeek();
+initChangelog();
 initFileDrop();
 // caffeinate always starts off — the assertion is bound to the last run's process
 // (`-w <pid>` on macOS, the parked thread on Windows) and died with it; renderAll's

--- a/src/styles.css
+++ b/src/styles.css
@@ -1851,3 +1851,62 @@ select.in-ctl { cursor: pointer; }
 .sw.off { opacity: .4; cursor: not-allowed; }
 .dsh code { font: 10px var(--font-mono); color: var(--accent-ink); }
 @media (prefers-reduced-motion: reduce) { .dsh, .dsh-scrim, .sw i, .sw i::after { transition: none; } }
+
+/* ═══ What's new — the changelog screen ════════════════════════════════════════
+   Opened once after an update, and by the ✦ beside the version number. Content is
+   CHANGELOG.md, bundled at build time; ./changelog parses it, ./changelogui owns
+   this markup. Shares #scrim with #wtDlg / #setDlg / #palette. */
+.clbtn { display:inline-flex; align-items:center; justify-content:center; width:18px; height:16px; padding:0; border-radius:5px; cursor:pointer; border:1px solid transparent; background:none; color: var(--muted-2); }
+.clbtn:hover { color: var(--accent-ink); border-color: var(--accent-line); background: var(--accent-wash); }
+.clbtn .spark { font-size:10px; line-height:1; }
+/* Lit until the running version has been read once — the only signal that there is
+   something new, which is why it sits ON the version number rather than in the top bar. */
+.clbtn.fresh { color: var(--accent-ink); border-color: var(--accent-line); background: var(--accent-wash); }
+@media (prefers-reduced-motion: no-preference) { .clbtn.fresh .spark { animation: cl-sp 2.4s ease-in-out infinite; } }
+@keyframes cl-sp { 0%,100%{opacity:1;} 50%{opacity:.35;} }
+
+.cl-dlg { position: fixed; z-index: 61; top: 7%; left: 50%; transform: translateX(-50%) translateY(-8px) scale(.985);
+  width: min(760px, 92vw); height: min(560px, 82vh); display: flex; flex-direction: column; overflow: hidden;
+  border-radius: var(--radius-lg); opacity: 0; pointer-events: none;
+  transition: opacity .2s ease, transform .24s cubic-bezier(.32,.72,0,1);
+  background: linear-gradient(180deg, rgba(255,255,255,.05), transparent 34%), color-mix(in srgb, var(--panel) 94%, transparent);
+  backdrop-filter: blur(24px) saturate(1.4); border: 1px solid var(--hair-strong);
+  box-shadow: 0 44px 110px -34px rgba(0,0,0,.85), inset 0 1px 0 rgba(255,255,255,.07); }
+.cl-dlg.show { opacity: 1; pointer-events: auto; transform: translateX(-50%) translateY(0) scale(1); }
+.cl-head { display: flex; align-items: center; gap: 11px; padding: 13px 15px; border-bottom: 1px solid var(--hair); flex: none; }
+.cl-head h3 { margin: 0; font-size: 15px; font-weight: 800; letter-spacing: -.02em; }
+.cl-sub { font: 10.5px var(--font-mono); color: var(--muted-2); }
+.cl-head .rt, .cl-foot .rt { margin-left: auto; display: flex; gap: 6px; }
+.cl-body { flex: 1; min-height: 0; display: grid; grid-template-columns: 158px minmax(0, 1fr); }
+/* The rail is what turns a one-shot notice into a history you can walk. */
+.cl-rail { border-right: 1px solid var(--hair); overflow-y: auto; padding: 8px 7px 12px; background: color-mix(in srgb, var(--bg-2) 45%, transparent); }
+.cl-railh { padding: 8px 9px 5px; font: 700 8.5px var(--font-ui); letter-spacing: .11em; text-transform: uppercase; color: var(--muted-2); }
+.cl-v { display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 8px; cursor: pointer; border: 1px solid transparent; }
+.cl-v:hover { background: var(--surface); }
+.cl-v.on { background: var(--accent-wash); border-color: var(--accent-line); }
+.cl-v .n { font: 700 11px var(--font-mono); color: var(--muted); }
+.cl-v.on .n { color: var(--accent-ink); }
+.cl-v .d { margin-left: auto; font: 9px var(--font-mono); color: var(--muted-2); }
+.cl-v .dot { width: 5px; height: 5px; border-radius: 50%; flex: none; background: transparent; }
+.cl-v.running .dot { background: var(--st-done); box-shadow: 0 0 7px -1px var(--st-done); }
+.cl-v.unrel .n { color: var(--st-working); }
+.cl-v.unrel .dot { background: var(--st-working); }
+.cl-main { overflow-y: auto; padding: 16px 20px 26px; }
+.cl-vh { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; margin-bottom: 4px; }
+.cl-vh h4 { margin: 0; font-size: 19px; font-weight: 800; letter-spacing: -.025em; }
+.cl-vh .when { font: 10px var(--font-mono); color: var(--muted-2); }
+.cl-lede { margin: 0 0 16px; font-size: 13.5px; line-height: 1.6; color: var(--muted); max-width: 60ch; }
+.cl-group { margin-bottom: 15px; }
+.cl-gh { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+.cl-gh .t { font: 700 8.5px var(--font-ui); letter-spacing: .12em; text-transform: uppercase; color: var(--muted-2); }
+.cl-gh::after { content: ""; flex: 1; height: 1px; background: var(--hair); }
+.cl-item { display: grid; grid-template-columns: 16px minmax(0, 1fr); gap: 10px; padding: 5px 0; align-items: baseline; }
+.cl-item .m { font: 10px var(--font-mono); text-align: center; line-height: 1.5; }
+.cl-item.new .m { color: var(--st-done); }
+.cl-item.fixed .m { color: var(--st-working); }
+.cl-item.changed .m { color: #7cc7ff; }
+.cl-item .tx { font-size: 13px; line-height: 1.55; color: var(--muted); }
+.cl-item .tx b { color: var(--text); font-weight: 600; }
+.cl-item .tx code { font: 11.5px var(--font-mono); color: var(--accent-ink); }
+.cl-foot { flex: none; display: flex; align-items: center; gap: 9px; padding: 9px 15px; border-top: 1px solid var(--hair); background: var(--bg-2); font: 10.5px var(--font-mono); color: var(--muted-2); }
+@media (max-width: 640px) { .cl-body { grid-template-columns: 1fr; } .cl-rail { display: none; } }

--- a/test/changelog.test.ts
+++ b/test/changelog.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import {
+  grouped, parseChangelog, releaseFor, shouldAnnounce, type Release,
+} from "../src/changelog";
+
+const SAMPLE = `# Changelog
+
+Preamble prose that is not a release.
+
+## Unreleased
+
+What the next one is about.
+
++ A new thing.
+~ A changed thing.
+
+## 0.12.0 — 2026-07-31
+
+Six branches landed at once.
+
++ The app draws its own title bar.
+! A turn the API killed no longer turns green.
+
+## 0.11.1 — 2026-07-28
+
+! A one-liner.
+`;
+
+describe("parseChangelog", () => {
+  const log = parseChangelog(SAMPLE);
+
+  it("reads the releases in file order, newest first", () => {
+    expect(log.map((r) => r.version)).toEqual(["Unreleased", "0.12.0", "0.11.1"]);
+  });
+  it("marks Unreleased as not released, and everything else as released", () => {
+    expect(log.map((r) => r.released)).toEqual([false, true, true]);
+  });
+  it("keeps the date as written, and leaves Unreleased without one", () => {
+    expect(log[1].date).toBe("2026-07-31");
+    expect(log[0].date).toBe("");
+  });
+  it("takes the first paragraph as the lede and the markers as entries", () => {
+    expect(log[1].lede).toBe("Six branches landed at once.");
+    expect(log[1].entries).toEqual([
+      { mark: "new", text: "The app draws its own title bar." },
+      { mark: "fixed", text: "A turn the API killed no longer turns green." },
+    ]);
+  });
+  it("does not treat the preamble as a release", () => {
+    expect(log.some((r) => r.lede.includes("Preamble"))).toBe(false);
+  });
+  it("allows a release with no lede at all", () => {
+    expect(log[2].lede).toBe("");
+    expect(log[2].entries).toHaveLength(1);
+  });
+
+  it("rejects a prose heading rather than inventing a version from it", () => {
+    // Somebody will add `## Notes for the team`. It must not become a release, and it
+    // must not swallow the release above it either.
+    const l = parseChangelog("## 1.0.0 — 2026-01-01\n\n+ Real.\n\n## Notes\n\n+ Not a release.\n");
+    expect(l.map((r) => r.version)).toEqual(["1.0.0"]);
+    expect(l[0].entries).toHaveLength(1);
+  });
+
+  it("joins a wrapped entry instead of dropping its tail", () => {
+    const l = parseChangelog("## 1.0.0 — 2026-01-01\n\n+ A long entry that\n  wraps onto a second line.\n");
+    expect(l[0].entries[0].text).toBe("A long entry that wraps onto a second line.");
+  });
+
+  it("accepts a leading v on the heading, because tags carry one", () => {
+    expect(parseChangelog("## v2.0.0 — 2026-02-02\n\n+ x\n")[0].version).toBe("2.0.0");
+  });
+
+  it("is an empty list for an empty or structureless file, never a throw", () => {
+    expect(parseChangelog("")).toEqual([]);
+    expect(parseChangelog("just some words\n")).toEqual([]);
+  });
+});
+
+describe("shouldAnnounce — when What's new opens by itself", () => {
+  const log = parseChangelog(SAMPLE);
+  it("opens when the running version differs from the last one acknowledged", () => {
+    expect(shouldAnnounce("0.12.0", "0.11.1", log)).toBe(true);
+  });
+  it("stays shut on a fresh install — nothing is new to someone who never ran it", () => {
+    expect(shouldAnnounce("0.12.0", null, log)).toBe(false);
+  });
+  it("stays shut when it has already been seen", () => {
+    expect(shouldAnnounce("0.12.0", "0.12.0", log)).toBe(false);
+  });
+  it("stays shut for a version the file has no section for", () => {
+    // A local dev build, or a downgrade: the screen would open on nothing.
+    expect(shouldAnnounce("9.9.9", "0.12.0", log)).toBe(false);
+  });
+  it("never announces Unreleased, which is not a version anyone runs", () => {
+    expect(shouldAnnounce("Unreleased", "0.12.0", log)).toBe(false);
+  });
+});
+
+describe("releaseFor", () => {
+  const log = parseChangelog(SAMPLE);
+  it("opens on the running version when the file knows it", () => {
+    expect(releaseFor("0.11.1", log)?.version).toBe("0.11.1");
+  });
+  it("falls back to the newest RELEASED one, not to Unreleased", () => {
+    // A dev build's version isn't in the file; Unreleased describes something nobody
+    // is running, so it must not be what the screen lands on.
+    expect(releaseFor("0.13.0-dev", log)?.version).toBe("0.12.0");
+  });
+  it("is null for an empty log", () => {
+    expect(releaseFor("1.0.0", [])).toBeNull();
+  });
+});
+
+describe("grouped", () => {
+  it("orders the groups the same way every time and drops the empty ones", () => {
+    const r = parseChangelog(SAMPLE)[1];
+    expect(grouped(r).map((g) => g.mark)).toEqual(["new", "fixed"]);
+  });
+  it("is empty for a release with no entries", () => {
+    expect(grouped({ version: "1.0.0", date: "", lede: "x", entries: [], released: true } as Release)).toEqual([]);
+  });
+});
+
+// The file is shipped in the bundle and parsed at runtime, so a malformed one is a
+// broken feature in a release nobody would notice until after it went out.
+describe("the real CHANGELOG.md", () => {
+  const log = parseChangelog(readFileSync(new URL("../CHANGELOG.md", import.meta.url), "utf8"));
+
+  it("parses, and starts with Unreleased", () => {
+    expect(log.length).toBeGreaterThan(5);
+    expect(log[0].version).toBe("Unreleased");
+  });
+  it("gives every released section a date and at least one entry", () => {
+    for (const r of log.filter((x) => x.released)) {
+      expect(r.date, `${r.version} has no date`).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(r.entries.length, `${r.version} has no entries`).toBeGreaterThan(0);
+    }
+  });
+  it("has an Unreleased section with something in it — the CI gate reads this", () => {
+    expect(log[0].entries.length).toBeGreaterThan(0);
+  });
+  it("lists versions newest-first, which is the order the rail renders", () => {
+    const rel = log.filter((r) => r.released).map((r) => r.date);
+    expect([...rel].sort().reverse()).toEqual(rel);
+  });
+});


### PR DESCRIPTION
**Design mock:** https://claude.ai/code/artifact/7c2b8554-01d2-49a5-9541-e1d1a277c0f7

Episko updates itself silently — you get a new build and no idea what changed. This adds **What's new**: it opens once after an update, the **✦** beside the version number in the footer reopens it, and the version rail is the whole history back to the rename.

## One file, three consumers

`CHANGELOG.md` is now the only place release notes are written, and the three readers cannot disagree:

| consumer | how |
| --- | --- |
| the app | `?raw` import → `changelog.ts` parses → `changelogui.ts` renders |
| `release.yml` | lifts the tag's section into the GitHub release body |
| `ci.yml` | refuses a `dev → main` PR whose `Unreleased` section is empty |

## Decisions worth reviewing

- **The app ships the file, it doesn't fetch it.** Works offline, and **a build can only ever describe itself** — the releases API would let a newer entry describe a version the user isn't running, which is worse than showing nothing.
- **The gate is on the PR, not the tag.** You said whichever was easier; the PR check is both. A tag that fails has already had the decision to ship behind it. `pnpm changelog draft` writes the section through Haiku and **stops** — never commits — and the gate checks only that the section is *non-empty*, never that a model wrote it. A gate demanding generated prose would make writing your own notes a CI failure.
- **`shouldAnnounce` is narrow on purpose.** A fresh install, a downgrade and a local dev build are all silent. A changelog over an app nobody has run yet is noise before it's information.
- **Three markers, not six headings** — `+` new, `~` changed, `!` fixed. Keep-a-Changelog's sections force a judgement call per line and leave headings with one bullet under them.

## One trap worth knowing

The release body is assembled in a **step**, not inlined in the YAML. A multi-line `${{ }}` inside a literal block indents only its first line and silently mangles the rest — so the install text moved to `.github/release-install.md` and is concatenated. I simulated the step locally: the heredoc delimiters balance and an unknown tag falls back to a note rather than failing the build.

## Populated

Every release back to **0.4.3**, including the six that shipped as **Muster**. Four tests assert the *real* `CHANGELOG.md` parses, that every released section has a date and entries, and that it's newest-first — so a malformed file fails CI rather than shipping as a broken screen.

**Confetti is parked.** It never felt right; it can arrive later without changing any of this.

## Verification

- **604 vitest** (+24) · **140 cargo** · clippy clean · `tsc` clean · build clean · no import cycles.
- Coverage 90.5% over loaded modules, 21.3% over all of `src/`.
- Version bumped to **0.13.0** in `package.json` + `tauri.conf.json`.
- **Not verified:** the screen has never been rendered, and neither workflow change has run on GitHub — the CI gate first executes on the `dev → main` PR, which is the next thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
