### PR TITLE
0.13.6 — the surfaces 0.13 added, tidied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,35 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
+Housekeeping on the surfaces 0.13 added, plus two in History.
+
+! **The project dashboard's top strip reads as five figures again.** It was printing
+  the raw markup of its own commit sparkline as text, and stacking the five tiles into
+  a column one per row instead of laying them across. Two separate faults that arrived
+  looking like one.
+! **⌘K's project swatches lost the grey dot beside them.** Every coloured square in the
+  list had a second, larger circle spilling out of its corner — a switch knob it had
+  inherited from an unrelated control that happened to share its name.
+! **The stage header runs the full width of the window.** The title, ◷ History,
+  ❯ Terminal, ▶ Run and ＋ Session had to share the space left over beside the
+  inspector; the inspector now starts below the header instead of beside it, which is
+  where it was always acting from anyway.
+! **The *Reveal idle checkouts on hover* switch sits beside its label**, not on its own
+  line underneath it, matching every other switch in Settings.
+! **⌘I on a project dashboard collapses the inspector to its 44px rail.** It was
+  documented and drawn that way but the panel never actually narrowed, so the rail was
+  a row of glyphs adrift in a full-width empty panel.
+! **The macOS traffic lights have room to breathe.** The Episko logo sat close enough to
+  them to read as a fourth button in the row.
+! **History no longer lists Episko's own summariser.** The one-line summary the Trail
+  writes for each day is a real Claude session, so it left a transcript behind — and
+  History, which reads every transcript on the machine, listed all of them. Dozens of
+  identical rows reading "Below is a factual record of one day of…", crowding out the
+  conversations you were looking for.
+! **A transcript with nothing to preview says so in a box, not over the whole dialog.**
+  Picking a session that turned out to be tool calls only replaced the entire list with
+  one centred sentence, which read as the dialog breaking rather than as an answer.
+
 ## 0.13.5 — 2026-08-01
 
 Two things 0.13.0 shipped that had never been clicked.

--- a/index.html
+++ b/index.html
@@ -70,22 +70,29 @@
         <div class="railmini" id="railmini"></div>
       </aside>
 
-      <main class="stage">
-        <div class="stage-head">
-          <div class="st-title">
-            <span class="proj" id="hProj">no session</span><span class="chip" id="hBranch" hidden></span>
-            <span class="stitle" id="hTitle"></span>
-            <span class="path" id="hPath"></span>
-          </div>
-          <div class="st-actions">
-            <button class="act" id="btnHist" title="Reopen a past session in this project — including ones you closed (⌘⇧H)">◷ History</button>
-            <button class="act" id="btnTerm" title="Open a plain (non-Claude) terminal at the project root">❯ Terminal</button>
-            <button class="act" id="btnRun" title="Run a task or script from this project">▶ Run</button>
-            <button class="act primary" id="btnNew" title="Start a session — pick the repo, a worktree, or a branch">＋ Session</button>
-            <button class="act icon" id="btnClose" title="Close session" hidden>✕</button>
-            <button class="act icon" id="inspBtn" title="Toggle inspector (⌘I)">◨</button>
-          </div>
+      <!--
+        A sibling of .stage rather than a child of it, so it can own a grid row of its
+        own that spans the stage AND the inspector (see the `head` area in styles.css).
+        The title and the six verbs all act on what is on the stage, so the panel beside
+        it starts underneath — and the row gets the whole width to lay them out in.
+      -->
+      <div class="stage-head">
+        <div class="st-title">
+          <span class="proj" id="hProj">no session</span><span class="chip" id="hBranch" hidden></span>
+          <span class="stitle" id="hTitle"></span>
+          <span class="path" id="hPath"></span>
         </div>
+        <div class="st-actions">
+          <button class="act" id="btnHist" title="Reopen a past session in this project — including ones you closed (⌘⇧H)">◷ History</button>
+          <button class="act" id="btnTerm" title="Open a plain (non-Claude) terminal at the project root">❯ Terminal</button>
+          <button class="act" id="btnRun" title="Run a task or script from this project">▶ Run</button>
+          <button class="act primary" id="btnNew" title="Start a session — pick the repo, a worktree, or a branch">＋ Session</button>
+          <button class="act icon" id="btnClose" title="Close session" hidden>✕</button>
+          <button class="act icon" id="inspBtn" title="Toggle inspector (⌘I)">◨</button>
+        </div>
+      </div>
+
+      <main class="stage">
         <div id="terminals">
           <div class="empty" id="empty">
             <div class="empty-card">

