### PR TITLE
The dashboard says when it is still reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,37 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
++ **The project dashboard says when it is still reading.** Opening a project costs a
+  scan of every transcript on the machine, three git calls and — on a GitHub repo — two
+  more `gh` calls after those, and none of it used to show. The strip led with a
+  confident row of zeros, the aside was simply short a card or two, and a folder still
+  being read looked exactly like a folder with nothing in it. Every wait now draws the
+  shape of what is coming: the strip, the timeline, the aside's cards, and the issues
+  card that arrives last. A day whose sentence is still being written says *writing*
+  beside the plain headline it already has, rather than hiding a line you can read to
+  promise a better one.
+! **Every project in the sidebar opens its dashboard, not just the ones with a session
+  running.** A folder Episko knew about only from a session in another terminal, only
+  from past sessions, or from a worktree whose session had ended simply did not respond
+  to the click — with nothing greyed out to say why, because the header was built without
+  the handler rather than with a disabled one. A worktree's header now opens its
+  *project's* dashboard, too: keyed to the checkout it matched no sessions at all, so the
+  timeline showed commits nobody appeared to have worked on. Checkouts are a card inside
+  the project, which is where they belong.
+! **Clicking a session from the project dashboard opens it.** Picking an external or a
+  restorable session while the dashboard was on screen changed the header, the inspector
+  and the accent colour but left the dashboard itself sitting on top of the transcript it
+  had just loaded, so the click read as recolouring the page. Leaving a dashboard you had
+  collapsed to its icon rail (⌘I) also carried the rail onto the next session, where it
+  held the wrong buttons — and closing the dashboard with nothing else running left a
+  blank stage instead of the "no sessions" card. All three were the same missing
+  handover: what takes the stage now says so in one place, and everything else steps
+  aside.
+! **The dashboard no longer shows the last project's answers under the new project's
+  name.** Clicking from one project to another kept the previous one's tier for a beat,
+  so a repository could flash *not a repo* — losing the worktree and commit-graph verbs
+  with it — and a GitHub project's issues could appear briefly under a folder that has
+  none.
 + **A day now gets two sentences: yours, and the project's.** The one on the timeline is
   still your day — your sessions, your spend. Above it, on days more than one person
   committed, sits a second line describing what the *project* did, written from the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,6 +312,22 @@ sorted first, so one gesture meant two different things depending on state, and 
 is going on in this repo" lived in a right-click menu nobody opens. The sessions are
 the rows directly beneath the header; this is the header's own answer.
 
+**Every header, whatever put the project in the list** — `renderSidebar` builds three
+shapes (has sessions / favourite / discovered) and for two releases only the first two
+carried `data-dash`, so a folder known only from an external session, only from past
+ones, or from a worktree whose session had ended was inert on click. Nothing refused it;
+the attribute was absent, so `closest()` returned null and the handler returned before
+the branch written for it — the same silent shape `test/dispatch.test.ts` guards the
+*other* half of. "Has an Episko session or is a favourite" is not a fact worth gating a
+view on, and the empty-but-real dashboard those folders get is the answer.
+
+**The key is `repoRoot ?? path`, because a checkout is not a project.** `splitByWorktree`
+mints one group per worktree keyed by its checkout dir, and `dashDays` filters history
+through `histProject`, which regrafts every row onto the repo root — so a dashboard keyed
+by a worktree dir matches no sessions at all and renders a timeline of commits nobody
+appears to have worked on. Splitting is the only thing that severs a group from its
+project, so `splitByWorktree` now carries `repoRoot` for whatever needs to get back.
+
 The split is `graph.ts`/`graphview.ts` again: **`dash.ts` is pure and tested**
 (`projectTier`, `dashDays`, `dashPulse`, `projectCost`, `densePerDay`), **`dashview.ts`
 takes data and returns a string**, **`dashboard.ts`** owns the pane, the IPC, the
@@ -343,6 +359,31 @@ from one `project_facts` call):
 A card with nothing to say is **absent, not empty** — an "Issues" panel in a folder
 that has no issues reads as breakage — and `missingCard` says once, plainly, what this
 folder cannot do instead.
+
+**And a card not read yet is neither**, which is what the skeletons are for. Opening a
+project is a whole-machine transcript scan, three git calls, and then two `gh` calls
+*after* those; every one of them used to land in silence, so "nothing here" and "not
+read yet" — opposite answers — looked identical, and the strip led with a confident row
+of zeros. Four things about that are worth keeping:
+
+- **The waits are separate flags on purpose.** `loading` (the local reads), `ghLoading`
+  (the GitHub half, which starts later and ends later) and `writing`/`stage` (the model
+  calls) each darken a different surface. One `isLoading` over the lot would skeleton
+  something that already has its answer.
+- **`factsKnown` is not `loading`.** It asks whether `project_facts` has answered *for
+  the project on screen*, and it is what the inspector's repo verbs and the `not a repo`
+  chip hang off — because `tier` defaults to `none`, which is an assertion, not an
+  absence. Keeping it separate is what stops a range change (which reloads the timeline
+  but settles nothing about the tier) blinking ⑃ and ⑂ off and on.
+- **Every write in `loadDash` is guarded by `root() !== r`, including `loading` itself.**
+  Two awaits, and a click on another project during either one leaves a continuation
+  that would otherwise land the previous folder's answers under the new folder's name —
+  or clear the new load's skeletons while it is still running.
+- **A pending sentence is not an absent one.** Your day already has a deterministic
+  headline that reads correctly, so waiting is a mark *beside* it; the shared box has no
+  such stand-in, so that one is a real skeleton. The shimmer and spinner are the usage
+  screen's `.u-skel`/`.u-spin` — a second loading vocabulary is a second thing to keep in
+  step.
 
 Three things that are easy to get wrong:
 
@@ -1029,6 +1070,7 @@ Episko's launch uuid **is** Claude's `--session-id`, so every session it launche
   **The baseline is persisted (`cc-cost-base`), and it has to be**: held only in memory it covered a *Move session* and an in-session History reopen but not the commonest route of all — quit, reopen, restore. `cc-usage` is localStorage and survives that; a run-scoped map does not, so the restored pane's first statusLine met an empty baseline and booked the carried-over total into a day that already had it. The obvious worry about persisting — a baseline outliving the counter it describes would *swallow* real spend, the failure nobody can see — is what the **drop branch** answers: a restarted counter reads below its old baseline, so the whole new reading is booked as fresh. Retention is therefore deliberately generous and capped by count, not by age; the drop branch, not an expiry, is what makes a stale entry harmless.
 - **The roster is a convenience layer, not a system of record** — `/resume` inside Claude always lists every session for a folder, so nothing dropped or removed is ever lost. Keep UI copy honest about that, and don't build recovery machinery for a problem `/resume` already solves.
 - **The stage has one owner:** `activeId` and the `mirror` pointer (`{kind:"ext"|"past"}`) are mutually exclusive — the read-only kinds share one discriminated pointer rather than a flag each. Timer-driven inspector repaints must bail on `mirror`, not just the external case.
