### PR TITLE
fix: What's new skipped the release that introduced it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Two things 0.13.0 shipped that had never been clicked.
 ! **The sidebar shows a hairline filling under a project while it counts down** to
   revealing that project's idle checkouts. Without it the panel appeared a second after
   you stopped moving, which read as a glitch rather than as a deliberate pause.
+! **What's new opens by itself after an update again.** It skipped 0.13.0 entirely: the
+  release that introduced the screen is the one where nobody has a record of having read
+  it, and that empty record was being read as "brand new install, stay quiet". It now
+  remembers every version it has shown you, so each one announces once and going back to
+  an older build stays silent.
+~ **The release-notes button is a document icon, and sits to the right of the version
+  number** it explains rather than the left. It was also sharing a CSS class with the
+  usage sparkline, which gave an 18px button a 24px-tall glyph.
 
 ## 0.13.0 — 2026-07-31
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,10 +267,22 @@ GitHub release body, and `ci.yml` refuses a `dev → main` pull request whose
   demanding generated prose would make writing your own notes a CI failure.
 - **Three markers, not six headings**: `+` new, `~` changed, `!` fixed. Keep-a-Changelog's
   sections force a judgement call per line and leave headings with one bullet under them.
-- **`shouldAnnounce` is deliberately narrow.** It opens only when the running version
-  differs from `cc-seen-version` *and* the file has a section for it — so a fresh install,
-  a downgrade and a local dev build are all silent. Opening a changelog over an app
-  somebody has never run is noise before it is information.
+- **`shouldAnnounce` opens once per released version, and the record is a set.**
+  `cc-seen-versions` lists every version *What's new* has been opened for here (0.13.0's
+  single-value `cc-seen-version` is still read once and folded in), so a version already
+  read stays shut even after running a newer one, and a build with no section — a local
+  dev build — is silent because the screen would open on nothing.
+- **It used to have a fresh-install guard, and that guard is why 0.13.0 shipped silent.**
+  It keyed on the seen-record being absent — but the release that *introduces* a
+  seen-record is precisely the one where every existing install has none, so the version
+  that shipped the feature was the version nobody was shown. Rescuing it means guessing
+  whether the rest of `localStorage` looks "used", and that guess was measured wrong
+  twice: `cc-icons`, `cc-icons-v` and `cc-restore` are all written during a first boot,
+  `cc-restore` before `changelogui` is even imported. It also cannot be unit-tested — it
+  depends on module import order across the whole app graph — so it would rot silently,
+  in the direction of hiding the feature. **Don't reintroduce it.** The cost of living
+  without it is that a first-time user sees the notes for the version they installed,
+  once, which reads as an introduction and is one Esc away.
 - **The release body is assembled in a step, not inlined in YAML.** A multi-line `${{ }}`
   inside a literal block indents only its first line and silently mangles the rest, which
   is why the install text lives in `.github/release-install.md` and is concatenated.
@@ -633,7 +645,7 @@ And the things that hold however the files are arranged:
 - **Event wiring**: `listen("pty-output" | "pty-exit" | "telemetry" | "permission" | "tray-select")` at the bottom of `main.ts`. Telemetry is routed by `data.session_id?.toLowerCase()` — session ids are matched case-insensitively, so keep them lowercase.
 - `applyHook` maps lifecycle events → a `Phase` state machine (idle/thinking/working/done/error/ended) and attention flags; `applyStatusline` fills model/context%/cost/duration. **Rate limits are account-wide**, held in a single `rl` object and shown identically on every session, not per-session.
 - **A turn that died is not a turn that finished, and only one hook knows which.** Claude Code fires `StopFailure` (not `Stop`) when the API kills a turn — a 529, a rate limit, a dead key — carrying an `error` enum (`overloaded`, `rate_limit`, `authentication_failed`, `max_output_tokens`, …) and the `error_details` text the pane shows. Everything *after* that point looks identical to a clean finish: the same 60-second idle `Notification` (`notification_type: "idle_prompt"`) arrives either way. Unguarded it relabelled the turn "your turn" and turned the red ✕ green a minute after the failure — which shipped, and is why `Sess.apiErr` exists. It is set by `StopFailure`, cleared only when the session genuinely starts another turn (`UserPromptSubmit` / `PreToolUse` / `SessionStart` / `SessionEnd`), and **`endTurn` is the single place that decides done vs. error** — both `Stop` and the idle nudge go through it, and the run-on-stop rule is skipped while it's set. Every surface that spells a state out reads `phaseText(s)`, not `PILL_TEXT[s.phase]`, so the reason travels with the glyph: "API overloaded" means wait, "auth failed" means go fix your credentials, and a bare ✕ means neither.
