### PR TITLE
The dashboard header's buttons act on the project they are in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
+The project dashboard stops being a page you can only read.
+
+~ **The stage header's buttons work on a project dashboard.** ◷ History, ❯ Terminal and
+  ▶ Run were greyed out there and ＋ Session opened ⌘K to ask which project — while the
+  project's name sat in the header beside them. All four now act on the project on
+  screen: History opens scoped to it, Terminal and Run start in its root, and ＋ Session
+  opens the same new-session dialog you get from one of its sessions. ⌘T, ⌘⇧R, ⌘⇧H and
+  ⌘⏎ follow.
+
 ## 0.13.6 — 2026-08-01
 
 Housekeeping on the surfaces 0.13 added, plus two in History.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,10 +333,22 @@ Three things that are easy to get wrong:
   nothing happened on (a column of blank rows reads as broken); `densePerDay` fills
   them back in, because two busy days a week apart otherwise render as two adjacent
   bars and read as "constantly busy".
-- **⌘I collapses to a 44px rail here, not to nothing.** The dashboard header carries
-  only `＋ Session`, `✕` and `◨` — History, Terminal and Run act on the *project* and
-  live in the inspector — so hiding the panel outright would hide real verbs. On a
-  session ⌘I still hides it completely.
+- **The header's four verbs act on the dashboard's project, not on a session.**
+  `activeProjectCtx`/`activeCwd` (panes.ts) answer for the dash mirror as well as for a
+  session, external or dormant one, so ＋ Session, ❯ Terminal, ▶ Run and ◷ History —
+  and everything else keyed off those two, ⌘T/⌘⇧R/⌘⇧H/⌘⏎ included — treat the project on
+  screen exactly as they treat a session's. `＋ Session` opening ⌘K instead was the odd
+  one out: it asked which project when the answer was the header it was in.
+  `requestLaunch` decides "repo, so offer the worktree dialog" from three **zero-IPC**
+  signals, and all three only cover a folder something is *running* in — which a
+  dashboard is precisely not. Hence `dashLaunchHint()`: the dashboard already bought
+  `project_facts` and `worktree_heads` for this folder, so the answer is passed in
+  rather than asked for again, and the click stays synchronous (see the comment on
+  `requestLaunch` for why nothing may be awaited before that dialog is on screen).
+- **⌘I collapses to a 44px rail here, not to nothing.** The dashboard's own verbs — the
+  worktree dialog, the commit graph, the folder, the live-session strip — exist only in
+  the inspector, so hiding the panel outright would hide real verbs. On a session ⌘I
+  still hides it completely.
 
 ### The GitHub half
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -142,9 +142,9 @@ export function cycleSort() { setSort(SORT_MODES[(SORT_MODES.indexOf(sortMode) +
 export function toggleRail() { $("app").classList.toggle("rail-mini"); }
 // ⌘I / ◨. On a session this hides the inspector outright — nothing in it is
 // unreachable from that header. **On the dashboard it collapses to a 44px icon rail
-// instead**, because there the inspector holds the ONLY copy of History, Terminal and
-// Run: the dashboard header gave those up on the grounds that they act on the project
-// rather than on what is on the stage, so hiding the panel would hide real verbs.
+// instead**: History, Terminal and Run are in the header there too now, but the
+// worktree dialog, the commit graph, the folder and the live-session strip are not,
+// so hiding the panel would still hide real verbs.
 export function toggleInsp() {
   const app = $("app");
   if (dashMirror()) {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -125,6 +125,25 @@ let openView: "checkouts" | "notes" | "work" | "triage" | null = null;
 const root = () => dashMirror()?.root ?? "";
 const name = () => dashMirror()?.name ?? "";
 
+/**
+ * What ＋ Session needs to know, when the dashboard is what's on stage.
+ *
+ * `requestLaunch` opens the worktree dialog only for a folder it can already tell is a
+ * repo, and its two zero-IPC signals — a live session's `branch`, `dirtyByFolder` —
+ * both only cover folders something is *running* in. A dashboard is the opposite case:
+ * you opened it precisely because nothing is. But it has already paid for
+ * `project_facts` and `worktree_heads` for this exact folder, so the answer is on
+ * screen; asking git a third time would be a second answer to a settled question.
+ *
+ * `null` while the first load is still in flight (`openDashboard` clears `facts` on a
+ * project change, so this can never be the *previous* project's answer) — the caller
+ * then falls back to what it did before, which is a plain launch in the project root.
+ */
+export function dashLaunchHint(): { branch: string } | null {
+  if (!dashMirror() || !facts?.is_repo) return null;
+  return { branch: heads.find((h) => h.is_main)?.branch ?? "" };
+}
+
 // ---------- data ----------
 async function loadDash(): Promise<void> {
   const r = root();

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,7 +67,7 @@ import { closeDiff, diffOpen, openDiff, setDiffCloseFootMenus } from "./diffview
 import { closeGraph, graphEscape, graphOpen, openGraph as openGraphFor } from "./graphview";
 import { changelogOpen, closeChangelog, initChangelog } from "./changelogui";
 import {
-  closeDashboard, dashEscape, openDashboard, releaseClaimFor, renderDash,
+  closeDashboard, dashEscape, dashLaunchHint, openDashboard, releaseClaimFor, renderDash,
   renderDashHeader, renderDashInspector, setDashHost, wireDashboard,
 } from "./dashboard";
 import {
@@ -578,10 +578,14 @@ $("inspBtn").addEventListener("click", toggleInsp);
 
 
 // "+ Session" starts a session in the current project (offering a worktree if it
-// already has one). With no active session there's no project context → palette.
+// already has one). With nothing on stage there's no project context → palette.
+// A dashboard IS a project context — and the one place the question "which repo?"
+// is already answered on screen — so it gets the same dialog a session would, with
+// the repo-ness the dashboard has already read rather than the palette it used to
+// open, which asked again for something it had just been told.
 $("btnNew").addEventListener("click", () => {
   const c = activeProjectCtx();
-  if (c) requestLaunch(c.project, c.path); else openPalette();
+  if (c) requestLaunch(c.project, c.path, dashLaunchHint()); else openPalette();
 });
 $("btnTerm").addEventListener("click", openPlainTerminal);
 // Two doors into History: the stage-header button opens it scoped to the project on

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -40,7 +40,7 @@ import { nextAfterClose } from "./grouping";
 import { probeIcon } from "./icons";
 import { execCmd, exitWaiters, taskPrefs, type TaskLaunchOpts } from "./tasks";
 import {
-  accentFor, activeId, dirtyByFolder, dormants, engineDef, externals, extMirrorId,
+  accentFor, activeId, dashMirror, dirtyByFolder, dormants, engineDef, externals, extMirrorId,
   ioAll, pastMirrorId, permMode, permModeDef, sessions, setActiveId, setDormants,
   termEngine, termFontSize, worktreesByRepo, wtSig,
 } from "./state";
@@ -131,7 +131,12 @@ export async function launch(project: string, workdir: string, opts: { colorKey?
 //   • an external session carries the branch the registry reported
 //   • dirtyByFolder holds a non-null diffstat for anything that IS a git repo
 // so repo-ness and the branch label both come for free, with zero IPC.
-export function requestLaunch(project: string, path: string) {
+//
+// All three of those only cover a folder something is *running* in, which is exactly
+// what a project dashboard is not — so a caller that already knows better passes
+// `known`. It is still not an await: the dashboard bought that answer when it opened.
+export function requestLaunch(project: string, path: string, known?: { branch: string } | null) {
+  if (known) { openWt(project, path, known.branch); return; }
   // "Is anything already running here?" must include EXTERNAL sessions: they live in
   // their own array, not in `sessions`, so checking only the map sent a click straight
   // to a bare launch in the repo root even when the dialog was the obvious answer.
@@ -475,8 +480,17 @@ export function renderHeader(s: Sess | null) {
   $("hPath").textContent = tilde(s.drift?.dir ?? s.workdir);
 }
 
-// The active project context is either an Episko session or an external one.
+// The active project context is an Episko session, an external one, or — when the
+// dashboard is on stage — the project the dashboard is *about*. That last case is the
+// whole reason these two resolvers are shared: a dashboard names its project more
+// plainly than any session does, so ＋ Session, ❯ Terminal, ▶ Run and ◷ History should
+// act on it exactly as they act on a session's project rather than greying out (or,
+// in ＋ Session's case, falling back to ⌘K and asking a question already answered).
 export function activeProjectCtx(): { project: string; path: string } | null {
+  // The dashboard's root *is* the repo key — the sidebar groups by it — so it needs no
+  // resolution, and it is checked first because all three mirror kinds share one pointer.
+  const dm = dashMirror();
+  if (dm) return { project: dm.name, path: dm.root };
   // For an external session use its repo root, not the worktree cwd, so launching a
   // session / opening a worktree from it operates on the repo (and groups under it).
   if (extMirrorId()) { const e = externals.find((x) => x.session_id === extMirrorId()); if (e) { const root = e.repo_root || e.cwd; return { project: basename(root), path: root }; } }
@@ -488,6 +502,9 @@ export function activeProjectCtx(): { project: string; path: string } | null {
 // The active session's *actual* cwd (the worktree dir for worktree sessions, not
 // the color-grouping repo key) — used when opening a plain terminal there.
 export function activeCwd(): string | null {
+  // A dashboard is about a repo, not a checkout, so its root is both answers at once.
+  const dm = dashMirror();
+  if (dm) return dm.root;
   if (extMirrorId()) { const e = externals.find((x) => x.session_id === extMirrorId()); return e ? e.cwd : null; }
   if (pastMirrorId()) { const d = dormants.find((x) => x.id === pastMirrorId()); return d ? d.workdir : null; }
   const s = activeId ? sessions.get(activeId) : null;
@@ -507,10 +524,13 @@ export function openPlainTerminal() {
   const e = extMirrorId() ? externals.find((x) => x.session_id === extMirrorId()) : undefined;
   // A dormant session can also own the stage; it already stores the repo key.
   const d = pastMirrorId() ? dormants.find((x) => x.id === pastMirrorId()) : undefined;
+  // …and so can a dashboard, whose root is the repo key and whose name is the label
+  // the sidebar already uses — better than basename(), which is what the fallback gives.
+  const dm = dashMirror();
   const colorKey = s ? s.colorKey : e ? (e.repo_root || e.cwd) : d ? d.colorKey : wd;
   const worktree = s ? s.worktree : e ? (e.repo_root && e.cwd !== e.repo_root ? (e.branch || basename(e.cwd)) : null) : d ? d.worktree : null;
   const branch = s ? s.branch : (e?.branch || d?.branch || "");
-  launchShell(s ? s.project : (d?.project ?? basename(colorKey)), wd, { colorKey, worktree, branch });
+  launchShell(s ? s.project : (d?.project ?? dm?.name ?? basename(colorKey)), wd, { colorKey, worktree, branch });
 }
 
 // terminal and put the command on the clipboard — honest about the extra paste.

--- a/src/taskui.ts
+++ b/src/taskui.ts
@@ -26,7 +26,7 @@ import { $, toast } from "./dom";
 import { dlog } from "./debug";
 import { basename, esc, tilde } from "./format";
 import type { Runnable } from "./types";
-import { activeId, externals, extMirrorId, sessions } from "./state";
+import { activeId, dashMirror, externals, extMirrorId, sessions } from "./state";
 import { bumpFrec, frecScore } from "./palette";
 import {
   applyInputs, discoverTasks, execCmd, hiddenIds, launchWithDeps, pinnedIds,
@@ -284,9 +284,12 @@ export function runTargetCtx() {
   if (!wd) return null;
   const s = activeId ? sessions.get(activeId) : null;
   const e = extMirrorId() ? externals.find((x) => x.session_id === extMirrorId()) : undefined;
+  // The dashboard names its own project; basename(root) would usually agree, but the
+  // sidebar's label is the one the run's pane should carry.
+  const dm = dashMirror();
   return {
     workdir: wd,
-    project: s ? s.project : e ? basename(e.repo_root || e.cwd) : basename(wd),
+    project: s ? s.project : e ? basename(e.repo_root || e.cwd) : dm ? dm.name : basename(wd),
     colorKey: s ? s.colorKey : e ? (e.repo_root || e.cwd) : wd,
     worktree: s ? s.worktree : null,
     branch: s ? s.branch : (e?.branch || ""),


### PR DESCRIPTION
◷ History, ❯ Terminal and ▶ Run were greyed out on a project dashboard, and ＋ Session opened ⌘K to ask which project — while the project's name sat in the header beside it.

**The cause is one pair of resolvers.** `activeProjectCtx()` / `activeCwd()` in `panes.ts` knew about sessions, external mirrors and dormant mirrors, but not the dash mirror — even though all three share one `mirror` pointer. On a dashboard both returned `null`, which is what `syncStageButtons` greys on and what sent ＋ Session to the palette. Teaching them the dash kind enables all four at once, plus everything else keyed off them: ⌘T, ⌘⇧R, ⌘⇧H and ⌘⏎.

**＋ Session needed one more thing.** `requestLaunch` only offers the worktree dialog for a folder it can already tell is a repo, and it must stay synchronous — the comment there records that awaiting `git_branch` once made the button feel dead behind the git pollers. But its three zero-IPC signals (a live session's branch, an external's branch, `dirtyByFolder`) all only cover folders something is *running* in, which a dashboard is precisely not. So `dashLaunchHint()` hands back what the dashboard already bought with `project_facts` / `worktree_heads` for that exact folder. No new IPC, no await. A non-repo folder returns `null` and the old plain-launch behaviour stands, which is still the honest answer there.

Two smaller alignments so a pane launched from a dashboard is labelled by the project rather than `basename(root)`: `openPlainTerminal` and `runTargetCtx`.

**Docs.** The CLAUDE.md bullet claiming the dashboard header carries only ＋ Session / ✕ / ◨ was about to be wrong; it and the ⌘I comment in `actions.ts` now give the surviving reason for the 44px rail — the worktree dialog, commit graph, folder and live-session strip are still inspector-only.

## Verification

- `tsc --noEmit` clean, 631 vitest passing, `pnpm build` clean, `cargo clippy --all-targets -- -D warnings` clean (no Rust changed).
- No new import edges, so no cycle risk: only `dashMirror` from `state` into two files that already import it, and `dashLaunchHint` into a file that already imports `dashboard`.
- Clicked through in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)