--- a/src-tauri/src/summarize.rs
+++ b/src-tauri/src/summarize.rs
@@ -29,7 +29,7 @@ use std::time::{Duration, Instant};
 
 use tauri::{AppHandle, Manager};
 
-use crate::platform::{augmented_path, resolve_claude, sys_command};
+use crate::platform::{augmented_path, physical_cwd, resolve_claude, sys_command};
 
 /// Long enough for a small prompt on a slow link, short enough that a wedged CLI is
 /// noticed rather than leaking a blocked thread for the life of the app.
@@ -67,11 +67,26 @@ fn write_cache(app: &AppHandle, map: &serde_json::Map<String, serde_json::Value>
 }
 
 /// A scratch cwd for the summariser's own transcripts, kept out of every real project.
-fn scratch_cwd() -> PathBuf {
-    let mut d = std::env::temp_dir();
+///
+/// Keeping them out of a project folder is only half the job: they are still real
+/// transcripts under `~/.claude/projects/<enc(this)>`, so History's whole-machine scan
+/// finds them and lists one "Below is a factual record of one day of …" row per day
+/// summarised. `scan_history_in` skips this directory by name, which is why this is
+/// `pub(crate)` and why it must NOT create anything — the scan calls it too, and a
+/// read-only listing has no business making directories. `run_claude` creates it.
+///
+/// It resolves through `physical_cwd` at the **temp dir**, not at the leaf, and that is
+/// what makes the skip hold. Claude writes the transcript under an encoding of the
+/// child's `getcwd()`, which is always the resolved spelling (macOS `$TMPDIR` is
+/// `/var/folders/…`, a symlink to `/private/var/folders/…`) — so an unresolved path
+/// here encodes to a different folder than the one the transcripts are in. The leaf
+/// cannot do the resolving: `physical_cwd` passes a path that does not exist straight
+/// through, and the OS purges `/var/folders` while `~/.claude` keeps the transcripts,
+/// which is exactly the state where the rows would come back.
+pub(crate) fn scratch_cwd() -> PathBuf {
+    let mut d = PathBuf::from(physical_cwd(&std::env::temp_dir().to_string_lossy()));
     d.push("cc-launcher");
     d.push("trail-summary");
-    let _ = std::fs::create_dir_all(&d);
     d
 }
 
@@ -96,9 +111,11 @@ FACTS\n{facts}"
 /// more than one pipe buffer, and "the summariser hung the app" is a far worse failure
 /// than "there is no summary today".
 fn run_claude(model: &str, prompt: &str) -> Result<String, String> {
+    let cwd = scratch_cwd();
+    let _ = std::fs::create_dir_all(&cwd); // `scratch_cwd` only names it — see above
     let mut child = sys_command(resolve_claude())
         .env("PATH", augmented_path())
-        .current_dir(scratch_cwd())
+        .current_dir(cwd)
         .args(["-p", prompt, "--model", model])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/src-tauri/src/usage.rs
+++ b/src-tauri/src/usage.rs
@@ -324,12 +324,21 @@ fn scan_history_in(base: &Path, limit: usize) -> Vec<HistorySession> {
         Err(_) => return vec![], // no transcripts yet — not an error
     };
 
+    // The Trail summariser is a `claude -p` like any other, so it leaves a transcript
+    // per day summarised. Those are Episko talking to itself — not a conversation the
+    // user had — and they are skipped by DIRECTORY, here in pass 1, rather than
+    // filtered out of the results: they are the newest thing on disk after any Trail
+    // view, so filtering later would let them take the top `limit` slots and push real
+    // sessions off the end of a list they never appear in.
+    let summariser = crate::summarize::scratch_cwd();
+    let summariser_dir = project_transcript_dir(base, &summariser.to_string_lossy());
+
     // Pass 1 — metadata only, no file contents. This is what keeps the scan bounded:
     // ranking by mtime here means the expensive pass never sees the old 95%.
     let mut files: Vec<(u64, u64, PathBuf)> = Vec::new();
     for proj in projects.flatten() {
         let pdir = proj.path();
-        if !pdir.is_dir() {
+        if !pdir.is_dir() || pdir == summariser_dir {
             continue;
         }
         let Ok(entries) = std::fs::read_dir(&pdir) else {
@@ -1122,6 +1131,69 @@ mod tests {
         assert_eq!(capped.len(), 1);
         assert_eq!(capped[0].session_id, "newest");
         assert!(scan_history_in(&dir.join("nope"), 0).is_empty(), "a missing base is empty, not an error");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The Trail summariser is a `claude -p`, so it leaves a transcript per day it
+    /// summarises — 27 of them on the machine this was found on, all reading "Below is
+    /// a factual record of one day of …". They are Episko talking to itself and must
+    /// not appear in History.
+    ///
+    /// The assertion that matters is the second one: the skip is computed from
+    /// `summarize::scratch_cwd()`, and it only lines up with what is on disk because
+    /// that function resolves `$TMPDIR` before appending. Encode the unresolved
+    /// spelling and this test still passes its first assertion on Linux while silently
+    /// missing every real transcript on a Mac, where `/var/folders` is a symlink.
+    #[test]
+    fn scan_history_hides_the_trail_summarisers_own_transcripts() {
+        let dir = scratch_dir();
+        let base = dir.join("claude");
+        let root = base.join("projects");
+
+        let scratch = crate::summarize::scratch_cwd();
+        let scratch_s = scratch.to_string_lossy().replace('\\', "\\\\");
+        let enc: String = scratch
+            .to_string_lossy()
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+            .collect();
+        std::fs::create_dir_all(root.join(&enc)).unwrap();
+        std::fs::create_dir_all(root.join("real")).unwrap();
+
+        let live = dir.join("live-project");
+        std::fs::create_dir_all(&live).unwrap();
+        let live_s = live.to_string_lossy().replace('\\', "\\\\");
+
+        // The summariser's row is the NEWER of the two, which is the case that matters:
+        // it is skipped in pass 1, so it must not consume the single `limit` slot below
+        // and push the real session off a list it never appears in.
+        std::fs::write(
+            root.join(&enc).join("summary.jsonl"),
+            format!(r#"{{"type":"user","cwd":"{scratch_s}","message":{{"content":"Below is a factual record of one day of a developer's work"}}}}"#) + "\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("real").join("mine.jsonl"),
+            format!(r#"{{"type":"user","cwd":"{live_s}","message":{{"content":"a real conversation"}}}}"#) + "\n",
+        )
+        .unwrap();
+
+        let out = scan_history_in(&base, 0);
+        let ids: Vec<&str> = out.iter().map(|h| h.session_id.as_str()).collect();
+        assert_eq!(ids, vec!["mine"], "the summariser's transcripts are not sessions the user had");
+
+        // The directory really was the one on disk — otherwise the line above passes
+        // for the wrong reason (nothing matched, nothing was skipped).
+        assert_eq!(
+            project_transcript_dir(&base, &scratch.to_string_lossy()),
+            root.join(&enc),
+            "the skip must name the folder Claude actually writes into",
+        );
+
+        let capped = scan_history_in(&base, 1);
+        assert_eq!(capped.len(), 1, "the skipped rows never took the limit slot");
+        assert_eq!(capped[0].session_id, "mine");
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/dashview.ts
+++ b/src/dashview.ts
@@ -28,8 +28,9 @@ function tile(k: string, v: string, d = ""): string {
 export function pulseHtml(p: Pulse, tier: ProjectTier, range: number, dense: number[]): string {
   const tiles: string[] = [];
   if (tier !== "none") {
+    // `sparkline` returns an inline SVG, not text — escaping it printed the markup.
     tiles.push(`<div class="db-tile"><span class="k">Commits</span><span class="v">${p.commits}</span>`
-      + `<span class="db-spark mono" aria-hidden="true">${esc(sparkline(dense))}</span></div>`);
+      + `<span class="db-spark" aria-hidden="true">${sparkline(dense)}</span></div>`);
   }
   tiles.push(tile("Sessions", String(p.sessions), `${range} days`));
   // Spend is per-project and only exists from the day the detail rollup started. A
@@ -42,7 +43,7 @@ export function pulseHtml(p: Pulse, tier: ProjectTier, range: number, dense: num
       : `<span class="dim">—</span>`;
     tiles.push(tile("Contributors", String(p.authors.length), who));
   }
-  return `<div class="db-pulse" data-tiles="${tiles.length + 1}">${tiles.join("")}
+  return `<div class="db-pulse">${tiles.join("")}
     <div class="db-tile win"><span class="db-seg">
       ${[7, 14, 30].map((r) => `<button${r === range ? ` class="on"` : ""} data-dashrange="${r}">${r}d</button>`).join("")}
     </span></div></div>`;
@@ -288,7 +289,7 @@ export function notesOverlay(
         <span class="mt"><span>${esc(relTime(n.created))}</span></span>
         <span class="bar"><button class="act" data-dashdispatch="${esc(n.id)}">▶ Start an agent</button>
           <button class="act" data-dashdrop="${esc(n.id)}">✕</button>
-          ${canShare ? `<span class="sw${sharedIds.has(n.id) ? " on" : ""}" data-dashshare="${esc(n.id)}"
+          ${canShare ? `<span class="dsw${sharedIds.has(n.id) ? " on" : ""}" data-dashshare="${esc(n.id)}"
             title="Write this into .episko/notes.toml so the team can read it"><i></i>shared</span>` : ""}
         </span></div>`).join("")}</div>`
     : `<div class="ac-empty">Nothing queued yet.</div>`;
@@ -460,7 +461,7 @@ export function closeSheet(t: GhThread, comment: string, slug: string): string {
 
 export function dispatchSheet(t: GhThread, p: ClaimPolicy, allow: ClaimAllow, mode: string, holder: Holder | null): string {
   const sw = (k: string, on: boolean, permitted: boolean, label: string) =>
-    `<span class="sw${on && permitted ? " on" : ""}${permitted ? "" : " off"}" data-dashclaim="${k}"
+    `<span class="dsw${on && permitted ? " on" : ""}${permitted ? "" : " off"}" data-dashclaim="${k}"
       ${permitted ? "" : `title="This project's .episko/episko.toml switches it off for everyone"`}><i></i>${label}</span>`;
   return `<h4>Start an agent on #${t.number}</h4>
     <div class="body">

--- a/src/historyui.ts
+++ b/src/historyui.ts
@@ -173,8 +173,8 @@ function histDetailHtml(h: HistEntry | undefined): string {
             const user = m.role === "user";
             return `<div class="tvmsg ${esc(m.role)}"><span class="tvgutter">${user ? "❯" : "⏺"}</span><div class="tvtext">${esc(abbr(m.text, 420))}</div></div>`;
           }).join("")}</div>`
-        : `<div class="hist-tv empty">No prose in this transcript — it's tool traffic only.</div>`)
-    : `<div class="hist-tv empty">Reading the transcript…</div>`;
+        : `<div class="hist-tv tv-empty">No prose in this transcript — it's tool traffic only.</div>`)
+    : `<div class="hist-tv tv-empty">Reading the transcript…</div>`;
   return `
     <div class="wt-dhead">
       <div class="wt-dkind">past session</div>

--- a/src/palui.ts
+++ b/src/palui.ts
@@ -190,7 +190,7 @@ function renderPal() {
   const html = palGroups.map((g) => {
     const rows = g.items.map((it) => {
       const i = idx++;
-      const ic = it.icon ? `<img class="pal-icimg" src="${it.icon}" alt="" />` : it.sw ? `<span class="sw" style="background:${it.sw}"></span>` : (it.glyph || "›");
+      const ic = it.icon ? `<img class="pal-icimg" src="${it.icon}" alt="" />` : it.sw ? `<span class="pal-sw" style="background:${it.sw}"></span>` : (it.glyph || "›");
       const sh = it.shortcut ? `<span class="pal-sh">${it.shortcut.map((k) => `<span class="k">${esc(k)}</span>`).join("")}</span>`
         : it.session ? `<span class="pal-sh actions"><span class="k">${chord("K")}</span></span>` : "";
       return `<div class="pal-item ${i === palSel ? "on" : ""}" data-i="${i}"><span class="pal-ic">${ic}</span><span class="pal-main"><span class="pm">${it.labelHtml}</span>${it.sub ? `<span class="ps">${esc(it.sub)}</span>` : ""}</span>${sh}</div>`;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1119,7 +1119,12 @@ select.in-ctl { cursor: pointer; }
    column: enough to recognise a conversation, not enough to read it here. */
 .hist-tv { display: flex; flex-direction: column; gap: 9px; max-height: 34vh; overflow-y: auto; padding: 10px 11px; border: 1px solid var(--hair); border-radius: var(--radius-sm); background: var(--terminal-bg); }
 .hist-tv .tvtext { font-size: 11px; line-height: 1.55; }
-.hist-tv.empty { display: block; color: var(--muted-2); font: 10.5px var(--font-ui); padding: 12px 11px; text-align: center; }
+/* `tv-empty`, NOT a bare `empty` modifier — `.empty` is the stage's "No sessions
+   running" splash, which is `position: absolute; inset: 0`. This element never set
+   `position`, so it inherited that and stretched to fill the whole dialog, covering the
+   list with one centred sentence. Every other placeholder in the app is prefixed
+   (`wt-empty`, `db-empty`, `set-empty`, `insp-empty`); this one was the exception. */
+.hist-tv.tv-empty { display: block; color: var(--muted-2); font: 10.5px var(--font-ui); padding: 12px 11px; text-align: center; }
 
 @media (max-width: 900px) { .histdlg .wt-body { grid-template-columns: minmax(0, 1fr); } }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -69,8 +69,11 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .app {
   height: 100dvh; display: grid;
   grid-template-columns: 232px minmax(0,1fr) 296px;
-  grid-template-rows: 40px minmax(0,1fr) 25px;
-  grid-template-areas: "top top top" "rail stage insp" "foot foot foot";
+  /* `head` is a row of its own spanning stage AND insp, so the stage header runs to
+     the right edge and the inspector starts underneath it. It is `auto` because the
+     header sizes itself from its buttons; only the row below it takes the slack. */
+  grid-template-rows: 40px auto minmax(0,1fr) 25px;
+  grid-template-areas: "top top top" "rail head head" "rail stage insp" "foot foot foot";
   background: radial-gradient(1000px 460px at 80% -10%, var(--accent-wash), transparent 60%), var(--bg);
   color: var(--text); font-family: var(--font-ui); font-size: 12.5px; line-height: 1.45;
   -webkit-font-smoothing: antialiased; overflow: hidden; transition: background .5s ease, grid-template-columns .22s ease;
@@ -79,6 +82,12 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
 .app.insp-off .insp { display: none; }
 .app.rail-mini { grid-template-columns: 54px minmax(0,1fr) 296px; }
 .app.rail-mini.insp-off { grid-template-columns: 54px minmax(0,1fr) 0; }
+/* ⌘I on the dashboard collapses to the 44px rail rather than to nothing (see
+   .insp-strip). The class alone only swapped the panel's contents — without these the
+   column stayed 296px wide and the "rail" was a row of glyphs floating in the middle
+   of an empty panel. */
+.app.insp-mini { grid-template-columns: 232px minmax(0,1fr) 44px; }
+.app.rail-mini.insp-mini { grid-template-columns: 54px minmax(0,1fr) 44px; }
 
 .mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
 .label { font-size: 9px; letter-spacing: .11em; text-transform: uppercase; color: var(--muted-2); font-weight: 700; }
@@ -116,7 +125,10 @@ body { overflow: hidden; font-family: var(--font-ui); color: var(--text); backgr
    flush into the corner and full height, because that corner is where a thrown
    pointer lands. .wclose alone takes the OS's red, the one colour a user should
    never have to aim for twice. */
-html.mac .top { padding-left: 78px; }
+/* The lights end at x=68 — `trafficLightPosition.x` is 14 and AppKit spaces the three
+   14px buttons 20px apart — so this is 68 + the gutter. 78px left a 10px one, tight
+   enough that the logo read as a fourth button in the row. */
+html.mac .top { padding-left: 94px; }
 html.mac.fs .top { padding-left: 12px; }
 .wctl { display: none; align-self: stretch; margin-right: -12px; }
 html.win .wctl { display: flex; }
@@ -369,7 +381,7 @@ html.win .wctl { display: flex; }
 
 /* center: terminal */
 .stage { grid-area: stage; display: flex; flex-direction: column; min-width: 0; }
-.stage-head { display: flex; flex-wrap: nowrap; align-items: center; gap: 11px; padding: 8px 14px; min-width: 0; background: linear-gradient(180deg, var(--accent-wash), transparent 90%), var(--panel); border-bottom: 1px solid var(--hair); }
+.stage-head { grid-area: head; display: flex; flex-wrap: nowrap; align-items: center; gap: 11px; padding: 8px 14px; min-width: 0; background: linear-gradient(180deg, var(--accent-wash), transparent 90%), var(--panel); border-bottom: 1px solid var(--hair); }
 .st-title { display: flex; align-items: center; gap: 9px; min-width: 0; flex: 1 1 auto; overflow: hidden; }
 .st-title .proj { flex: 0 1 auto; min-width: 0; max-width: 46%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-size: 13.5px; font-weight: 800; color: var(--accent-ink); letter-spacing: -.02em; }
 .chip { flex: none; white-space: nowrap; font-size: 9.5px; color: var(--muted); padding: 2px 7px; border-radius: 6px; background: var(--surface); border: 1px solid var(--hair); font-family: var(--font-mono); }
@@ -803,7 +815,10 @@ html.win .wctl { display: flex; }
 .pal-item { display: flex; align-items: center; gap: 10px; padding: 8px 10px; border-radius: var(--radius-sm); cursor: pointer; }
 .pal-item.on { background: var(--accent-wash); box-shadow: inset 0 0 0 1px var(--accent-line); }
 .pal-ic { width: 20px; height: 20px; border-radius: 6px; display: grid; place-items: center; font-size: 11px; flex: none; background: var(--surface); border: 1px solid var(--hair); color: var(--muted); }
-.pal-ic .sw { width: 8px; height: 8px; border-radius: 3px; }
+/* NOT `.sw` — that name belongs to the settings toggle further down, whose `::after`
+   knob is a 15px grey circle. Shared, it drew that knob spilling out of every 8px
+   project swatch in ⌘K. Its own name, its own box, like `.clico`. */
+.pal-sw { display: block; width: 8px; height: 8px; border-radius: 3px; }
 .pal-icimg { width: 18px; height: 18px; border-radius: 5px; object-fit: cover; }
 .pal-main { display: flex; flex-direction: column; gap: 1px; min-width: 0; flex: 1; }
 .pal-main .pm { font-size: 12px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -902,6 +917,9 @@ select.in-ctl { cursor: pointer; }
 .s-ctl .opt { font: 10px var(--font-mono); border: 1px solid var(--hair-strong); border-radius: 6px; padding: 3px 7px; color: var(--muted-2); background: var(--surface); cursor: pointer; white-space: nowrap; }
 .s-ctl .opt:hover { color: var(--text); background: var(--surface-2); }
 .s-ctl .opt.on { background: var(--accent); border-color: var(--accent); color: #17121f; font-weight: 700; }
+/* The settings window's toggle, and nothing else — a bare <button> whose knob is its
+   own `::after`, so any element that borrows the name inherits a 15px grey circle it
+   never asked for. The dashboard's switches are `.dsw`; ⌘K's project swatch `.pal-sw`. */
 .sw { width: 34px; height: 19px; border-radius: 999px; background: var(--surface-2); border: 1px solid var(--hair-strong); position: relative; flex: none; cursor: pointer; padding: 0; transition: background .14s, border-color .14s; }
 .sw::after { content: ""; position: absolute; top: 1px; left: 1px; width: 15px; height: 15px; border-radius: 50%; background: var(--muted-2); transition: transform .14s, background .14s; }
 .sw.on { background: var(--accent); border-color: var(--accent); }
@@ -1131,8 +1149,13 @@ select.in-ctl { cursor: pointer; }
    MUST stay after `.set-group` or its `flex-direction: column` wins on source order
    alone and the row lays out as a column. That is not hypothetical: it shipped that
    way, with the label and the switch stacked and centred, because `align-items:
-   center` below still applied and centres cross-axis in a column. Keep them adjacent. */
-.set-inline { flex-direction: row; align-items: center; justify-content: space-between; gap: 16px; }
+   center` below still applied and centres cross-axis in a column. Keep them adjacent.
+   It declares `display: flex` itself rather than borrowing `.set-group`'s, because the
+   peek control puts the two classes on *different* elements (the switch shares a row
+   with the label, the steppers and the preview sit below) — inheriting the display
+   only worked on the elements that happened to be both, and there the switch dropped
+   onto its own line under the hint. */
+.set-inline { display: flex; flex-direction: row; align-items: center; justify-content: space-between; gap: 16px; }
 .set-itxt { flex: 1; min-width: 0; }
 .set-inline .set-hint { margin-bottom: 0; }
 .set-inline > .sw { flex: none; }
@@ -1612,14 +1635,21 @@ select.in-ctl { cursor: pointer; }
 .dash-view[hidden] { display: none; }
 .dash { flex: 1; min-height: 0; display: flex; flex-direction: column; }
 
-/* the pulse strip — five numbers before any detail, so the window answers itself */
-.db-pulse { display: grid; grid-template-columns: repeat(auto-fit, minmax(112px, 1fr)) auto; gap: 1px; background: var(--hair); border-bottom: 1px solid var(--hair); flex: none; }
-.db-tile { padding: 9px 13px 10px; background: var(--panel); display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+/* the pulse strip — five numbers before any detail, so the window answers itself.
+   Flex, not grid: the tiles are equal shares with one content-sized tile (the range
+   picker) on the end, and grid cannot say that in an auto-repeat track list. It was
+   `repeat(auto-fit, minmax(112px,1fr)) auto`, which is invalid — every track beside an
+   auto-repeat must be a <fixed-size>, and `auto` is not one — so the whole declaration
+   was dropped and all five tiles stacked as rows in a single implicit column. */
+.db-pulse { display: flex; align-items: stretch; gap: 1px; background: var(--hair); border-bottom: 1px solid var(--hair); flex: none; }
+.db-tile { flex: 1 1 0; padding: 9px 13px 10px; background: var(--panel); display: flex; flex-direction: column; gap: 3px; min-width: 0; }
 .db-tile .k { font-size: 9px; letter-spacing: .1em; text-transform: uppercase; color: var(--muted-2); font-weight: 700; }
 .db-tile .v { font: 700 19px var(--font-mono); letter-spacing: -.03em; line-height: 1; font-variant-numeric: tabular-nums; }
 .db-tile .d { font: 9.5px var(--font-mono); color: var(--muted-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.db-tile.win { flex-direction: row; align-items: center; padding: 9px 12px; }
-.db-spark { font-size: 12px; line-height: 1; color: var(--accent-ink); letter-spacing: -1px; }
+.db-tile.win { flex: none; flex-direction: row; align-items: center; padding: 9px 12px; }
+/* A wrapper around format.ts's `.spark` SVG (108×24, display:block), so it needs no
+   type of its own — `line-height: 0` only stops the line box padding the tile out. */
+.db-spark { display: block; line-height: 0; color: var(--accent-ink); }
 .dim { color: var(--muted-2); }
 /* Its own picker — `.seg` belongs to the settings window and is a flex column. */
 .db-seg { display: inline-flex; padding: 2px; border-radius: 8px; background: var(--bg-2); border: 1px solid var(--hair); gap: 1px; flex: none; }
@@ -1855,18 +1885,20 @@ select.in-ctl { cursor: pointer; }
 .dsh .opts { display: flex; flex-direction: column; gap: 7px; padding: 9px 10px; border-radius: 8px; background: var(--bg-2); border: 1px solid var(--hair); }
 .dsh .foot { display: flex; gap: 7px; padding: 11px 15px; border-top: 1px solid var(--hair); background: color-mix(in srgb, var(--bg-2) 60%, transparent); }
 .dsh .foot .sp { margin-left: auto; }
-/* the claim switches */
-.sw { display: inline-flex; align-items: center; gap: 8px; cursor: pointer; font: 10.5px var(--font-mono); color: var(--muted-2); }
-.sw i { width: 24px; height: 14px; border-radius: 999px; background: var(--bg-2); border: 1px solid var(--hair-strong); position: relative; transition: background .18s, border-color .18s; flex: none; }
-.sw i::after { content: ""; position: absolute; top: 1px; left: 1px; width: 10px; height: 10px; border-radius: 50%; background: var(--muted-2); transition: transform .18s cubic-bezier(.32,.72,0,1), background .18s; }
-.sw.on i { background: var(--accent-wash); border-color: var(--accent-line); }
-.sw.on i::after { transform: translateX(10px); background: var(--accent-ink); }
-.sw.on { color: var(--accent-ink); }
+/* The claim switches — `.dsw`, NOT `.sw`, which is the settings window's own toggle
+   (a bare 34×19 button whose knob is an `::after`). Sharing the name gave every one of
+   these label-plus-`<i>` switches that button's pill as a second background. */
+.dsw { display: inline-flex; align-items: center; gap: 8px; cursor: pointer; font: 10.5px var(--font-mono); color: var(--muted-2); }
+.dsw i { width: 24px; height: 14px; border-radius: 999px; background: var(--bg-2); border: 1px solid var(--hair-strong); position: relative; transition: background .18s, border-color .18s; flex: none; }
+.dsw i::after { content: ""; position: absolute; top: 1px; left: 1px; width: 10px; height: 10px; border-radius: 50%; background: var(--muted-2); transition: transform .18s cubic-bezier(.32,.72,0,1), background .18s; }
+.dsw.on i { background: var(--accent-wash); border-color: var(--accent-line); }
+.dsw.on i::after { transform: translateX(10px); background: var(--accent-ink); }
+.dsw.on { color: var(--accent-ink); }
 /* A switch the project has turned off is shown greyed, never hidden: "why can't I
    assign?" needs an answer, and an absent control gives none. */
-.sw.off { opacity: .4; cursor: not-allowed; }
+.dsw.off { opacity: .4; cursor: not-allowed; }
 .dsh code { font: 10px var(--font-mono); color: var(--accent-ink); }
-@media (prefers-reduced-motion: reduce) { .dsh, .dsh-scrim, .sw i, .sw i::after { transition: none; } }
+@media (prefers-reduced-motion: reduce) { .dsh, .dsh-scrim, .dsw i, .dsw i::after { transition: none; } }
 
 /* ═══ What's new — the changelog screen ════════════════════════════════════════
    Opened once after an update, and by the notes icon beside the version number. Content


### PR DESCRIPTION
Eight fixes, all visual or in History. No behaviour changes to launching, telemetry
or the PTY, so the release-checklist risk is confined to what a browser can show.

### Three names that collided

`.sw` meant three unrelated things in `styles.css`, and the last definition did not
displace the others — it only overrode the properties it happened to name. ⌘K's 8px
project swatch inherited the settings toggle's `::after`, a 15px grey circle, and wore
it as a dot spilling out of its corner. The dashboard's claim switches inherited that
toggle's 34×19 pill as a second background. Each now has its own name — `pal-sw`,
`dsw`, `.sw` left to Settings alone — the way `.clico` already does for this reason.

The same class of bug is what covered the History dialog: `<div class="hist-tv empty">`
picked up `.empty`, the stage's "No sessions running" splash, which is `position:
absolute; inset: 0`.

### An invalid track list

The dashboard's pulse strip used `repeat(auto-fit, minmax(112px, 1fr)) auto`. Every
track beside an auto-repeat must be a `<fixed-size>` and `auto` is not one, so the
declaration was invalid and the browser dropped it whole — five tiles in a single
implicit column. It is flex now, which says what was meant. Its sparkline was also
being `esc()`'d, so it printed its own SVG markup as text.

### History listing Episko talking to itself

`summarize_day` is a `claude -p`, so it leaves a transcript per day the Trail
summarises — 27 on the machine this was found on. Skipped by directory in pass 1, not
filtered from the results: they are the newest thing on disk after any Trail view, so
filtering later would let them take the top `limit` slots and push real sessions off
the end.

### Verification

`tsc`, 631 vitest, 141 cargo tests (one new, confirmed failing without its fix) and
clippy under `-D warnings` all pass locally on macOS; CI re-runs them on both legs.
Everything else here is CSS and DOM, which no suite covers, so each surface was
measured in a browser against the dev server rather than eyeballed — tile widths, the
switch's position relative to its label, and `position`/box size on the History note
before and after.

**Not done:** the manual click-through in `RELEASE.md`. Nothing in this diff touches
the PTY, permissions, telemetry routing or drift, and the one checklist item that does
land on it — "Settings toggles sit beside their label, not under it", the `.set-inline`
cascade — is the item this PR fixes and was verified directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)