### PR TITLE
fix: the dashboard's entry point was never connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
+Two things 0.13.0 shipped that had never been clicked.
+
+! **Clicking a project opens its dashboard.** It did nothing at all in 0.13.0 — the
+  header carried the right attribute and the handler had the right branch, but the
+  attribute was missing from the delegated click selector, so the branch was
+  unreachable and the whole feature was dead on arrival.
+! **The sidebar shows a hairline filling under a project while it counts down** to
+  revealing that project's idle checkouts. Without it the panel appeared a second after
+  you stopped moving, which read as a glitch rather than as a deliberate pause.
+
 ## 0.13.0 — 2026-07-31
 
 A project is a place you arrive at now, not a session you fall into.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Mac has the same symlink — but it is one both legs will find at once.
 
 **Package manager: `pnpm`** for this repo (there's a `pnpm-lock.yaml`; both CI workflows use `pnpm install --frozen-lockfile`, and `packageManager` in `package.json` pins the version for corepack/CI). Use pnpm here, not npm. Windows code-signing / release-signing setup lives in `src-tauri/SIGNING.md`.
 
-Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **604 vitest + cargo (140 on macOS, 137 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
+Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **608 vitest + cargo (140 on macOS, 137 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
 
 **vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which nineteen those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
 
@@ -538,7 +538,7 @@ Four conventions hold across them:
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (~70 lines — it is the seam map, and belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, the window controls (see One title bar), and the seven `setInterval`s.
 
-**Tested logic modules** (nineteen — no DOM, no Tauri, no render imports; these are what the 604 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
+**Tested logic modules** (nineteen — no DOM, no Tauri, no render imports; these are what the 608 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
 
 | Module | What |
 | --- | --- |
@@ -623,6 +623,13 @@ And the things that hold however the files are arranged:
   off), so the browser path would raise a WebView2 permission prompt on Windows and
   WKWebView's paste-confirmation button on macOS. Pasting goes through `term.paste`
   rather than `write_pty` so bracketed-paste mode and `\r\n`→`\r` still apply.
+- **A `[data-*]` branch is only reachable if its attribute is ALSO in the dispatcher's
+  `closest()` selector.** One selector decides what `el` is; an unlisted attribute means
+  `el` is null and the handler returns before the branch written for it. `tsc` is happy
+  and every unit test passes — the feature is simply dead, and only clicking it finds
+  out. That is how the dashboard shipped in 0.13.0 with its entry point disconnected.
+  `test/dispatch.test.ts` now compares the two halves in both directions (an unlisted
+  branch is unreachable; a listed attribute with no branch silently swallows clicks).
 - **Event wiring**: `listen("pty-output" | "pty-exit" | "telemetry" | "permission" | "tray-select")` at the bottom of `main.ts`. Telemetry is routed by `data.session_id?.toLowerCase()` — session ids are matched case-insensitively, so keep them lowercase.
 - `applyHook` maps lifecycle events → a `Phase` state machine (idle/thinking/working/done/error/ended) and attention flags; `applyStatusline` fills model/context%/cost/duration. **Rate limits are account-wide**, held in a single `rl` object and shown identically on every session, not per-session.
 - **A turn that died is not a turn that finished, and only one hook knows which.** Claude Code fires `StopFailure` (not `Stop`) when the API kills a turn — a 529, a rate limit, a dead key — carrying an `error` enum (`overloaded`, `rate_limit`, `authentication_failed`, `max_output_tokens`, …) and the `error_details` text the pane shows. Everything *after* that point looks identical to a clean finish: the same 60-second idle `Notification` (`notification_type: "idle_prompt"`) arrives either way. Unguarded it relabelled the turn "your turn" and turned the red ✕ green a minute after the failure — which shipped, and is why `Sess.apiErr` exists. It is set by `StopFailure`, cleared only when the session genuinely starts another turn (`UserPromptSubmit` / `PreToolUse` / `SessionStart` / `SessionEnd`), and **`endTurn` is the single place that decides done vs. error** — both `Stop` and the idle nudge go through it, and the run-on-stop rule is skipped while it's set. Every surface that spells a state out reads `phaseText(s)`, not `PILL_TEXT[s.phase]`, so the reason travels with the glyph: "API overloaded" means wait, "auth failed" means go fix your credentials, and a bare ✕ means neither.

--- a/src/main.ts
+++ b/src/main.ts
@@ -501,7 +501,7 @@ document.addEventListener("click", (e) => {
   if (dot) { const owner = dot.closest<HTMLElement>("[data-key]"); if (owner?.dataset.key) { openColorPopover(owner.dataset.key, e.clientX, e.clientY + 6); return; } }
   // data-forget and data-resume sit INSIDE a data-past row, so they must be matched
   // (and dispatched) ahead of it or the row's own click would swallow them.
-  const el = t.closest<HTMLElement>("[data-perm],[data-driftfollow],[data-git],[data-diff],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-sel],[data-wtadd],[data-launch],[data-pal],[data-rail],[data-toast]");
+  const el = t.closest<HTMLElement>("[data-perm],[data-driftfollow],[data-git],[data-diff],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-sel],[data-wtadd],[data-launch],[data-dash],[data-pal],[data-rail],[data-toast]");
   if (!el) return;
   if (el.dataset.perm) resolvePermission(el.dataset.permid || "", el.dataset.perm);
   else if (el.dataset.driftfollow) void followSessionDrift(el.dataset.driftfollow);

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -88,10 +88,10 @@ export function renderSidebar() {
     const wtSuffix = p.wtBranch ? `<span class="pwt">· ${esc(p.wtBranch)}</span>` : "";
     let head: string;
     if (p.sessions.length) {
-      head = `<div class="phead" data-dash="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}${wtSuffix}</span>${dot}<span class="pcount">${total}</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}">＋</span></div>`;
+      head = `<div class="phead" data-dash="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}${wtSuffix}</span>${dot}<span class="pcount">${total}</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}">＋</span><span class="parm"></span></div>`;
     } else if (isFav) {
       const tail = p.externals.length ? `<span class="pcount ext">${p.externals.length} ext</span>` : `<span class="plaunch">open →</span>`;
-      head = `<div class="phead empty-p" data-dash="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="premove" data-remove="${esc(p.path)}" title="Remove project">✕</span></div>`;
+      head = `<div class="phead empty-p" data-dash="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="premove" data-remove="${esc(p.path)}" title="Remove project">✕</span><span class="parm"></span></div>`;
     } else {
       // discovered via an external session or a restorable one only — not a saved project
       const tail = p.externals.length
@@ -131,6 +131,18 @@ let peekHover: string | null = null;
 function applyPeek() {
   for (const el of $("projects").querySelectorAll<HTMLElement>(".pgroup")) {
     el.classList.toggle("peek", el.dataset.path === peek.open);
+    // The arming hairline. Without it the group expands out of nowhere a second after
+    // you stopped moving, which reads as a glitch rather than as a deliberate delay —
+    // you cannot tell the app is counting unless it shows you.
+    const arming = !!peek.arming && el.dataset.path === peek.arming.path;
+    if (arming) {
+      // Restart the fill from zero. The class alone won't re-run the animation on a
+      // group that was already armed, cancelled and re-entered.
+      el.classList.remove("arming");
+      void el.offsetWidth;
+      el.style.setProperty("--peek-open", `${peekPrefs.openMs}ms`);
+    }
+    el.classList.toggle("arming", arming);
   }
 }
 function peekSchedule() {
@@ -144,10 +156,15 @@ function peekSchedule() {
 }
 /// Commit a new state: repaint only when what's on screen actually changed, then
 /// re-arm the timer.
+///
+/// **Both fields are on screen**, which is easy to forget: `open` is the expansion and
+/// `arming` is the hairline counting down to it. Comparing only `open` meant entering a
+/// group changed `arming` alone, no repaint happened, and the bar never appeared — the
+/// panel then opened a second later out of nowhere.
 function peekAdvance(next: PeekState) {
-  const wasOpen = peek.open;
+  const before = peek.open + "|" + (peek.arming?.path ?? "");
   peek = next;
-  if (peek.open !== wasOpen) applyPeek();
+  if (peek.open + "|" + (peek.arming?.path ?? "") !== before) applyPeek();
   peekSchedule();
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -285,6 +285,18 @@ html.win .wctl { display: flex; }
 .wthead:hover .wtadd { opacity: 1; }
 .wtadd:hover { color: var(--text); background: var(--surface-2); }
 .wtsessions { padding-left: 8px; margin-left: 6px; border-left: 1px solid color-mix(in srgb, var(--wtc, var(--hair)) 45%, transparent); display: flex; flex-direction: column; gap: 1px; }
+/* The arming hairline: fills under the project name while the open timer runs, so a
+   panel that appears a second later reads as deliberate rather than as a glitch. The
+   duration is the real preference (--peek-open, set by applyPeek), not a constant —
+   a bar that finishes before or after the panel opens is worse than no bar. */
+.phead { position: relative; }
+.parm { position: absolute; left: 7px; right: 7px; bottom: 1px; height: 1.5px; border-radius: 2px;
+  background: var(--accent-line); transform: scaleX(0); transform-origin: left; opacity: 0; pointer-events: none; }
+.pgroup.arming .parm { opacity: 1; animation: peek-arm var(--peek-open, 1000ms) linear forwards; }
+@keyframes peek-arm { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+/* Reduced motion gets no sweep — the delay still applies, it just isn't animated. */
+@media (prefers-reduced-motion: reduce) { .pgroup.arming .parm { animation: none; opacity: 0; } }
+
 /* ---------- peek: the checkouts nothing is running in ----------------------------
    Collapsed until the pointer rests on the project group (./peek owns the timing,
    ./sidebar drives it, ./sidebarview renders the rows). Always in the DOM — hover

--- a/test/dispatch.test.ts
+++ b/test/dispatch.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+// The delegated click dispatcher's one failure mode, made impossible.
+//
+// main.ts routes every `[data-*]` click through ONE `closest()` call and then an
+// if-chain over `el.dataset.*`. The two halves have to agree: a branch whose attribute
+// is missing from the selector is **unreachable**, because `closest()` returns null and
+// the handler returns before reaching it.
+//
+// Nothing else catches this. `tsc` is happy — `el.dataset.dash` is a valid string
+// lookup. Every unit test is happy — the modules underneath work fine. The feature is
+// simply dead, silently, and only clicking it in the running app finds out.
+//
+// That is exactly how the project dashboard shipped in 0.13.0 with its entry point
+// disconnected: `data-dash` was on the sidebar header and in the if-chain, but not in
+// the selector. This test is the reason that cannot happen twice.
+
+const MAIN = readFileSync(new URL("../src/main.ts", import.meta.url), "utf8");
+
+/// `data-driftfollow` → `driftfollow`, matching how the DOM lowercases dataset keys.
+const attrToKey = (attr: string) => attr.replace(/^data-/, "").replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+
+/** The one big `closest()` in the click handler, as a list of attribute names. */
+function selectorAttrs(): string[] {
+  const m = /const el = t\.closest<HTMLElement>\("([^"]+)"\)/.exec(MAIN);
+  if (!m) throw new Error("could not find the click dispatcher's closest() call in main.ts");
+  return m[1].split(",").map((s) => s.trim().replace(/^\[|\]$/g, ""));
+}
+
+/**
+ * Every `el.dataset.X` the if-chain **branches on** — the condition position only.
+ *
+ * The distinction is the whole test. `el.dataset.permid`, `gitsid`, `difftitle`, `proj`,
+ * `root` and `branch` are *payload*, read off an element that has already matched on a
+ * different attribute; they must NOT be in the selector, and requiring them there would
+ * make every one of them a click target in its own right.
+ */
+function branchKeys(): string[] {
+  const start = MAIN.indexOf("const el = t.closest<HTMLElement>(");
+  const end = MAIN.indexOf("});", start);
+  const body = MAIN.slice(start, end);
+  const keys = new Set<string>();
+  for (const m of body.matchAll(/(?:^\s*|\belse\s+)if\s*\(\s*el\.dataset\.([A-Za-z0-9_]+)\s*\)/gm)) keys.add(m[1]);
+  return [...keys];
+}
+
+describe("the delegated click dispatcher", () => {
+  const attrs = selectorAttrs();
+  const selectorKeys = new Set(attrs.map(attrToKey));
+  const branches = branchKeys();
+
+  it("finds a selector and an if-chain to compare", () => {
+    expect(attrs.length).toBeGreaterThan(10);
+    expect(branches.length).toBeGreaterThan(10);
+  });
+
+  it("has NO unreachable branch — every dataset key it tests for is in the selector", () => {
+    // The failing case reads: `dash` is branched on but [data-dash] is not selected.
+    const unreachable = branches.filter((k) => !selectorKeys.has(k));
+    expect(unreachable, `unreachable branch(es): ${unreachable.map((k) => `el.dataset.${k} (add [data-${k}] to the selector)`).join(", ")}`).toEqual([]);
+  });
+
+  it("selects nothing it never dispatches — a dead entry swallows clicks", () => {
+    // The mirror image, and it is not harmless: an attribute in the selector with no
+    // branch makes `closest()` match that element and then fall through every branch,
+    // so the click is consumed and whatever it was nested inside never fires.
+    //
+    // `data-proj`, `data-root` and `data-branch` are deliberately absent from the
+    // selector for this reason — they are payload read off a matched element, never a
+    // target themselves.
+    const undispatched = [...selectorKeys].filter((k) => !branches.includes(k));
+    expect(undispatched, `selected but never dispatched: ${undispatched.join(", ")}`).toEqual([]);
+  });
+
+  it("routes the project header to the dashboard", () => {
+    // The specific regression: clicking a project must open its dashboard. Both the
+    // attribute the sidebar writes and the branch that acts on it have to exist.
+    const sidebar = readFileSync(new URL("../src/sidebar.ts", import.meta.url), "utf8");
+    expect(sidebar).toContain('data-dash=');
+    expect(selectorKeys.has("dash")).toBe(true);
+    expect(branches).toContain("dash");
+  });
+});


### PR DESCRIPTION
Two things 0.13.0 shipped that had never been clicked. You found both in about a minute of using it, which is the honest verdict on shipping unrendered UI.

## 1. Clicking a project did nothing

The sidebar header carried `data-dash`, and the click handler had an `else if (el.dataset.dash)` branch. But `[data-dash]` was missing from the **one `closest()` selector** that decides what `el` is — so `el` came back `null` and the handler returned before reaching the branch written for it.

`tsc` was happy (`el.dataset.dash` is a valid lookup). All 604 tests were happy (every module underneath works). The feature was simply dead.

**`test/dispatch.test.ts` makes that impossible now.** It parses the selector and the if-chain out of `main.ts` and asserts they agree **in both directions**:

- a branch whose attribute isn't selected is **unreachable**;
- an attribute that's selected but never dispatched **swallows clicks** for whatever it's nested inside.

It distinguishes branch conditions from payload reads (`el.dataset.permid` and friends must *not* be selectable). I verified it by reintroducing the exact bug and watching it fail, then restoring the fix.

## 2. The peek hairline was never implemented

`peek.ts` tracked `arming` from the start and it's unit-tested — but the driver only repainted when `open` changed. Entering a group changes `arming` alone, so no repaint happened and the bar never appeared. Both fields are on screen; both now trigger it. The fill duration is the real `--peek-open` preference, so a bar that finishes out of step with the panel isn't possible.

## Verified in a browser this time

Seeded a favourite against the vite dev server and clicked the header: `#dashPane` becomes visible with its header, pulse strip, aside cards and six inspector actions rendered. The `arming` class, `--peek-open: 1000ms`, the `peek-arm` keyframes and the animation binding are all applied on hover from rest, and clear correctly when the group opens.

**What I could not verify there:** the bar physically filling. The MCP-driven tab reports `visibilityState: "hidden"`, and Chrome suspends CSS animations in a hidden tab — the transform stays at `scaleX(0)` for that reason, not because the animation is broken. That's the one thing still worth your eye.

**608 vitest** (+4) · clippy clean · build clean. `CHANGELOG.md`'s `Unreleased` describes both fixes — the gate demanded it, which is the gate working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