+- **And one function decides what is *on* it.** `takeStage(show)` in `dom.ts` — `"session" | "ext" | "dash" | "none"` — is the only thing that may touch `#extPane`, `#dashPane`, `#empty` or `insp-mini`. It lives in the leaf module so every opener can call it without an import edge (it is why `mirror.ts` still needs no `./dashboard` dependency). Each opener used to hide its rivals by hand and **only two of four did it completely**, which is not a class of bug the type checker or a unit test can see: `#extPane` and `#dashPane` are both `position:absolute; inset:0` with **no `z-index`**, so DOM order alone decides and `#dashPane` is second — an opener that shows the mirror without hiding the dashboard puts it *behind* a fully opaque pane. Nothing errors, nothing logs, and the header, inspector and `--accent` all update correctly, so the click reads as "it only changed the colours". `insp-mini` rides along because the 44px rail is a **dashboard-only** mode; anything else taking the stage must clear it or the next session inherits a rail holding the wrong buttons. Add a fourth pane by extending `Stage`, never by poking `hidden` at the call site.
 
 ## History (`◷ History`, ⌘⇧H, `list_session_history`)
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -17,16 +17,17 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { $, toast } from "./dom";
+import { $, takeStage, toast } from "./dom";
 import { dlog } from "./debug";
 import {
   canShare, clampRange, DASH_RANGE_DEFAULT, dashDays, dashPulse, densePerDay,
   projectCost, projectTier, type ProjectFacts, type ProjectTier,
 } from "./dash";
 import {
-  checkoutsCard, checkoutsOverlay, closeSheet, dashInspector, dashStrip, dayHtml,
-  dispatchSheet, ghUnavailable, missingCard, notesCard, notesOverlay, pulseHtml,
-  triageCard, triageOverlay, workCard, workLogOffer, workOverlay,
+  cardSkeleton, checkoutsCard, checkoutsOverlay, closeSheet, dashInspector, dashStrip,
+  dayHtml, dispatchSheet, ghUnavailable, missingCard, notesCard, notesOverlay, pulseHtml,
+  pulseSkeleton, spineSkeleton, triageCard, triageOverlay, workCard, workLogOffer,
+  workOverlay,
 } from "./dashview";
 import {
   ALLOW_ALL, claims, claimForSession, DEFAULT_POLICY, dropClaim, recordClaim,
@@ -102,7 +103,24 @@ let tier: ProjectTier = "none";
 let days: TrailDay[] = [];
 let heads: WtHead[] = [];
 let hasDigest = false;
-let loading = false;
+/**
+ * The waits, and they are deliberately separate flags rather than one `isLoading` —
+ * three here, plus `writing`/`stage` down with the summary queue. Each starts at a
+ * different moment, ends at a different moment, and darkens a different part of the
+ * screen; one flag over the lot would either skeleton a surface that already has its
+ * answer or leave one that doesn't looking settled.
+ */
+let loading = false;                 // the local reads: facts, history, git log, digest
+/// Whether `project_facts` has answered **for the project now on screen**. Not the same
+/// question as `loading`: a range change reloads the timeline without putting the tier
+/// back in doubt, so the inspector's repo verbs must not blink for it. False only
+/// between clicking a new project and its facts landing — during which `tier` reads
+/// `none`, which is an assertion this has no basis for yet.
+let factsKnown = false;
+/// The GitHub half, which fires *after* the local reads and used to be entirely silent:
+/// the Open work card was simply not there yet, which on a repo whose issues are the
+/// point reads as `gh` being broken rather than as `gh` being slow.
+let ghLoading = false;
 /// The GitHub half. `gh` is allowed to be missing, logged out, or pointed at a folder
 /// that is not a GitHub repo — every one of those is `available: false` and a reason,
 /// shown as one quiet row rather than as breakage.
@@ -131,6 +149,16 @@ const teamSummaries = new Map<string, string>();
 const openDays = new Set<string>();
 /// Which enlarge overlay is up, if any.
 let openView: "checkouts" | "notes" | "work" | "triage" | null = null;
+/// The one day whose sentence is out at the model right now, and in which scope. One at
+/// a time by construction — `runSummaryQueue` is sequential — so this is a value, not a
+/// set, and the mark it draws walks down the timeline as the queue does.
+let writing: { key: string; scope: "me" | "project" } | null = null;
+/// Which half of a pass is running. It is what lets a *shared* box be drawn before its
+/// sentence exists: during stage 2 every shared day with no line yet is genuinely queued
+/// for one. Gated on the stage rather than on the whole queue because stage 1 can be a
+/// fortnight of calls, and a screenful of boxes shimmering through all of it promises
+/// something that is true but not yet happening.
+let stage: "me" | "project" | null = null;
 
 const root = () => dashMirror()?.root ?? "";
 const name = () => dashMirror()?.name ?? "";
@@ -157,16 +185,32 @@ export function dashLaunchHint(): { branch: string } | null {
 // ---------- data ----------
 async function loadDash(): Promise<void> {
   const r = root();
-  if (!r) return;
+  // `openDashboard` sets `loading` before this is even called, so bailing without
+  // clearing it would leave the pane shimmering at a skeleton nothing is filling.
+  if (!r) { loading = false; return; }
   loading = true;
+  ghLoading = false;
   summaries.clear();
   teamSummaries.clear();
   renderDash();
   try {
     // `project_facts` first and alone: it decides which of the calls below are even
     // worth making, and a folder that isn't a repo must not be asked for a git log.
-    facts = await invoke<ProjectFacts>("project_facts", { dir: r }).catch(() => null);
+    const f = await invoke<ProjectFacts>("project_facts", { dir: r }).catch(() => null);
+    // Everything below is an answer *about `r`*, and a load for another project may have
+    // started while this one was awaiting — in which case that load owns the state and
+    // this one must touch none of it, `loading` included. The same guard `loadGh` has
+    // always had, needed at both awaits here because both write module state; without it
+    // a stale continuation lands the previous project's tier under the new one's name
+    // and, worse, declares it *known*.
+    if (root() !== r) return;
+    facts = f;
     tier = projectTier(facts);
+    factsKnown = true;
+    // The tier is what the inspector's repo verbs and the strip's hang off, and they are
+    // painted by `renderAll`, not by us — so say so now rather than at the end of the
+    // reads below, which are several seconds of history scanning away.
+    host.renderAll();
     const wantGit = tier !== "none";
     const [hist, commits, wt, digest, sn] = await Promise.all([
       invoke<HistEntry[]>("list_session_history", { limit: 400 }).catch((e) => {
@@ -184,12 +228,14 @@ async function loadDash(): Promise<void> {
       wantGit ? invoke<SharedNote[]>("list_shared_notes", { root: r }).catch(() => [] as SharedNote[])
               : Promise.resolve([] as SharedNote[]),
     ]);
+    if (root() !== r) return;
     shared = sn;
     heads = wt.filter((w) => w.exists);
     // The GitHub half, only for a repo that has a GitHub remote. Fired after the
     // cheap local reads rather than alongside them: `gh` is a process per call and
     // the timeline should paint without waiting for the network.
     if (tier === "github") {
+      ghLoading = true;
       void loadGh(r);
     } else {
       gh = { available: false, reason: null, threads: [], viewer: null };
@@ -203,7 +249,9 @@ async function loadDash(): Promise<void> {
       || (wantGit && await invoke<boolean>("has_digest", { root: r }).catch(() => false));
     days = dashDays(r, hist, commits, usageWindow(dashRange), (k) => projectCost(usageDetail, k, name()));
   } finally {
-    loading = false;
+    // Guarded like every other write above: clearing it unconditionally would take the
+    // *next* project's skeletons down while its own load is still running.
+    if (root() === r) loading = false;
   }
   renderDash();
   if (dashSummaries) void runSummaryQueue();
@@ -220,6 +268,10 @@ async function loadGh(r: string, force = false): Promise<void> {
     invoke<ClaimAllow>("claim_policy", { root: r }).catch(() => ALLOW_ALL),
   ]);
   if (root() !== r) return;   // the user moved on while this was in flight
+  // Cleared inside the guard, never before it: a stale call landing after the user has
+  // moved to another GitHub project would otherwise take that project's skeleton down
+  // and leave its own, still-running, call with nothing on screen saying so.
+  ghLoading = false;
   gh = res; kept = k; allow = a;
   renderDash();
 }
@@ -254,6 +306,9 @@ async function runSummaryQueue(): Promise<void> {
     } while (queueAgain && dashMirror() && dashSummaries);
   } finally {
     queueRunning = false;
+    // A pass that answered every day from cache never renders on its own, so the marks
+    // it drew on the way in would sit there until something else repainted.
+    renderDash();
   }
 }
 
@@ -278,8 +333,19 @@ async function summaryPass(): Promise<void> {
   const r = root();
   const now = Date.now();
   const ordered = [...days.filter((d) => dayIsClosed(d, now)), ...days.filter((d) => !dayIsClosed(d, now))];
-  for (const d of ordered) if (!await summariseDay(d, r, now, "me")) return;
-  for (const d of ordered) if (!await summariseDay(d, r, now, "project")) return;
+  try {
+    stage = "me";
+    for (const d of ordered) if (!await summariseDay(d, r, now, "me")) return;
+    stage = "project";
+    // The shared boxes this stage is about to fill, drawn before the first call goes
+    // out: the box is a block that would otherwise appear from nothing, and its heading
+    // — that this day had more than one human committer, and who — has been known since
+    // the timeline was assembled.
+    renderDash();
+    for (const d of ordered) if (!await summariseDay(d, r, now, "project")) return;
+  } finally {
+    stage = null;
+  }
 }
 
 /**
@@ -306,6 +372,11 @@ async function summariseDay(d: TrailDay, r: string, now: number, scope: "me" | "
   // say and must not be asked — an empty record would spend a call on "quiet day".
   const f = mine ? dayFacts(d) : projectDayFacts(d);
   if (!f.trim()) return true;
+  // Marked only from here, past every early return above: a day answered from cache or
+  // skipped by the sharing rule is not waiting on anything, and marking it would put a
+  // "writing…" on rows that will never change.
+  writing = { key: d.key, scope };
+  renderDash();
   try {
     const line = await invoke<string>("summarize_day", {
       root: r, key: d.key, facts: f, model: "haiku", scope, force: !closed,
@@ -317,7 +388,6 @@ async function summariseDay(d: TrailDay, r: string, now: number, scope: "me" | "
     if (root() !== r) return false;
     if (!line) return true;
     into.set(d.key, line);
-    renderDash();
     // Share it — and only ever this half. A day still being written is not written to
     // the repo either: today's line changes as the day goes on, and each change would
     // dirty a tracked file.
@@ -334,6 +404,12 @@ async function summariseDay(d: TrailDay, r: string, now: number, scope: "me" | "
     // No summary is a fine state — the deterministic headline already reads correctly —
     // so a failure is logged and the loop moves on.
     dlog("warn", `dash: ${scope} summary for ${d.key} failed — ${e}`);
+  } finally {
+    // Cleared and repainted however the call went, so a failed or empty one doesn't
+    // leave its row claiming to still be writing. Safe to null unconditionally: the
+    // queue is sequential, so nothing newer can have claimed the slot.
+    writing = null;
+    if (root() === r) renderDash();
   }
   return true;
 }
@@ -344,13 +420,20 @@ const liveHere = () => [...sessions.values()].filter((s) => s.colorKey === root(
 
 export function renderDash(): void {
   if (!dashMirror()) return;
+  // One place says the pane is working, because the bars themselves say nothing: they
+  // are `<i>`s of colour, and a reader not looking at them needs the state, not the
+  // shape. Every wait counts, including the two that leave real content on screen.
+  $("dashPane").setAttribute("aria-busy", loading || ghLoading || queueRunning ? "true" : "false");
   const p = dashPulse(days);
   const dense = densePerDay(days, dashRange, Date.now());
-  $("dashPulse").innerHTML = pulseHtml(p, tier, dashRange, dense);
+  // A row of zeros is not an empty answer, it is a wrong one — `dashPulse([])` counts no
+  // commits, no sessions and no contributors for a project that may have had plenty, and
+  // reads as "nothing happened here" rather than "nothing has been read yet".
+  $("dashPulse").innerHTML = loading ? pulseSkeleton(dashRange) : pulseHtml(p, tier, dashRange, dense);
 
   const spine = $("dashSpine");
   if (loading) {
-    spine.innerHTML = `<div class="db-empty">Reading this project's history…</div>`;
+    spine.innerHTML = spineSkeleton();
   } else if (!days.length) {
     spine.innerHTML = `<div class="db-empty">Nothing in the last ${dashRange} days.
       Sessions, commits and spend appear here on their own — there is nothing to fill in.</div>`;
@@ -368,7 +451,15 @@ export function renderDash(): void {
       dayHtml(d, summaries.get(d.key) ?? null, deterministicHeadline(d), openDays.has(d.key),
         // Written for every day, shown only where it says something your own line
         // doesn't — see `sharedDay`.
-        sharedDay(d) ? teamSummaries.get(d.key) ?? null : null, humanAuthors(d))).join("")
+        sharedDay(d) ? teamSummaries.get(d.key) ?? null : null, humanAuthors(d),
+        {
+          mine: writing?.scope === "me" && writing.key === d.key,
+          // The whole of stage 2, not just the call in flight: every shared day without
+          // a line is queued for one, and `sharedDay` is exactly the condition under
+          // which `summariseDay` buys it — so the box drawn here is one that will fill.
+          team: dashSummaries && sharedDay(d) && !teamSummaries.has(d.key)
+            && (stage === "project" || writing?.scope === "project"),
+        })).join("")
       + workLogOffer(unshared);
   }
 
@@ -377,13 +468,20 @@ export function renderDash(): void {
   const stale = staleCandidates(gh.threads, kept, now).map((t) => ({ t, why: quietFor(t.updated_at, now) }));
   const prs = gh.threads.filter((t) => t.kind === "pr").length;
 
-  $("dashAside").innerHTML =
-    (gh.available ? workCard(cardRows(gh.threads), gh.threads.length, prs, holder) : "")
-    + (gh.available ? triageCard(stale, gh.threads.filter((t) => t.kind === "issue").length) : "")
-    + checkoutsCard(heads, liveIn, folderDirty)
-    + notesCard(noteList(root()))
-    + (tier === "github" && !gh.available && gh.reason ? ghUnavailable(gh.reason) : "")
-    + missingCard(tier, facts);
+  // Notes survive the wait because they never needed the wait: they are localStorage and
+  // are already correct, and the jot box is the one thing here you might have opened the
+  // project to type into. Everything else is either unread or, in `missingCard`'s case, a
+  // statement about a tier that hasn't been answered — hence the whole branch, rather
+  // than a skeleton bolted onto the front of the real list.
+  $("dashAside").innerHTML = loading
+    ? cardSkeleton() + notesCard(noteList(root()))
+    : (ghLoading ? cardSkeleton() : "")
+      + (gh.available ? workCard(cardRows(gh.threads), gh.threads.length, prs, holder) : "")
+      + (gh.available ? triageCard(stale, gh.threads.filter((t) => t.kind === "issue").length) : "")
+      + checkoutsCard(heads, liveIn, folderDirty)
+      + notesCard(noteList(root()))
+      + (tier === "github" && !gh.available && gh.reason ? ghUnavailable(gh.reason) : "")
+      + missingCard(tier, facts);
 
   const ovl = $("dashOverlay");
   ovl.classList.toggle("show", openView !== null);
@@ -431,9 +529,9 @@ export function renderDashInspector(): void {
     cls: GCLASS[statusKey(s)] ?? "g-idle",
     ctx: s.ctxPct != null ? `${Math.round(s.ctxPct)}%` : "",
   }));
-  $("inspector").innerHTML = dashInspector(root(), tier, facts, live, hasDigest);
+  $("inspector").innerHTML = dashInspector(root(), tier, facts, live, hasDigest, factsKnown);
   $("dashStrip").innerHTML = dashStrip(accentFor(root()), (name()[0] || "?").toUpperCase(), tier,
-    live.map((s) => ({ id: s.id, glyph: s.glyph, cls: s.cls, label: s.label })));
+    live.map((s) => ({ id: s.id, glyph: s.glyph, cls: s.cls, label: s.label })), factsKnown);
 }
 
 // ---------- open / close ----------
@@ -442,11 +540,19 @@ export function openDashboard(project: string, path: string): void {
   setMirror({ kind: "dash", root: path, name: project });
   setActiveId(null);
   for (const x of sessions.values()) x.pane.classList.remove("active");
-  ($("empty") as HTMLElement).style.display = "none";
-  ($("extPane") as HTMLElement).hidden = true;
-  ($("dashPane") as HTMLElement).hidden = false;
+  takeStage("dash");
   document.documentElement.style.setProperty("--accent", accentFor(path));
-  if (changed) { days = []; heads = []; facts = null; openDays.clear(); openView = null; }
+  // A new project inherits nothing. Everything below is an *answer about a folder*, so
+  // leaving any of it in place shows the previous project's answer under this one's name
+  // — and `renderAll` below paints before `loadDash` has reached its first await, so
+  // there is a real frame in which it would. `loading` is part of the reset for the same
+  // reason: it is what the paint reads to know it has nothing yet.
+  if (changed) {
+    days = []; heads = []; facts = null; openDays.clear(); openView = null;
+    tier = "none"; factsKnown = false; loading = true; ghLoading = false;
+    gh = { available: false, reason: null, threads: [], viewer: null };
+    kept = []; shared = []; hasDigest = false; sheet = null; writing = null;
+  }
   host.renderAll();
   void loadDash();
 }
@@ -455,10 +561,11 @@ export function closeDashboard(): void {
   if (!dashMirror()) return;
   setMirror(null);
   openView = null;
-  ($("dashPane") as HTMLElement).hidden = true;
-  // The collapsed rail is a dashboard-only mode: left set, the next session would get
-  // a 44px inspector holding the wrong buttons.
-  $("app").classList.remove("insp-mini");
+  // Takes the collapsed rail with it — that is a dashboard-only mode, and left set the
+  // next session gets a 44px inspector holding the wrong buttons. It also brings the
+  // empty card back: `renderAll` never touches it, so closing the last thing on the
+  // stage by hand used to leave a blank one.
+  takeStage("none");
 }
 
 /// Esc steps out one layer at a time — the enlarge overlay first, then the pane. Same

--- a/src/dashview.ts
+++ b/src/dashview.ts
@@ -25,6 +25,13 @@ function tile(k: string, v: string, d = ""): string {
     + (d ? `<span class="d">${d}</span>` : "") + `</div>`;
 }
 
+/// The range picker is not data — it is a preference, and it answers instantly whether
+/// or not anything else has. So it is shared with the skeleton below, where every tile
+/// beside it is a bar.
+const rangeTile = (range: number) => `<div class="db-tile win"><span class="db-seg">
+      ${[7, 14, 30].map((r) => `<button${r === range ? ` class="on"` : ""} data-dashrange="${r}">${r}d</button>`).join("")}
+    </span></div>`;
+
 export function pulseHtml(p: Pulse, tier: ProjectTier, range: number, dense: number[]): string {
   const tiles: string[] = [];
   if (tier !== "none") {
@@ -43,10 +50,81 @@ export function pulseHtml(p: Pulse, tier: ProjectTier, range: number, dense: num
       : `<span class="dim">—</span>`;
     tiles.push(tile("Contributors", String(p.authors.length), who));
   }
-  return `<div class="db-pulse">${tiles.join("")}
-    <div class="db-tile win"><span class="db-seg">
-      ${[7, 14, 30].map((r) => `<button${r === range ? ` class="on"` : ""} data-dashrange="${r}">${r}d</button>`).join("")}
-    </span></div></div>`;
+  return `<div class="db-pulse">${tiles.join("")}${rangeTile(range)}</div>`;
+}
+
+// ---------- skeletons ----------
+//
+// WHY THESE EXIST. Opening a project costs a `git` process for the facts, a scan of
+// every transcript on the machine, a `git log`, a worktree probe and a digest read —
+// and then, on a GitHub repo, two `gh` calls *after* all of that, plus a model call per
+// day for the sentences. Every one of those used to land in silence: the strip showed a
+// confident row of zeros, the aside was simply short a card or two, and nothing on
+// screen told "there is nothing here" apart from "this has not been read yet". Those
+// are opposite answers, and they looked identical.
+//
+// Each skeleton is drawn in the geometry of what replaces it, so the answer arriving is
+// a substitution rather than a jump. The bars carry no text and `./dashboard` marks the
+// pane `aria-busy` instead — grey rectangles are decoration, and a reader who isn't
+// looking at them wants the sentence at the foot of the timeline.
+//
+// The shimmer (`.db-sk`) and the spinner (`.u-spin`) are the usage screen's own. A
+// second loading vocabulary would only be a second thing to keep in step.
+
+const sk = (w: string, h = 9) => `<i class="db-sk" style="width:${w};height:${h}px"></i>`;
+
+/**
+ * The strip, before it knows anything.
+ *
+ * The tile *labels* are bars too, not the real words. Which tiles exist depends on the
+ * tier — a folder with no git has neither Commits nor Contributors — and `project_facts`
+ * is one of the calls still out, so naming them here would be a guess the answer then
+ * contradicts by removing two tiles.
+ */
+export function pulseSkeleton(range: number): string {
+  const tiles = [["52px", "44px"], ["48px", "62px"], ["62px", "38px"], ["58px", "54px"]]
+    .map(([k, v]) => `<div class="db-tile"><span class="k">${sk(k, 7)}</span>`
+      + `<span class="v">${sk(v, 15)}</span><span class="d">${sk("40px", 7)}</span></div>`).join("");
+  return `<div class="db-pulse">${tiles}${rangeTile(range)}</div>`;
+}
+
+/**
+ * The timeline, before it has any days.
+ *
+ * Three rows in the real `.db-day` geometry — gutter, spine dot, summary line, facts —
+ * so the first real day lands where the first bar was. Three, and not enough to fill the
+ * column, because the window is a preference this doesn't read: a skeleton that runs to
+ * the fold promises a length it has no way to know.
+ *
+ * The sentence underneath is the part a skeleton can't say. It is the usage screen's
+ * spinner-and-line pattern, for the same reason it has one.
+ */
+export function spineSkeleton(): string {
+  const row = (w: string) => `<div class="db-day">
+      <div class="db-gut">${sk("30px", 8)}</div>
+      <div class="db-dbody">
+        <p class="db-sum">${sk(w, 11)}</p>
+        <div class="db-facts">${sk("54px", 8)}${sk("60px", 8)}</div>
+      </div></div>`;
+  return ["88%", "72%", "80%"].map(row).join("")
+    + `<p class="db-skhint"><span class="u-spin"></span>Reading this project's history…</p>`;
+}
+
+/**
+ * One aside card, before its rows exist.
+ *
+ * Used for two different waits. The local reads get one because the aside would
+ * otherwise be a lone Notes box; the GitHub half gets one because it fires *after* the
+ * rest and was the most silent wait of the lot — the Open work card was simply not
+ * there, which on a repo whose issues are the point reads as `gh` being broken rather
+ * than as `gh` being slow.
+ */
+export function cardSkeleton(rows = 3): string {
+  const body = ["78%", "62%", "88%", "70%"].slice(0, rows).map((w) =>
+    `<div class="cr">${sk("13px", 13)}<span class="ti">${sk(w, 9)}</span>`
+    + `<span class="rt">${sk("30px", 9)}</span></div>`).join("");
+  return `<div class="ac sk"><div class="ac-h">${sk("58px", 8)}<span class="n">${sk("24px", 8)}</span></div>
+    <div class="ac-b">${body}</div></div>`;
 }
 
 // ---------- the timeline ----------
@@ -63,25 +141,43 @@ export function pulseHtml(p: Pulse, tier: ProjectTier, range: number, dense: num
  * they are reading. `team` arrives already gated (see `sharedDay`): the caller decides
  * whether it is worth showing, this only decides how.
  */
+export interface DayPending {
+  /// Your own line, `dayFacts` → `summarize_day`.
+  mine?: boolean;
+  /// The project's line — the shared box, which on this day will exist.
+  team?: boolean;
+}
+
 export function dayHtml(
   d: TrailDay, summary: string | null, headline: string, open: boolean,
-  team: string | null = null, authors: string[] = [],
+  team: string | null = null, authors: string[] = [], pend: DayPending = {},
 ): string {
   const dt = new Date(d.when);
   const rows = dayRows(d);
   const hidden = rows.length;
+  // A pending line is not an absent one, and the two want opposite treatments. Your own
+  // sentence has a deterministic headline standing in for it that is already correct and
+  // already readable, so waiting is a mark *beside* it — replacing a sentence somebody
+  // can read with a grey bar to promise a nicer one is a bad trade. The shared box has no
+  // such stand-in: it is a block that would otherwise appear out of nothing, and its
+  // heading is known (this day has more than one human committer, and who they were) long
+  // before its sentence is, so only the sentence is a bar.
+  const teamBox = (body: string, cls = "") => `<div class="db-team${cls}">
+        <span class="tl"><span class="sh">shared</span>The project${
+          authors.length ? `<span class="au">${esc(authors.join(" · "))}</span>` : ""}</span>
+        <p>${body}</p>
+      </div>`;
   return `<div class="db-day${open ? " open" : ""}" data-dashday="${esc(d.key)}">
     <div class="db-gut">
       <span class="dd">${WEEKDAY[dt.getDay()]} ${dt.getDate()}</span>
       ${d.cost > 0 ? `<span class="cc">${esc(uUsd2(d.cost))}</span>` : ""}
     </div>
     <div class="db-dbody">
-      ${team ? `<div class="db-team">
-        <span class="tl"><span class="sh">shared</span>The project${
-          authors.length ? `<span class="au">${esc(authors.join(" · "))}</span>` : ""}</span>
-        <p>${esc(team)}<span class="ai">· ai</span></p>
-      </div>` : ""}
-      <p class="db-sum">${esc(summary || headline)}${summary ? `<span class="ai">· ai</span>` : ""}</p>
+      ${team ? teamBox(`${esc(team)}<span class="ai">· ai</span>`)
+        : pend.team ? teamBox(sk("84%", 10), " sk") : ""}
+      <p class="db-sum">${esc(summary || headline)}${
+        summary ? `<span class="ai">· ai</span>`
+        : pend.mine ? `<span class="ai wr">· writing</span>` : ""}</p>
       <div class="db-facts">
         ${d.commits.length ? `<span>${d.commits.length} commit${d.commits.length === 1 ? "" : "s"}</span>` : ""}
         ${d.commits.length && d.sessions.length ? `<span class="dot">·</span>` : ""}
@@ -226,18 +322,25 @@ export function missingCard(tier: ProjectTier, f: ProjectFacts | null): string {
 
 // ---------- the inspector: the project's context menu, standing open ----------
 
+/// `known` is whether `project_facts` has answered *for this project yet*. It is not the
+/// same question as "is anything loading": a range change reloads the timeline without
+/// putting the tier back in doubt, and blanking the repo verbs for it would be a flicker
+/// that says nothing. False only between clicking a new project and its facts landing —
+/// during which `tier` reads `none`, which is an assertion, not an absence.
 export function dashInspector(
   root: string, tier: ProjectTier, f: ProjectFacts | null,
   live: { id: string; label: string; glyph: string; cls: string; ctx: string }[],
-  shared: boolean,
+  shared: boolean, known = true,
 ): string {
   const act = (a: string, ic: string, lb: string, sb = "", cls = "") =>
     `<button class="ia ${cls}" data-dashact="${a}"><span class="ic">${ic}</span>`
     + `<span><span class="lb">${esc(lb)}</span>${sb ? `<span class="sb">${esc(sb)}</span>` : ""}</span></button>`;
+  const repo = known && tier !== "none";
   const chips = [
     f?.slug ? `<span class="chip">${esc(f.slug)}</span>` : "",
     f?.host && !f.slug ? `<span class="chip">${esc(f.host)}</span>` : "",
-    tier === "none" ? `<span class="chip warn">not a repo</span>` : "",
+    !known ? `<span class="chip sk">${sk("62px", 8)}</span>`
+      : tier === "none" ? `<span class="chip warn">not a repo</span>` : "",
     shared ? `<span class="chip acc" title="This project has a committed .episko/digest.md">.episko/ shared</span>` : "",
   ].filter(Boolean).join("");
   return `
@@ -246,15 +349,15 @@ export function dashInspector(
       + `<span class="sbranch">${esc(s.label)}</span><span class="sctx">${esc(s.ctx)}</span></div>`).join("")}</div></div>` : ""}
     <div><span class="label">Do something here</span><div class="ip-acts">
       ${act("launch", "＋", "New session", live.length ? `${live.length} already running here` : "start Claude Code in this folder")}
-      ${tier !== "none" ? act("worktree", "⑃", "New worktree session…", "on a branch of its own") : ""}
+      ${repo ? act("worktree", "⑃", "New worktree session…", "on a branch of its own") : ""}
       ${act("terminal", "❯", "Open terminal here")}
       ${act("run", "▶", "Run a task…")}
       <div class="ip-sep"></div>
-      ${tier !== "none" ? act("graph", "⑂", "Commit graph…", "history, branches, merges") : ""}
+      ${repo ? act("graph", "⑂", "Commit graph…", "history, branches, merges") : ""}
       ${act("history", "◷", "History…", "reopen a session you closed")}
       ${act("folder", "⌂", "Open project folder")}
       ${act("copypath", "⧉", "Copy path")}
-      ${tier !== "none" && !shared
+      ${repo && !shared
         ? act("worklog", "↑", "Share the work log…", "commit each day's summary to .episko/") : ""}
     </div></div>
     ${chips ? `<div><span class="label">Repository</span><div class="db-chips">${chips}</div></div>` : ""}
@@ -268,20 +371,23 @@ export function dashInspector(
 /// survives the collapse.
 export function dashStrip(
   accent: string, initial: string, tier: ProjectTier,
-  live: { id: string; glyph: string; cls: string; label: string }[],
+  live: { id: string; glyph: string; cls: string; label: string }[], known = true,
 ): string {
   const b = (a: string, ic: string, t: string, cls = "") =>
     `<button class="isb ${cls}" data-dashact="${a}" title="${esc(t)}">${ic}</button>`;
+  // Same `known` gate as the inspector: the rail is the *same* verbs, and two surfaces
+  // offering a different set of them for a second is worse than either alone.
+  const repo = known && tier !== "none";
   return `<span class="sglyphs">
       <span class="pglyph" style="background:${esc(accent)}">${esc(initial)}</span>
       ${live.map((s) => `<button class="isb live ${s.cls}" data-sel="${esc(s.id)}" title="${esc(s.label)}">${s.glyph}</button>`).join("")}
     </span>
     ${b("launch", "＋", "New session")}
-    ${tier !== "none" ? b("worktree", "⑃", "New worktree session…") : ""}
+    ${repo ? b("worktree", "⑃", "New worktree session…") : ""}
     ${b("terminal", "❯", "Open terminal here")}
     ${b("run", "▶", "Run a task…")}
     <span class="isep"></span>
-    ${tier !== "none" ? b("graph", "⑂", "Commit graph…") : ""}
+    ${repo ? b("graph", "⑂", "Commit graph…") : ""}
     ${b("history", "◷", "History…")}
     ${b("folder", "⌂", "Open project folder")}
     ${b("copypath", "⧉", "Copy path")}`;

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -25,6 +25,38 @@ export function dropScrim() {
   if (!SCRIM_DLGS.some((id) => $(id).classList.contains("show"))) $("scrim").classList.remove("show");
 }
 
+/**
+ * What is on the stage. Three panes stacked in `#terminals` — the session terminals,
+ * the read-only mirror (`#extPane`, shared by external and dormant sessions) and the
+ * project dashboard (`#dashPane`) — plus the "no sessions" card.
+ *
+ * WHY THIS IS ONE FUNCTION. Every opener used to hide its rivals by hand, and only two
+ * of the four did it completely. `#extPane` and `#dashPane` are both `position:absolute;
+ * inset:0` with no `z-index`, so DOM order alone decides, and `#dashPane` is second —
+ * meaning an opener that shows the mirror without hiding the dashboard puts it *behind*
+ * a pane that is still fully opaque. Nothing errors, nothing logs, and the header, the
+ * inspector and `--accent` all update correctly, so the click reads as "it only changed
+ * the colours".
+ *
+ * So a caller now says what it wants on screen and this hides the rest:
+ *   • `session` — an Episko pane; the panes themselves carry `.active`
+ *   • `ext`     — the read-only mirror (external OR dormant)
+ *   • `dash`    — the project dashboard
+ *   • `none`    — nothing; the empty card comes back
+ *
+ * `insp-mini` goes with it, and that is not a bolt-on: the 44px inspector rail is a
+ * *dashboard-only* mode (it exists because the dashboard's verbs live nowhere else), so
+ * anything else taking the stage must clear it or the next session inherits a rail
+ * holding the wrong buttons.
+ */
+export type Stage = "session" | "ext" | "dash" | "none";
+export function takeStage(show: Stage) {
+  ($("extPane") as HTMLElement).hidden = show !== "ext";
+  ($("dashPane") as HTMLElement).hidden = show !== "dash";
+  ($("empty") as HTMLElement).style.display = show === "none" ? "grid" : "none";
+  if (show !== "dash") $("app").classList.remove("insp-mini");
+}
+
 // Platform-aware shortcut hints. Display only: the key handlers already accept
 // both modifiers (`e.metaKey || e.ctrlKey`), so only the glyphs differ per OS.
 // Nothing below touches the DOM at module scope, deliberately: ./debug imports this

--- a/src/grouping.ts
+++ b/src/grouping.ts
@@ -24,7 +24,10 @@ import { taskPrefs } from "./tasks";
 // rather than the worktree clusters: a dormant session has no live checkout state
 // to cluster by, and pinning them below the live rows keeps the distinction between
 // "running now" and "was running before" visually obvious.
-export interface ProjGroup { name: string; path: string; accent: string; sessions: Sess[]; externals: ExtSession[]; dormants: Restorable[]; wtBranch?: string }
+/// `repoRoot` is set only on the groups `splitByWorktree` mints — a checkout is not a
+/// project, it is one folder of one. Anything that wants "the project this row belongs
+/// to" reads `repoRoot ?? path`; anything that wants the folder itself reads `path`.
+export interface ProjGroup { name: string; path: string; accent: string; sessions: Sess[]; externals: ExtSession[]; dormants: Restorable[]; wtBranch?: string; repoRoot?: string }
 // A worktree cluster = the sessions of one project that share a checkout dir. Order
 // follows first appearance in the (already-sorted) session list, so the active/
 // attention sort still decides which worktree floats up. The repo-root checkout
@@ -88,7 +91,10 @@ export function splitByWorktree(list: ProjGroup[]): ProjGroup[] {
     // Keep the root group only when it carries something — root-checkout rows or a
     // favourite (a launch target). Drops the phantom empty root of a worktree-only repo.
     if (root || FAVORITES.some((f) => f.path === p.path)) out.push({ ...p, sessions: root?.sessions ?? [], externals: root?.externals ?? [] });
-    for (const c of wts) out.push({ name: p.name, path: c.key, accent: p.accent, sessions: c.sessions, externals: c.externals, dormants: [], wtBranch: c.branch });
+    // `repoRoot` is what the group was split OUT of. Splitting drops it otherwise, and
+    // then nothing downstream can get back to the project — which is how a worktree
+    // group's dashboard came to be keyed by its checkout dir and show no sessions at all.
+    for (const c of wts) out.push({ name: p.name, path: c.key, accent: p.accent, sessions: c.sessions, externals: c.externals, dormants: [], wtBranch: c.branch, repoRoot: p.path });
   }
   return out;
 }

--- a/src/mirror.ts
+++ b/src/mirror.ts
@@ -13,7 +13,7 @@
 // always lists every session for a folder, so nothing dropped here is ever lost.
 
 import { invoke } from "@tauri-apps/api/core";
-import { $, toast } from "./dom";
+import { $, takeStage, toast } from "./dom";
 import { dlog } from "./debug";
 import { basename, esc, relTime, tilde } from "./format";
 import { probeIcon } from "./icons";
@@ -94,11 +94,11 @@ export async function refreshExternals() {
         setMirror({ kind: "ext", id: e.session_id, pid: e.pid });
         renderExtHeader(e); renderExtInspector(e);
       } else {
-        // Truly gone — fall back to an Episko session or the empty state.
+        // Truly gone — fall back to an Episko session, or to the empty card, which
+        // `closeExternalView` has already dropped the stage to.
         closeExternalView();
         const next = orderedSessions()[0];
         if (next) setActive(next.id);
-        else ($("empty") as HTMLElement).style.display = "grid";
       }
     }
     renderSidebar(); renderMini();
@@ -148,8 +148,7 @@ export function openExternal(sid: string) {
   setMirror({ kind: "ext", id: sid, pid: e.pid });
   setActiveId(null);
   for (const x of sessions.values()) x.pane.classList.remove("active");
-  ($("empty") as HTMLElement).style.display = "none";
-  ($("extPane") as HTMLElement).hidden = false;
+  takeStage("ext");
   document.documentElement.style.setProperty("--accent", accentFor(e.cwd));
   renderExtHeader(e); renderExtInspector(e); renderSidebar(); renderMini(); renderFoot();
   $("extBody").innerHTML = `<div class="ext-empty">Loading transcript…</div>`;
@@ -168,11 +167,14 @@ export function closeExternalView() {
   if (mirror == null) return;
   setMirror(null);   // clears the ext pid with it — one pointer, one lifetime
   clearInterval(extTranscriptTimer);
-  ($("extPane") as HTMLElement).hidden = true;
   // The dashboard rides the same pointer, so it has the same lifetime: whatever took
-  // the stage just replaced it. Hidden here rather than through ./dashboard so this
-  // module keeps no dependency on it — one `hidden` flag is not worth an import edge.
-  ($("dashPane") as HTMLElement).hidden = true;
+  // the stage just replaced it. `takeStage` is what keeps this module free of a
+  // ./dashboard dependency — it lives in ./dom, which everything may import.
+  //
+  // `none` rather than `session`: every caller either activates a session immediately
+  // after (which re-takes the stage) or wants the empty card, and this one cannot tell
+  // which without importing state it has no other use for.
+  takeStage("none");
 }
 // ---------- dormant (restorable) sessions ----------
 // Clicking a dormant row mirrors its transcript read-only — the same pane an
@@ -184,8 +186,7 @@ export function openDormant(id: string) {
   setMirror({ kind: "past", id });
   setActiveId(null);
   for (const x of sessions.values()) x.pane.classList.remove("active");
-  ($("empty") as HTMLElement).style.display = "none";
-  ($("extPane") as HTMLElement).hidden = false;
+  takeStage("ext");
   clearInterval(extTranscriptTimer); // a finished transcript doesn't grow — no polling
   document.documentElement.style.setProperty("--accent", accentFor(d.colorKey));
   renderPastHeader(d); renderPastInspector(d); renderSidebar(); renderMini(); renderFoot();
@@ -230,10 +231,11 @@ export function resumeDormant(id: string) {
 export function forgetDormant(id: string) {
   setDormants(dormants.filter((x) => x.id !== id));
   if (pastMirrorId() === id) {
+    // The empty card is where `closeExternalView` leaves the stage, so only the
+    // "there is a session to fall back to" case needs saying.
     closeExternalView();
     const next = orderedSessions()[0];
     if (next) setActive(next.id);
-    else ($("empty") as HTMLElement).style.display = "grid";
   }
   flushRoster();
   renderAll();

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -20,7 +20,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
-import { $, toast } from "./dom";
+import { $, takeStage, toast } from "./dom";
 import { dlog } from "./debug";
 import { basename, esc, tilde } from "./format";
 import {
@@ -289,7 +289,7 @@ export function closeSession(id: string) {
     setActiveId(null);
     if (next) { setActive(next.id); return; }
     document.documentElement.style.setProperty("--accent", "#a78bfa");
-    ($("empty") as HTMLElement).style.display = "grid";
+    takeStage("none");
   }
   renderAll();
 }
@@ -298,9 +298,12 @@ export function closeSession(id: string) {
 export function setActive(id: string) {
   const s = sessions.get(id);
   if (!s) return;
+  // The pointer and the transcript timer, then the panes: `closeExternalView` owns the
+  // first pair, `takeStage` the second. It is called after, not instead — that one drops
+  // the stage to the empty card, which this immediately replaces with the pane.
   closeExternalView();
   setActiveId(id);
-  ($("empty") as HTMLElement).style.display = "none";
+  takeStage("session");
   for (const x of sessions.values()) x.pane.classList.toggle("active", x.id === id);
   document.documentElement.style.setProperty("--accent", accentFor(s.colorKey));
   if (s.term && s.fit) {

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -86,18 +86,33 @@ export function renderSidebar() {
     const dirty = p.sessions.some((s) => folderDirty(s.workdir)) || p.externals.some((e) => folderDirty(e.cwd));
     const dot = dirty ? `<span class="pdirty" title="Uncommitted changes in this project"></span>` : "";
     const wtSuffix = p.wtBranch ? `<span class="pwt">· ${esc(p.wtBranch)}</span>` : "";
+    // **Every project header opens the dashboard, whatever put it in the list.** It used
+    // to depend on which of the three shapes below a project happened to land in, so a
+    // folder Episko only knew about from an external session, from a past one, or from a
+    // worktree whose session had ended was simply not clickable — with no disabled state
+    // to say so, because the attribute was absent rather than refused. "Has an Episko
+    // session or is a favourite" is not a fact about a project worth having a view gated
+    // on; the empty-but-real dashboard those folders get is the answer.
+    //
+    // Keyed to `repoRoot ?? path`: a checkout is not a project. `dashDays` filters
+    // history by `histProject().colorKey`, which regrafts every row onto the repo root —
+    // so a dashboard keyed by a worktree dir matches no sessions at all and renders a
+    // timeline of commits with nobody having worked on them. The checkouts are a card
+    // *inside* the project's dashboard, which is where a worktree belongs.
+    const dashRoot = p.repoRoot ?? p.path;
+    const opens = `data-dash="${esc(dashRoot)}" data-proj="${esc(p.name)}"`;
     let head: string;
     if (p.sessions.length) {
-      head = `<div class="phead" data-dash="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}${wtSuffix}</span>${dot}<span class="pcount">${total}</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}">＋</span><span class="parm"></span></div>`;
+      head = `<div class="phead" ${opens} data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}${wtSuffix}</span>${dot}<span class="pcount">${total}</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}">＋</span><span class="parm"></span></div>`;
     } else if (isFav) {
       const tail = p.externals.length ? `<span class="pcount ext">${p.externals.length} ext</span>` : `<span class="plaunch">open →</span>`;
-      head = `<div class="phead empty-p" data-dash="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="premove" data-remove="${esc(p.path)}" title="Remove project">✕</span><span class="parm"></span></div>`;
+      head = `<div class="phead empty-p" ${opens} data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="premove" data-remove="${esc(p.path)}" title="Remove project">✕</span><span class="parm"></span></div>`;
     } else {
       // discovered via an external session or a restorable one only — not a saved project
       const tail = p.externals.length
         ? `<span class="pcount ext">${p.externals.length} ext</span>`
         : `<span class="pcount ext">${p.dormants.length} past</span>`;
-      head = `<div class="phead ext-only" data-key="${esc(p.path)}" title="${esc(tilde(p.path))}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" title="Launch an Episko session here">＋</span><span class="parm"></span></div>`;
+      head = `<div class="phead ext-only" ${opens} data-key="${esc(p.path)}" title="${esc(tilde(p.path))}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}${wtSuffix}</span>${dot}${tail}<span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" title="Launch an Episko session here">＋</span><span class="parm"></span></div>`;
     }
     return `<div class="pgroup" data-path="${esc(p.path)}">${head}${rows ? `<div class="psessions">${rows}</div>` : ""}${peekBody(p)}</div>`;
   }).join("");

--- a/src/styles.css
+++ b/src/styles.css
@@ -1269,14 +1269,17 @@ select.in-ctl { cursor: pointer; }
 
 /* loading state while the (off-thread) transcript token scan runs */
 .u-spin { width: 11px; height: 11px; border-radius: 50%; border: 1.5px solid var(--hair-strong); border-top-color: var(--accent); display: inline-block; vertical-align: -1px; margin-right: 5px; animation: u-spin .7s linear infinite; }
-.u-skel, .u-skelbar { background: linear-gradient(90deg, var(--surface-2) 25%, color-mix(in srgb, var(--hair-strong) 60%, var(--surface-2)) 37%, var(--surface-2) 63%); background-size: 400px 100%; border-radius: 6px; animation: u-shimmer 1.25s ease-in-out infinite; }
+/* `.db-sk` is the dashboard's, and it lives here rather than with the rest of that pane
+   so the shimmer stays one declaration: two loading vocabularies in one app is two
+   things to keep in step, and they drift in the direction of looking like two bugs. */
+.u-skel, .u-skelbar, .db-sk { background: linear-gradient(90deg, var(--surface-2) 25%, color-mix(in srgb, var(--hair-strong) 60%, var(--surface-2)) 37%, var(--surface-2) 63%); background-size: 400px 100%; border-radius: 6px; animation: u-shimmer 1.25s ease-in-out infinite; }
 .u-skel { display: inline-block; height: 16px; width: 78px; vertical-align: -2px; }
 .u-skelbar { display: block; height: 12px; width: 100%; margin-top: 9px; }
 @keyframes u-spin { to { transform: rotate(360deg); } }
 @keyframes u-shimmer { 0% { background-position: 200px 0; } 100% { background-position: -200px 0; } }
 @media (prefers-reduced-motion: reduce) {
   .u-spin { animation: none; border-top-color: var(--accent); }
-  .u-skel, .u-skelbar { animation: none; }
+  .u-skel, .u-skelbar, .db-sk { animation: none; }
 }
 
 @media (max-width: 900px) {
@@ -1665,6 +1668,19 @@ select.in-ctl { cursor: pointer; }
 .db-spine { min-width: 0; padding: 15px 17px 26px; overflow-y: auto; }
 .db-aside { min-width: 0; border-left: 1px solid var(--hair); background: color-mix(in srgb, var(--panel) 55%, transparent); padding: 12px 12px 20px; overflow-y: auto; display: flex; flex-direction: column; gap: 10px; }
 .db-empty { padding: 18px 6px; max-width: 48ch; font-size: 12px; line-height: 1.6; color: var(--muted-2); }
+
+/* skeletons — drawn in the geometry of whatever replaces them, so an answer landing is
+   a substitution and not a jump. The shimmer itself is `.u-skel`'s, declared once up in
+   the usage screen's block, and `.u-spin` is borrowed whole. */
+.db-sk { display: inline-block; vertical-align: middle; border-radius: 4px; }
+.db-skhint { display: flex; align-items: center; gap: 2px; padding: 15px 6px 0; font-size: 11.5px; color: var(--muted-2); }
+/* A skeleton card has no rows to reach, so it must not offer the hover of one. */
+.ac.sk { pointer-events: none; }
+/* The waiting mark on a summary. It sits beside a headline that is already correct, so
+   it is the only thing moving. `pulse` is the app's existing "something is happening"
+   keyframe (see `.g-work`) and is declared inside a no-preference query, so reduced
+   motion leaves this static with no second rule to remember. */
+.db-sum .ai.wr { color: var(--accent-ink); animation: pulse 1.5s ease-in-out infinite; }
 
 /* the timeline: the summary IS the row, every commit one ⌄ away */
 .db-day { display: grid; grid-template-columns: 56px minmax(0, 1fr); gap: 12px; }

--- a/test/grouping.test.ts
+++ b/test/grouping.test.ts
@@ -216,6 +216,23 @@ describe("splitByWorktree — toplevel mode explodes a multi-checkout project", 
     expect(out[0].wtBranch).toBeUndefined();      // the root keeps the project's identity
     expect(out[1]).toMatchObject({ name: "epi", accent: "#fff", wtBranch: "feature" });
   });
+  it("carries the repo root onto every worktree group, and onto no other", () => {
+    // A checkout is not a project, and splitting is the only thing that severs the two.
+    // The sidebar's project header opens `repoRoot ?? path`, so losing it here keys a
+    // worktree's dashboard by its checkout dir — where `histProject` regrafts every
+    // history row onto the repo root, so the timeline matches no sessions at all.
+    const p = grp({ sessions: [
+      sess({ id: "a", workdir: "/w/epi", branch: "main" }),
+      sess({ id: "b", workdir: "/w/wt", branch: "feature" }),
+    ] });
+    const out = splitByWorktree([p]);
+    expect(out[0].repoRoot).toBeUndefined();   // the root group IS the project
+    expect(out[1].repoRoot).toBe("/w/epi");
+  });
+  it("leaves an unsplit project without a repoRoot, so `repoRoot ?? path` is its own path", () => {
+    const p = grp({ sessions: [sess({ id: "a", workdir: "/w/epi" })] });
+    expect(splitByWorktree([p])[0].repoRoot).toBeUndefined();
+  });
   it("drops the phantom root of a worktree-only repo", () => {
     const p = grp({ sessions: [sess({ id: "b", workdir: "/w/wt", branch: "feature" })] });
     expect(names(splitByWorktree([p]))).toEqual(["/w/wt"]);


### PR DESCRIPTION
Opening a project costs a whole-machine transcript scan, three git calls and — on a GitHub repo — two `gh` calls after those. None of it showed: the strip led with a confident row of zeros, the aside was simply short a card or two, and a folder still being read looked exactly like a folder with nothing in it.

Three parts, one theme — what the dashboard is doing, and what it can be reached from. Two of the three started as "why does it do X?" and turned out to be bugs.

## 1 — Skeletons

`pulseSkeleton` / `spineSkeleton` / `cardSkeleton` in `dashview.ts`, each drawn in the geometry of what replaces it, so the answer landing is a substitution and not a jump.

| Wait | Before | Now |
| --- | --- | --- |
| Local reads (facts, transcript scan, `git log`, worktree probe, digest) | a **row of zeros** and one line of text | skeleton tiles, three day-shaped rows + spinner line, one skeleton card |
| The GitHub half (fires *after* the above) | **entirely silent** — the card was simply not there | skeleton card in the slot it will occupy |
| A day's generated sentence | silently upgraded when it landed | `· writing` beside the headline; shared box skeletoned during the stage that fills it |

The waits are deliberately separate flags — `loading`, `ghLoading`, `factsKnown`, `writing`/`stage`. Each starts and ends at a different moment and darkens a different surface; one `isLoading` over the lot would skeleton something that already has its answer. `factsKnown` in particular is *not* `loading`: a range change reloads the timeline without putting the tier back in doubt, and blanking the repo verbs for it would be a flicker that says nothing.

A pending sentence is not an absent one. Your day already has a deterministic headline that reads correctly, so waiting is a mark *beside* it — replacing readable text with a grey bar to promise a nicer one is a bad trade. The shared box has no stand-in, so that one is a real skeleton. Shimmer and spinner are the usage screen's `.u-skel` / `.u-spin`, extended by selector rather than redeclared.

**Two `loadDash` bugs found on the way:**

- Clicking project A → B kept A's `tier`, `gh`, `kept`, `shared` and `hasDigest` for a frame, so a repository could flash *not a repo* and lose its ⑃ and ⑂ verbs.
- Every write after both awaits was unguarded, so a stale continuation landed the previous folder's answers under the new folder's name — and would have cleared the new load's skeletons while it was still running. Now guarded by `root() !== r`, `loading` included.

## 2 — One owner for the stage

Reported as *"clicking an external session doesn't switch to it, it just recolours the dashboard"*, which is exactly what it did.

`#extPane` and `#dashPane` are both `position:absolute; inset:0` with **no `z-index`**, so DOM order alone decides and `#dashPane` is second. `openExternal` showed the mirror but never hid the dashboard, loading the transcript *behind* a fully opaque pane — while the header, inspector and `--accent` all updated correctly. Confirmed in the browser: both `z-index: auto`, and `elementFromPoint` at the stage centre returns `dashPane`.

Root cause: four openers each hid their rivals by hand and **only two did it completely**. Two more of the same family, unreported:

- dashboard → **dormant** session had the identical omission
- leaving a ⌘I-collapsed dashboard carried the 44px rail onto the next session, holding the wrong buttons — the exact thing `closeDashboard`'s comment says it exists to prevent
- closing the dashboard with nothing running left a **blank stage**; `renderAll` never touches `#empty`

So `takeStage(show)` in `dom.ts` — `"session" | "ext" | "dash" | "none"` — is now the only thing that may touch those four elements. It lives in the leaf module so every opener calls it with no new import edge; `mirror.ts` still needs no `./dashboard` dependency, which is the trade its old comment was protecting.

## 3 — Every project header opens its dashboard

Reported as *"why can I only open the dashboard when there's a session in the project?"* The real rule was "has an Episko session **or** is a favourite": `renderSidebar` builds three header shapes and only two carried `data-dash`. So a folder known only from an external session, only from past sessions, or from a worktree whose session had ended was inert — with nothing greyed to say why, because the attribute was absent rather than refused. `tsc` and every test pass either way; only clicking finds out.

Headers now key to **`repoRoot ?? path`**, because a checkout is not a project. `dashDays` filters history through `histProject`, which regrafts every row onto the repo root — so a dashboard keyed by a worktree dir matches **no sessions at all** and renders a timeline of commits nobody appears to have worked on. That was already live on any worktree group with a session. `splitByWorktree` is the only thing that severs a group from its project, so it now carries `repoRoot`.

## Verification

- `pnpm exec tsc --noEmit` clean; **646 vitest** (up from 644 — two new tests pinning `repoRoot`, since the sidebar itself is untested by design)
- `changelog check` passes
- Skeletons rendered in a throwaway vite page and checked in **dark and light** themes; reduced motion covered (bars go static, and `· writing` uses the existing `pulse` keyframe, itself declared inside a `no-preference` query)
- All four `takeStage` transitions driven against the real module in a browser
- All three header click paths driven against the dispatcher's actual selector and branch precedence — ＋ and ✕ still win over the row

`CLAUDE.md` updated with all three invariants, including why neither the type checker nor a unit test can catch the stacking one.

**Not verified:** none of this has run in the real app under Tauri. The pane/IPC layer is the thinnest ice in the codebase, so a `RELEASE.md`-style click-through — open a project with a cold `gh`, watch the three phases land, then click an external session out of it — is worth doing before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