-- **Persistence is all `localStorage`**, ~20 keys prefixed `cc-` (favorites, drag order, colours, icons, engine, permission mode, font size, sort/grouping, frecency, caffeinate, the `cc-usage` daily cost rollup, the `cc-restore` roster, the sidebar's `cc-peek`, the dashboard's `cc-dash-*` and `cc-digest-ok`, and the task keys `cc-task-{prefs,pins,hidden,onstop,runner,inputs}` + `cc-trusted`). `grep '"cc-'` for the current set.
+- **Persistence is all `localStorage`**, ~20 keys prefixed `cc-` (favorites, drag order, colours, icons, engine, permission mode, font size, sort/grouping, frecency, caffeinate, the `cc-usage` daily cost rollup, the `cc-restore` roster, the sidebar's `cc-peek`, *What's new*'s `cc-seen-versions`, the dashboard's `cc-dash-*` and `cc-digest-ok`, and the task keys `cc-task-{prefs,pins,hidden,onstop,runner,inputs}` + `cc-trusted`). `grep '"cc-'` for the current set.
 - **Debug console** (🐞 button, bottom-right): an in-app event log + live state via `dlog()`/`dbgSnapshot()`. It flags **unrouted telemetry** (the routing-drift class of bug above) and JS errors, and mirrors a snapshot to `$TMPDIR/cc-launcher/episko-debug.json` (written by the `write_debug_file` command) so an external tool or an LLM agent can read live app state while it runs.
 - **Two-tier logging — live snapshot vs. durable timeline.** The `episko-debug.json` snapshot is a *state-of-now* blob that is overwritten each flush and does **not** survive a crash (the frontend never flushes if the process dies). The durable tier is the backend rolling `episko.log` (+ `panic.log`) in the OS app-log dir (macOS `~/Library/Logs/io.respeak.episko/`), via `tauri-plugin-log` and a panic hook — the only on-disk trace of a panic that unwinds cleanly out of `main` (no crash dump / WER otherwise). Every `dlog()` line tees into it through the `log_frontend` command (tagged `[ui]`), so the UI and backend event streams land in **one time-ordered file**. A `episko.log` that stops without an `exit · clean shutdown` line is itself evidence of an abnormal termination. Use the snapshot for "what is it doing *now*", the rolling log for "why did it *die*".
 

--- a/index.html
+++ b/index.html
@@ -129,8 +129,21 @@
 
       <footer class="foot">
         <a class="frepo" id="fRepo" href="https://github.com/respeak-io/episko" title="respeak-io/episko — open on GitHub">respeak-io/episko<span class="fcaret">↗</span></a>
-        <button class="clbtn" id="clBtn" title="What's new"><span class="spark">✦</span></button>
-        <span class="fver" id="fVer" title="Installed Episko version · click to check for updates"></span>
+        <!-- Release notes sit to the RIGHT of the version number and hug it: the glyph
+             explains that number, and at the footer's own 15px gap it would read as one
+             more independent segment. Inline SVG rather than a character — no document
+             glyph renders on both macOS and Windows, and ▤ already means "embedded
+             pane" everywhere else in the app. -->
+        <span class="fvern">
+          <span class="fver" id="fVer" title="Installed Episko version · click to check for updates"></span>
+          <button class="clbtn" id="clBtn" title="What's new">
+            <svg class="clico" viewBox="0 0 14 14" aria-hidden="true">
+              <path class="cl-pg" d="M3.6 1.6h4L10.4 4.4v8H3.6z"/>
+              <path class="cl-pg" d="M7.6 1.7V4.4h2.7"/>
+              <path class="cl-tx" d="M5.5 6.9h3.3M5.5 8.9h3.3M5.5 10.9h2"/>
+            </svg>
+          </button>
+        </span>
         <button class="fupdate" id="fUpdate" title="Download the new version and restart Episko" hidden></button>
         <span class="fseg"><span id="fSessions">0</span> sessions</span>
         <span class="fdiv"></span>

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -89,19 +89,67 @@ function splitHeading(h: string): [string, string] {
 /**
  * Should *What's new* open by itself?
  *
- * Only when the running version differs from the last one this machine acknowledged —
- * i.e. you just updated. Three cases are deliberately silent:
+ * Once per released version, on the machine that runs it. Three cases are silent:
  *
- * - **A fresh install** (`seen` is null). There is nothing new to someone who has never
- *   run it; opening a changelog over an empty app is noise before it is information.
- * - **A version with no section.** The screen would open on nothing.
- * - **A downgrade or a dev build.** Only a version we can find in the file counts, so
- *   running a local build with an unpublished version stays quiet.
+ * - **A version already read.** Including one read and then returned to — going back to
+ *   0.13.1 after trying 0.14.0 must not re-announce it. That is why `seen` is a set and
+ *   not a last-seen string.
+ * - **A version with no section.** A local dev build; the screen would open on nothing.
+ * - **`Unreleased`**, which describes something nobody is running.
+ *
+ * **There is deliberately no fresh-install exception, and that is a reversal.** 0.13.0
+ * had one, keyed on the seen-record being absent — but the release that *introduces* a
+ * seen-record is exactly the release where every existing install has none, so the one
+ * version the guard silenced was the one that shipped the feature. Rescuing it needs a
+ * guess at whether the rest of `localStorage` looks "used", and that guess was measured
+ * wrong twice: `cc-icons`, `cc-icons-v` and `cc-restore` are all written during a first
+ * boot, some of them before this module is even imported. It cannot be unit-tested
+ * either — it depends on import order across the whole app graph — so it would rot
+ * silently, in the direction of hiding the feature.
+ *
+ * The cost of dropping it is that a first-time user is shown the notes for the version
+ * they just installed, once. For someone who has never seen the app that reads as an
+ * introduction, and it is one Esc away.
  */
-export function shouldAnnounce(current: string, seen: string | null, log: Release[]): boolean {
-  if (!current || !seen || seen === current) return false;
+export function shouldAnnounce(current: string, seen: readonly string[], log: Release[]): boolean {
+  if (!current || seen.includes(current)) return false;
   return log.some((r) => r.released && r.version === current);
 }
+
+// ---------- the seen record ----------
+// Where it is *stored* is ./changelogui's business; what it MEANS is here, so the
+// migration path is covered by a test rather than by opening the app on a machine that
+// happens to hold the old key.
+
+/**
+ * Read the record, folding in 0.13.0's single-value key when the list is absent.
+ *
+ * The legacy fallback runs on the *value*, not on a version check — a machine that
+ * skipped a release still has the old key and nothing else, and there is no other
+ * evidence of what it has read.
+ */
+export function parseSeen(list: string | null, legacy: string | null): string[] {
+  if (list) {
+    try {
+      const a: unknown = JSON.parse(list);
+      // Anything hand-edited into the key is ignored rather than trusted: the cost of a
+      // bad entry is a missed announcement, which is silent.
+      if (Array.isArray(a)) return a.filter((x): x is string => typeof x === "string");
+    } catch { /* truncated or hand-mangled — fall through to the legacy key */ }
+  }
+  return legacy ? [legacy] : [];
+}
+
+/// Add a version, newest last, deduped and bounded. Re-adding one already present moves
+/// it to the end rather than duplicating it, so the cap can never evict a live version.
+export function recordSeen(seen: readonly string[], version: string, cap = SEEN_CAP): string[] {
+  if (!version) return [...seen];
+  return [...seen.filter((v) => v !== version), version].slice(-cap);
+}
+
+/// Bounded so the key can't grow forever — one entry per release actually run here, so
+/// the cap is decades away, and what falls off the front is versions nobody can reach.
+const SEEN_CAP = 50;
 
 /// The release to open on: the running version if the file knows it, else the newest
 /// released one, else whatever is first (an Unreleased-only file on a dev build).

--- a/src/changelogui.ts
+++ b/src/changelogui.ts
@@ -14,25 +14,32 @@ import { $, dropScrim } from "./dom";
 import { dlog } from "./debug";
 import { esc } from "./format";
 import {
-  grouped, MARK_GLYPH, MARK_LABEL, parseChangelog, releaseFor, shouldAnnounce,
-  type Release,
+  grouped, MARK_GLYPH, MARK_LABEL, parseChangelog, parseSeen, recordSeen, releaseFor,
+  shouldAnnounce, type Release,
 } from "./changelog";
 
 const LOG: Release[] = parseChangelog(raw);
-/// The last version this machine acknowledged. Absent on a fresh install, which is
-/// what keeps the screen shut for someone who has never run Episko.
-const SEEN = "cc-seen-version";
+/// Every version this machine has had *What's new* opened for, newest last. A list
+/// rather than a single last-seen string so that returning to a version already read
+/// stays quiet — see `SeenState`.
+const SEEN = "cc-seen-versions";
+/// 0.13.0's single-value key, folded into the list above by `parseSeen`.
+const SEEN_LEGACY = "cc-seen-version";
 
 let version = "";
 let sel = 0;
 
 export const changelogOpen = () => $("clDlg").classList.contains("show");
 
+/// Read fresh each time rather than cached: it is a handful of calls a session, and a
+/// stale copy would leave the footer handle lit after the screen had been opened.
+const seenVersions = () => parseSeen(localStorage.getItem(SEEN), localStorage.getItem(SEEN_LEGACY));
+
 /// The footer handle stays lit until the running version has been read once. It is the
-/// only signal that there is something new — which is why it sits ON the version
+/// only signal that there is something new — which is why it sits beside the version
 /// number rather than in the top bar: that number is the thing it explains.
 function syncHandle() {
-  const unread = !!version && localStorage.getItem(SEEN) !== version;
+  const unread = !!version && !seenVersions().includes(version);
   $("clBtn").classList.toggle("fresh", unread);
   $("clBtn").title = unread ? `What's new in ${version}` : "What's new";
 }
@@ -40,7 +47,8 @@ function syncHandle() {
 /// Mark the running version read. Called on open, not on close: opening it *is* the
 /// reading, and a user who closes with Esc has still seen it.
 function markSeen() {
-  if (version) localStorage.setItem(SEEN, version);
+  if (!version) return;
+  localStorage.setItem(SEEN, JSON.stringify(recordSeen(seenVersions(), version)));
   syncHandle();
 }
 
@@ -109,7 +117,7 @@ export function initChangelog() {
     syncHandle();
     // The one moment it opens by itself. Deliberately after the version resolves
     // rather than on a timer: opening over a half-painted app reads as a glitch.
-    if (shouldAnnounce(v, localStorage.getItem(SEEN), LOG)) {
+    if (shouldAnnounce(v, seenVersions(), LOG)) {
       dlog("info", `changelog: first run of v${v}`);
       openChangelog(v);
     }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1865,17 +1865,26 @@ select.in-ctl { cursor: pointer; }
 @media (prefers-reduced-motion: reduce) { .dsh, .dsh-scrim, .sw i, .sw i::after { transition: none; } }
 
 /* ═══ What's new — the changelog screen ════════════════════════════════════════
-   Opened once after an update, and by the ✦ beside the version number. Content is
-   CHANGELOG.md, bundled at build time; ./changelog parses it, ./changelogui owns
+   Opened once after an update, and by the notes icon beside the version number. Content
+   is CHANGELOG.md, bundled at build time; ./changelog parses it, ./changelogui owns
    this markup. Shares #scrim with #wtDlg / #setDlg / #palette. */
+/* Version + notes icon as one unit, so the footer's 15px gap falls either side of the
+   pair rather than between them — the icon explains that number. */
+.foot .fvern { display: flex; align-items: center; gap: 4px; }
 .clbtn { display:inline-flex; align-items:center; justify-content:center; width:18px; height:16px; padding:0; border-radius:5px; cursor:pointer; border:1px solid transparent; background:none; color: var(--muted-2); }
 .clbtn:hover { color: var(--accent-ink); border-color: var(--accent-line); background: var(--accent-wash); }
-.clbtn .spark { font-size:10px; line-height:1; }
+/* NOT `.spark` — that class is format.ts's sparkline SVG (108×24, display:block), and
+   sharing it gave this 18×16 button a 24px-tall child. Its own name, its own box. */
+.clico { display: block; width: 11px; height: 11px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; }
+.clico .cl-pg { stroke-width: 1.1; }
+/* The text lines carry the "notes" reading but must not muddy into a block at 11px, so
+   they are thinner and dimmer than the page outline. */
+.clico .cl-tx { stroke-width: .9; opacity: .62; }
 /* Lit until the running version has been read once — the only signal that there is
-   something new, which is why it sits ON the version number rather than in the top bar. */
+   something new, which is why it sits beside the version number rather than in the top bar. */
 .clbtn.fresh { color: var(--accent-ink); border-color: var(--accent-line); background: var(--accent-wash); }
-@media (prefers-reduced-motion: no-preference) { .clbtn.fresh .spark { animation: cl-sp 2.4s ease-in-out infinite; } }
-@keyframes cl-sp { 0%,100%{opacity:1;} 50%{opacity:.35;} }
+@media (prefers-reduced-motion: no-preference) { .clbtn.fresh .clico { animation: cl-sp 2.4s ease-in-out infinite; } }
+@keyframes cl-sp { 0%,100%{opacity:1;} 50%{opacity:.45;} }
 
 .cl-dlg { position: fixed; z-index: 61; top: 7%; left: 50%; transform: translateX(-50%) translateY(-8px) scale(.985);
   width: min(760px, 92vw); height: min(560px, 82vh); display: flex; flex-direction: column; overflow: hidden;

--- a/test/changelog.test.ts
+++ b/test/changelog.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import {
-  grouped, parseChangelog, releaseFor, shouldAnnounce, type Release,
+  grouped, parseChangelog, parseSeen, recordSeen, releaseFor, shouldAnnounce, type Release,
 } from "../src/changelog";
 
 const SAMPLE = `# Changelog
@@ -80,21 +80,80 @@ describe("parseChangelog", () => {
 
 describe("shouldAnnounce — when What's new opens by itself", () => {
   const log = parseChangelog(SAMPLE);
-  it("opens when the running version differs from the last one acknowledged", () => {
-    expect(shouldAnnounce("0.12.0", "0.11.1", log)).toBe(true);
+
+  it("opens for a version this machine has never had it opened for", () => {
+    expect(shouldAnnounce("0.12.0", ["0.11.1"], log)).toBe(true);
   });
-  it("stays shut on a fresh install — nothing is new to someone who never ran it", () => {
-    expect(shouldAnnounce("0.12.0", null, log)).toBe(false);
-  });
-  it("stays shut when it has already been seen", () => {
-    expect(shouldAnnounce("0.12.0", "0.12.0", log)).toBe(false);
+  it("stays shut when that version has already been read", () => {
+    expect(shouldAnnounce("0.12.0", ["0.12.0"], log)).toBe(false);
   });
   it("stays shut for a version the file has no section for", () => {
-    // A local dev build, or a downgrade: the screen would open on nothing.
-    expect(shouldAnnounce("9.9.9", "0.12.0", log)).toBe(false);
+    // A local dev build: the screen would open on nothing.
+    expect(shouldAnnounce("9.9.9", ["0.12.0"], log)).toBe(false);
   });
   it("never announces Unreleased, which is not a version anyone runs", () => {
-    expect(shouldAnnounce("Unreleased", "0.12.0", log)).toBe(false);
+    expect(shouldAnnounce("Unreleased", ["0.12.0"], log)).toBe(false);
+  });
+
+  // THE REGRESSION. 0.13.0 introduced this screen, so on every existing install the
+  // seen-record was absent — the same state a fresh install is in. The old rule read an
+  // absent record as "never been here" and stayed shut, so the release that shipped the
+  // feature was the one release nobody was shown it for.
+  it("opens on an empty record — an absent record is not evidence of anything", () => {
+    expect(shouldAnnounce("0.12.0", [], log)).toBe(true);
+  });
+
+  // Why a set and not a last-seen string: with one value, going back to a version
+  // already read differs from it and would announce a second time.
+  it("stays shut on a version read before, even after running a newer one", () => {
+    expect(shouldAnnounce("0.11.1", ["0.11.1", "0.12.0"], log)).toBe(false);
+  });
+  it("still opens for a skipped version reached later", () => {
+    expect(shouldAnnounce("0.11.1", ["0.12.0"], log)).toBe(true);
+  });
+});
+
+describe("the seen record", () => {
+  it("reads the list", () => {
+    expect(parseSeen('["0.12.0","0.13.0"]', null)).toEqual(["0.12.0", "0.13.0"]);
+  });
+  it("migrates 0.13.0's single-value key when the list is absent", () => {
+    // The whole reason the legacy key is still read: a machine that has opened the
+    // screen once must not be told about that version a second time.
+    expect(parseSeen(null, "0.13.0")).toEqual(["0.13.0"]);
+  });
+  it("prefers the list once it exists, and ignores the stale legacy key", () => {
+    expect(parseSeen('["0.13.1"]', "0.13.0")).toEqual(["0.13.1"]);
+  });
+  it("is empty when neither key is set — a genuinely unrecorded machine", () => {
+    expect(parseSeen(null, null)).toEqual([]);
+  });
+  it("falls back rather than throwing on a mangled list", () => {
+    expect(parseSeen("{not json", "0.13.0")).toEqual(["0.13.0"]);
+    expect(parseSeen('"a string"', null)).toEqual([]);
+    expect(parseSeen('["ok", 7, null]', null)).toEqual(["ok"]);
+  });
+
+  it("appends, newest last", () => {
+    expect(recordSeen(["0.12.0"], "0.13.0")).toEqual(["0.12.0", "0.13.0"]);
+  });
+  it("never duplicates, and re-reading moves it to the end", () => {
+    expect(recordSeen(["0.12.0", "0.13.0"], "0.12.0")).toEqual(["0.13.0", "0.12.0"]);
+  });
+  it("is bounded, dropping the oldest", () => {
+    expect(recordSeen(["a", "b", "c"], "d", 3)).toEqual(["b", "c", "d"]);
+  });
+  it("records nothing for an empty version", () => {
+    expect(recordSeen(["0.12.0"], "")).toEqual(["0.12.0"]);
+  });
+
+  it("survives a round trip, which is what the footer handle depends on", () => {
+    // Read 0.13.0 under the old key, then read 0.13.1: neither may announce again.
+    const after = recordSeen(parseSeen(null, "0.13.0"), "0.13.1");
+    const log = parseChangelog(SAMPLE);
+    expect(after).toEqual(["0.13.0", "0.13.1"]);
+    expect(shouldAnnounce("0.13.1", after, log)).toBe(false);
+    expect(shouldAnnounce("0.13.0", after, log)).toBe(false);
   });
 });
 


### PR DESCRIPTION
Reported after installing 0.13.0: the changelog never opened by itself, and had to be found via the footer icon.

## It wasn't intended, and the cause is a guard eating its own release

`shouldAnnounce` read an absent `cc-seen-version` as *"fresh install — nothing here is new to you"*. That is sound in general. But the release that **introduces** a seen-record is exactly the release where every existing install has none, so the guard silenced the one version that shipped the feature. Anyone still on ≤0.12.0 would have hit it again on the next update, so this was not only retrospective.

**The guard is removed rather than repaired.** Keeping it means guessing whether the rest of `localStorage` looks "used", and that guess was measured wrong twice while writing this — a boot with a cleared store already holds `cc-icons`, `cc-icons-v` and `cc-restore`, and `cc-restore` lands *before* `changelogui` is imported, so even a module-load snapshot computed `used: true` on an empty store. It also cannot be unit-tested: it depends on module import order across all 49 frontend modules. A rule that can't be tested and fails toward *hiding the feature* is not worth the noise it prevents.

What's lost: a first-time user is shown the notes for the version they installed, once. For someone who has never seen the app that reads as an introduction, and it is one Esc away.

## The record is a set

`cc-seen-versions` lists every version the screen has been opened for (0.13.0's single-value `cc-seen-version` is read once and folded in, so nobody is told twice). "Has this version been read" is the question asked, and it is the only form that stays correct when you go back to an older build — with one value, returning to 0.13.1 after trying 0.14.0 differs from the stored value and would announce a second time.

## The footer button

- A **document icon**, inline SVG rather than a glyph: no document character renders on both macOS and Windows, and `▤` already means *embedded pane* everywhere else in the app.
- **To the right of the version number**, wrapped with it so the footer's 15px gap falls either side of the pair rather than between them — the icon explains that number.
- It was `class="spark"` — the same class `format.ts`'s sparkline SVG uses (`108×24`, `display:block`) — so an 18×16 button was holding a 24px-tall child. Its own class now.

## Verified

- **620 vitest** (+12), `tsc` clean, `pnpm build` clean, changelog gate passes.
- The regression test was run against the old rule and **fails** on it — it isn't passing vacuously.
- `parseSeen` / `recordSeen` moved into the tested module, so the legacy-key migration is covered by a test rather than by finding a machine that holds the old key.
- Rendered in a real browser: icon position, size, both themes, and the dialog opening from the new button.

## Not covered

The auto-open path itself can only fire in the packaged app, after a real version change — `getVersion()` rejects outside Tauri. That is a `RELEASE.md` click-through, and **0.13.1 is the first build that can actually demonstrate it**.