### PR TITLE
Group projects in the sidebar, and collapse a group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
++ **Projects can be grouped, and a group folds away.** Name a set of projects — *Work*,
+  *Side* — and collapse it to a single line when you are not in it. Right-click a project
+  for *Add to group…*, or drag it onto a group the way you already drag one to reorder;
+  right-click the group's own heading to rename, fold, or delete it. A group has no
+  order of its own: it sits where its first project sits, so the sort you picked still
+  decides the rail and dragging a project takes its group with it.
++ **A folded group still says when something in it needs you.** The heading carries the
+  status glyph of the most urgent session it is hiding and a dot for uncommitted changes,
+  because a tidy-up that could bury a session waiting on a permission would be a trap.
+  ⌘1–9 still reaches into a folded group, and taking a session in one onto the stage
+  unfolds it rather than leaving the rail with nothing selected.
 + **A day now gets two sentences: yours, and the project's.** The one on the timeline is
   still your day — your sessions, your spend. Above it, on days more than one person
   committed, sits a second line describing what the *project* did, written from the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,9 @@ Mac has the same symlink — but it is one both legs will find at once.
 
 **Package manager: `pnpm`** for this repo (there's a `pnpm-lock.yaml`; both CI workflows use `pnpm install --frozen-lockfile`, and `packageManager` in `package.json` pins the version for corepack/CI). Use pnpm here, not npm. Windows code-signing / release-signing setup lives in `src-tauri/SIGNING.md`.
 
-Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **644 vitest + cargo (144 on macOS, 141 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
+Test coverage is **unit-only — there is no end-to-end harness**, but it is no longer thin: **686 vitest + cargo (144 on macOS, 141 on Windows — the platform tests are `cfg`-gated)**, both run in CI on both OSes.
 
-**vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which nineteen those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
+**vitest runs in the `node` environment, so no module a test can reach may touch a browser global at module scope.** Not just `document`/`window`: `globalThis.navigator` only exists from **Node 21**, so a bare `navigator.userAgent` at module scope killed every suite that transitively imported that file back when CI pinned Node 20 — while passing on a dev machine with a newer Node. Node is now pinned once in **`.nvmrc`** (26) and read from there by both workflows and `nvm use`, so CI and local cannot drift again; the guard stays regardless, because the rule is about the `node` environment, not about which Node. Platform predicates therefore live in `dom.ts` (`IS_MAC`, `IS_WIN`), read once through a `typeof navigator === "undefined"` guard; import those rather than reading `navigator` again. `vitest` covers the pure frontend logic modules (`test/*.test.ts`, one file per module — see the frontend module map below for which twenty those are); the Rust tests are `#[cfg(test)] mod tests` **in-file**, next to their subject, several of them real integration tests that drive `git` against temp repos or the real `tiny_http` telemetry server against a mock app. There is deliberately no `src-tauri/tests/` directory: it would only see the crate's public API, which here is `run()`.
 
 What is **untested by design**: the render, view and DOM-owning modules on both sides of the app — snapshotting template literals mostly re-asserts itself. Anything touching the DOM, PTYs, or live telemetry is still verified by **running the app and exercising it** — the statusLine half of telemetry only fires in interactive mode, so it cannot be checked end to end with `claude -p`. Split that one carefully, because the split is not where it looks: whether the generated statusLine command *works* is checked headlessly and in CI (the shell runs it for real — see the constraint above). What needs a live REPL is only whether **Claude still picks the shell and payload we expect**. That costs a TTY, not tokens: a session you launch and never prompt makes no API call, and the statusLine fires on start and every `refreshInterval` seconds regardless. It's a `RELEASE.md` click-through, and a cheap one. `tsc` (strict) is the real linter. Requires `claude` on PATH, the Node in `.nvmrc` (`nvm use`; `engines` floors it at 24), and Rust stable + Tauri system deps.
 
@@ -607,13 +607,13 @@ Four conventions hold across them:
 - **Telemetry server** (`run_telemetry_server`) forwards `/hook` and `/statusline` POSTs as one `telemetry` event each; `/permission` is the blocking path described above.
 - Commands are registered in the `invoke_handler![...]` list at the bottom of `run()` — add new `#[tauri::command]` fns there.
 
-## Frontend (`src/`, `index.html`, `src/styles.css`) — 49 modules
+## Frontend (`src/`, `index.html`, `src/styles.css`) — 50 modules
 
-**No framework, and no longer one file.** ~13065 lines across 49 modules; `main.ts` is 777 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
+**No framework, and no longer one file.** ~13700 lines across 50 modules; `main.ts` is 784 of them and is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly.
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (~70 lines — it is the seam map, and belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, the window controls (see One title bar), and the seven `setInterval`s.
 
-**Tested logic modules** (nineteen — no DOM, no Tauri, no render imports; these are what the 644 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
+**Tested logic modules** (twenty — no DOM, no Tauri, no render imports; these are what the 686 vitest tests cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it):
 
 | Module | What |
 | --- | --- |
@@ -630,6 +630,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 | `gitwatch.ts` | `gitMutates` — whether a shell command an agent ran is worth re-reading git for; `driftTarget`/`driftUpdate` — which checkout its work has moved to, from writes *and* `cwd` |
 | `graph.ts` | the commit graph: `layoutGraph`'s lanes, what names a lane (`lineRef`, `lineTip`), `parseRefs`, the geometry and `rowSvg` |
 | `peek.ts` | the sidebar's hover-to-reveal: what arms, what cancels, what the next deadline is |
+| `projgroups.ts` | the user's named groups of projects: the store, its repair, and every mutation of it |
 | `trail.ts` | a day of work assembled from transcripts, git and the usage rollup; `dayFacts` (yours) and `projectDayFacts`/`sharedDay` (the team's) |
 | `notes.ts` | the one thing on the dashboard you type — capture, filing, removal |
 | `dash.ts` | the project dashboard's rules: `projectTier`, `dashDays`, `dashPulse`, `projectCost` |
@@ -645,7 +646,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 
 **Behaviour** — IPC and DOM all the way down, so untested too, and therefore the thinnest ice in the app: `panes` (the three spawners + a pane's lifecycle), `terminal` (the xterm plumbing), `taskrun` (run on stop), `actions` (the app-level verbs), `icons` (the per-project glyph store).
 
-Four rules keep that graph honest. **There are no import cycles across the 49 modules; re-run a cycle check after any change that adds an import.**
+Four rules keep that graph honest. **There are no import cycles across the 50 modules; re-run a cycle check after any change that adds an import.**
 
 - **Dependency direction is state ← render ← wiring.** A logic module must not import render code or `main.ts`.
 - **When an extracted function needs something that lives further up**, resolve it in this order: (1) **move the callee down too** if it is itself leaf-shaped — that is why `icons.ts` sits below `sidebar.ts` and `usage.ts` below `phase.ts`; (2) **a settable hook defaulting to a no-op** (`setRlLogger`, `setPanesRenderAll`) when the callee genuinely belongs to the render layer; (3) **an extra parameter** only as a last resort, since it changes a signature the move was supposed to leave alone. A control panel touching many things it doesn't own may take **one host object** instead of N setters (`settings`, `palui`, `projmenu`); prefer per-callee setters below ~4.
@@ -708,7 +709,7 @@ And the things that hold however the files are arranged:
 - **Event wiring**: `listen("pty-output" | "pty-exit" | "telemetry" | "permission" | "tray-select")` at the bottom of `main.ts`. Telemetry is routed by `data.session_id?.toLowerCase()` — session ids are matched case-insensitively, so keep them lowercase.
 - `applyHook` maps lifecycle events → a `Phase` state machine (idle/thinking/working/done/error/ended) and attention flags; `applyStatusline` fills model/context%/cost/duration. **Rate limits are account-wide**, held in a single `rl` object and shown identically on every session, not per-session.
 - **A turn that died is not a turn that finished, and only one hook knows which.** Claude Code fires `StopFailure` (not `Stop`) when the API kills a turn — a 529, a rate limit, a dead key — carrying an `error` enum (`overloaded`, `rate_limit`, `authentication_failed`, `max_output_tokens`, …) and the `error_details` text the pane shows. Everything *after* that point looks identical to a clean finish: the same 60-second idle `Notification` (`notification_type: "idle_prompt"`) arrives either way. Unguarded it relabelled the turn "your turn" and turned the red ✕ green a minute after the failure — which shipped, and is why `Sess.apiErr` exists. It is set by `StopFailure`, cleared only when the session genuinely starts another turn (`UserPromptSubmit` / `PreToolUse` / `SessionStart` / `SessionEnd`), and **`endTurn` is the single place that decides done vs. error** — both `Stop` and the idle nudge go through it, and the run-on-stop rule is skipped while it's set. Every surface that spells a state out reads `phaseText(s)`, not `PILL_TEXT[s.phase]`, so the reason travels with the glyph: "API overloaded" means wait, "auth failed" means go fix your credentials, and a bare ✕ means neither.
-- **Persistence is all `localStorage`**, ~20 keys prefixed `cc-` (favorites, drag order, colours, icons, engine, permission mode, font size, sort/grouping, frecency, caffeinate, the `cc-usage` daily cost rollup and its `cc-cost-base` per-conversation baselines, the `cc-restore` roster, the sidebar's `cc-peek`, *What's new*'s `cc-seen-versions`, the dashboard's `cc-dash-*` and `cc-digest-ok`, and the task keys `cc-task-{prefs,pins,hidden,onstop,runner,inputs}` + `cc-trusted`). `grep '"cc-'` for the current set.
+- **Persistence is all `localStorage`**, ~20 keys prefixed `cc-` (favorites, drag order, colours, icons, engine, permission mode, font size, sort/grouping, frecency, caffeinate, the `cc-usage` daily cost rollup and its `cc-cost-base` per-conversation baselines, the `cc-restore` roster, the sidebar's `cc-peek` and `cc-proj-groups`, *What's new*'s `cc-seen-versions`, the dashboard's `cc-dash-*` and `cc-digest-ok`, and the task keys `cc-task-{prefs,pins,hidden,onstop,runner,inputs}` + `cc-trusted`). `grep '"cc-'` for the current set.
 - **Debug console** (🐞 button, bottom-right): an in-app event log + live state via `dlog()`/`dbgSnapshot()`. It flags **unrouted telemetry** (the routing-drift class of bug above) and JS errors, and mirrors a snapshot to `$TMPDIR/cc-launcher/episko-debug.json` (written by the `write_debug_file` command) so an external tool or an LLM agent can read live app state while it runs.
 - **Two-tier logging — live snapshot vs. durable timeline.** The `episko-debug.json` snapshot is a *state-of-now* blob that is overwritten each flush and does **not** survive a crash (the frontend never flushes if the process dies). The durable tier is the backend rolling `episko.log` (+ `panic.log`) in the OS app-log dir (macOS `~/Library/Logs/io.respeak.episko/`), via `tauri-plugin-log` and a panic hook — the only on-disk trace of a panic that unwinds cleanly out of `main` (no crash dump / WER otherwise). Every `dlog()` line tees into it through the `log_frontend` command (tagged `[ui]`), so the UI and backend event streams land in **one time-ordered file**. A `episko.log` that stops without an `exit · clean shutdown` line is itself evidence of an abnormal termination. Use the snapshot for "what is it doing *now*", the rolling log for "why did it *die*".
 
@@ -827,6 +828,48 @@ It closes the Episko sessions living there (the backend refuses while one runs),
 **refuses outright when an external session is in the checkout**: the backend can't see
 one, so `git worktree remove` would delete the folder out from under an agent in someone
 else's terminal. The menu says so on the row rather than letting the click fail.
+
+## Project groups — the user's own headings over the rail
+
+A named, collapsible fold holding several projects (`projgroups.ts` owns the store and
+is pure and tested; `grouping.ts`'s `groupedProjects` turns it into what the rail draws;
+`sidebarview.foldHead` is the markup; `sidebar.ts` owns the element and the drag). Made
+from a project's right-click → *Add to group…*, or by dragging a project onto one.
+
+- **A group is not an ordering, and that is the whole design.** It holds a name, a
+  collapsed flag and a set of paths. Where it *sits* is derived — the position of its
+  first member under whichever sort is active — so there is no second order to keep in
+  step with `cc-proj-order`, dragging a project takes its group with it, and a group
+  floats up in the attention sort exactly when one of its projects does. Persisting a
+  group order as well is the thing to not do here: the two would disagree within a day.
+- **`.pf*`, never `.pg*`.** `.pgroup` (a project) and `.pgpeek` (its idle checkouts) live
+  *inside* a fold, and `applyPeek`, the peek hover and the reorder all reach for
+  `.pgroup` by class. Same trap as the commit graph's `gc-*`/`gco-*`, same fix.
+- **Collapsed IS in the markup, unlike peek's hover.** Peek stays out of the string
+  because a mouse move would shred `renderSidebar`'s byte-identical cache; a collapse is
+  one deliberate click, so it costs one 7ms repaint and in exchange the state cannot be
+  lost by a re-render. The members are rendered either way — `grid-template-rows: 0fr →
+  1fr` needs content to have a height to animate to, and the 0fr row is also what makes a
+  collapsed group's rows un-clickable and invisible to `elementFromPoint`.
+- **Folding must never fold away urgency.** A collapsed header carries `groupSummary`'s
+  most-urgent glyph and a dirty dot; ⌘1–9 still reaches inside (`orderedSessions` walks
+  the *grouped* order, or ⌘4 would mean the fourth session in an order nothing is in);
+  and `setActive` calls `revealProjGroup` so landing on a session in a folded group
+  unfolds it rather than leaving the rail with nothing selected.
+- **The drag reads membership back off the DOM**, in the same pass as the order, because
+  they are one arrangement (`saveSidebarArrangement`). Two things it must keep doing: the
+  marker goes into the *drop target's parent* (inserting into `#projects` throws once the
+  reference node is a fold's child), and memberships for projects **not on screen** are
+  carried over untouched — in toplevel mode a repo can render only as its worktrees, so
+  rebuilding `of` from scratch would silently unfile it on the next drag.
+- **An empty group is kept, and lands at the end** — it has no member to be ranked by. It
+  is a heading someone named and the drop target that refills it; vanishing on the last
+  removal would read as Episko having deleted it.
+- **A menu row that re-renders `#ctxMenu` must stop the click there** (`keepMenuOpen`).
+  main.ts's outside-click closer asks `t.closest("#ctxMenu")` of the original target, and
+  after an `innerHTML` swap that node is detached, answers null, and closes the menu that
+  was just opened. Appearance never hit this because it only adds a class; every
+  drill-down here re-renders, and this cost the picker its first run.
 
 ## Drift — the agent left the checkout it was launched in
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -20,13 +20,17 @@ import { renderSettings } from "./settings";
 import { waitForExit } from "./tasks";
 import { queueRosterSave } from "./mirror";
 import {
-  dashMirror, FAVORITES, markWorkdirStale, peekPrefs, permMode, permModeDef,
-  saveFavorites, sessions, termEngine,
+  dashMirror, FAVORITES, markWorkdirStale, peekPrefs, permMode, permModeDef, projGroups,
+  saveFavorites, saveProjGroups, sessions, termEngine,
   setFavorites, setPeekPrefs as setPeekPrefsState, setPermMode as setPermModeState,
-  setSortMode, SORT_META, SORT_MODES,
+  setProjGroups, setSortMode, SORT_META, SORT_MODES,
   sortMode, setWtGroup as setWtGroupState, wtGroup,
   type SortMode, type WtGroup,
 } from "./state";
+import {
+  assignGroup, cleanGroupName, collapseAll, createGroup, deleteGroup, groupById,
+  renameGroup, setCollapsed, type GroupStore,
+} from "./projgroups";
 import type { PeekPrefs } from "./peek";
 import type { PermMode } from "./types";
 
@@ -112,6 +116,48 @@ export function setPeekPrefs(p: PeekPrefs) {
   renderSidebar();
   renderSettings(); // the live preview in the Worktrees tab reads these values
 }
+
+// ---------- the user's named groups of projects ----------
+// The same shape as everything else here (./projgroups computes, this persists and
+// repaints), with one addition worth keeping: every mutator in ./projgroups returns the
+// store it was handed when there is nothing to do, so a no-op costs neither a write nor
+// a 7ms sidebar repaint. `renderSidebar` rather than `renderAll` — nothing else in the
+// app shows a group, deliberately (see `renderMini`).
+function commitProjGroups(next: GroupStore) {
+  if (next === projGroups) return;
+  setProjGroups(next);
+  saveProjGroups();
+  renderSidebar();
+}
+export function setProjectGroup(path: string, gid: string | null) {
+  const to = gid ? groupById(projGroups, gid) : null;
+  commitProjGroups(assignGroup(projGroups, path, gid));
+  toast(to ? `Moved to ${to.name}` : "Removed from group");
+}
+export function newProjectGroup(name: string, path: string) {
+  const clean = cleanGroupName(name);
+  if (!clean) { toast("Give the group a name first"); return; }
+  commitProjGroups(createGroup(projGroups, clean, [path]));
+  toast(`Grouped under ${clean}`);
+}
+export function renameProjectGroup(gid: string, name: string) {
+  const clean = cleanGroupName(name);
+  if (!clean) { toast("A group needs a name"); return; }
+  commitProjGroups(renameGroup(projGroups, gid, clean));
+}
+/// The projects come back to the top level — only the heading goes. Said out loud,
+/// because "delete" next to a list of your repos deserves to be unambiguous.
+export function deleteProjectGroup(gid: string) {
+  const g = groupById(projGroups, gid);
+  if (!g) return;
+  commitProjGroups(deleteGroup(projGroups, gid));
+  toast(`Ungrouped ${g.name} — the projects stay`);
+}
+export function toggleProjGroup(gid: string) {
+  const g = groupById(projGroups, gid);
+  if (g) commitProjGroups(setCollapsed(projGroups, gid, !g.collapsed));
+}
+export function collapseAllProjGroups(collapsed: boolean) { commitProjGroups(collapseAll(projGroups, collapsed)); }
 
 // Which permission mode the NEXT session launches in — the same shape as the sort and
 // the grouping above (state assigns, this persists and announces). Announced rather

--- a/src/grouping.ts
+++ b/src/grouping.ts
@@ -14,9 +14,10 @@
 
 import { basename } from "./format";
 import type { ExtSession, Restorable, Sess } from "./types";
+import { groupOf, type GroupDef } from "./projgroups";
 import {
-  accentFor, dormants, externals, FAVORITES, projOrder, sessions, sortMode, wtGroup,
-  worktreesByRepo,
+  accentFor, dormants, externals, FAVORITES, folderDirty, projGroups, projOrder,
+  sessions, sortMode, wtGroup, worktreesByRepo,
 } from "./state";
 import { taskPrefs } from "./tasks";
 
@@ -24,7 +25,10 @@ import { taskPrefs } from "./tasks";
 // rather than the worktree clusters: a dormant session has no live checkout state
 // to cluster by, and pinning them below the live rows keeps the distinction between
 // "running now" and "was running before" visually obvious.
-export interface ProjGroup { name: string; path: string; accent: string; sessions: Sess[]; externals: ExtSession[]; dormants: Restorable[]; wtBranch?: string }
+// `wtRoot` is set only on the per-worktree groups `splitByWorktree` mints in toplevel
+// mode: their `path` is a checkout dir, so it is the only way back to the repo the
+// user actually filed into a project group.
+export interface ProjGroup { name: string; path: string; accent: string; sessions: Sess[]; externals: ExtSession[]; dormants: Restorable[]; wtBranch?: string; wtRoot?: string }
 // A worktree cluster = the sessions of one project that share a checkout dir. Order
 // follows first appearance in the (already-sorted) session list, so the active/
 // attention sort still decides which worktree floats up. The repo-root checkout
@@ -88,7 +92,7 @@ export function splitByWorktree(list: ProjGroup[]): ProjGroup[] {
     // Keep the root group only when it carries something — root-checkout rows or a
     // favourite (a launch target). Drops the phantom empty root of a worktree-only repo.
     if (root || FAVORITES.some((f) => f.path === p.path)) out.push({ ...p, sessions: root?.sessions ?? [], externals: root?.externals ?? [] });
-    for (const c of wts) out.push({ name: p.name, path: c.key, accent: p.accent, sessions: c.sessions, externals: c.externals, dormants: [], wtBranch: c.branch });
+    for (const c of wts) out.push({ name: p.name, path: c.key, accent: p.accent, sessions: c.sessions, externals: c.externals, dormants: [], wtBranch: c.branch, wtRoot: p.path });
   }
   return out;
 }
@@ -145,6 +149,76 @@ export function projectList(): ProjGroup[] {
   }
   return groups;
 }
+
+// ---------- the user's named groups, folded into that list ----------
+// `projectList()` above answers "which projects, in what order"; this layers the user's
+// own headings over the result without touching either question. ./projgroups owns the
+// store and its rules; this is the one place that turns it into what the rail draws.
+
+/// What the sidebar iterates: either a project on its own, or a named group with the
+/// projects that belong to it. Never nested further — a group holds projects, and a
+/// project is not a group.
+export type SidebarSlot =
+  | { kind: "project"; project: ProjGroup }
+  | { kind: "group"; group: GroupDef; projects: ProjGroup[] };
+
+/// Which group a project belongs to. The `wtRoot` fallback is what keeps toplevel mode
+/// coherent: there the repo has exploded into one group per checkout, and the user
+/// filed the *repo*, so every checkout of it has to answer with the repo's group or a
+/// grouped repo would scatter across the rail the moment you opened a second worktree.
+function foldIdOf(p: ProjGroup): string | null {
+  return groupOf(projGroups, p.path) ?? (p.wtRoot ? groupOf(projGroups, p.wtRoot) : null);
+}
+
+/**
+ * The sidebar's rows, with groups folded in.
+ *
+ * **A group sits where its first member does**, under whichever sort is active — so it
+ * floats up in `active` when one of its projects is busiest, and in `attention` when
+ * one of them needs you, exactly as that project would have on its own. This is why
+ * there is no group order to persist, and why dragging a project drags its group's
+ * position with it: derived, so the two cannot disagree.
+ *
+ * An **empty** group has no member to be ranked by, so it lands after everything else
+ * rather than vanishing. Keeping it is deliberate: it is a heading the user named and
+ * the drop target that refills it, and a group that disappeared the moment you took the
+ * last project out would read as Episko having deleted it.
+ */
+export function groupedProjects(list: ProjGroup[] = projectList()): SidebarSlot[] {
+  const store = projGroups;
+  if (!store.groups.length) return list.map((project) => ({ kind: "project" as const, project }));
+  const slots: SidebarSlot[] = [];
+  const open = new Map<string, ProjGroup[]>();
+  for (const project of list) {
+    const gid = foldIdOf(project);
+    const group = gid ? store.groups.find((g) => g.id === gid) : undefined;
+    if (!group) { slots.push({ kind: "project", project }); continue; }
+    let projects = open.get(group.id);
+    if (!projects) { projects = []; open.set(group.id, projects); slots.push({ kind: "group", group, projects }); }
+    projects.push(project);
+  }
+  for (const group of store.groups) if (!open.has(group.id)) slots.push({ kind: "group", group, projects: [] });
+  return slots;
+}
+
+/// What a group's header has to say for the projects it hides. Only `count` is shown
+/// while the group is open; `dirty` and `urgent` exist for the collapsed state, where
+/// the rule is that folding a group away must never fold away the fact that something
+/// in it is waiting on you.
+export interface GroupSummary { count: number; dirty: boolean; urgent: Sess | null }
+export function groupSummary(projects: ProjGroup[]): GroupSummary {
+  let count = 0, dirty = false, urgent: Sess | null = null;
+  for (const p of projects) {
+    count += p.sessions.length + p.externals.length;
+    if (!dirty) dirty = p.sessions.some((s) => folderDirty(s.workdir)) || p.externals.some((e) => folderDirty(e.cwd));
+    for (const s of p.sessions) {
+      if (!needsYou(s)) continue;
+      if (!urgent || urgencyRank(s) < urgencyRank(urgent) || (urgencyRank(s) === urgencyRank(urgent) && s.phaseSince < urgent.phaseSince)) urgent = s;
+    }
+  }
+  return { count, dirty, urgent };
+}
+
 // How much a session wants the user's attention (lower = more urgent). Shared by
 // the sidebar's "attention" sort and the header reactor.
 export function urgencyRank(s: Sess): number {
@@ -160,7 +234,14 @@ export function urgencyRank(s: Sess): number {
 function projActivity(p: ProjGroup): number { return p.sessions.reduce((m, s) => Math.max(m, s.lastActivity), 0); }
 function projUrgency(p: ProjGroup): number { return p.sessions.reduce((m, s) => Math.min(m, urgencyRank(s)), 99); }
 function projWaitSince(p: ProjGroup): number { return p.sessions.reduce((m, s) => Math.min(m, s.phaseSince), Number.MAX_SAFE_INTEGER); }
-export function orderedSessions(): Sess[] { return projectList().flatMap((p) => p.sessions); }
+// The sidebar read as one flat list — ⌘1–9 and `nextAfterClose`'s fallback. It goes
+// through `groupedProjects`, not `projectList`, because a group physically moves its
+// members: read from the ungrouped list, ⌘4 would land on the fourth session in an
+// order nothing on screen is in. A collapsed group's sessions stay in it (they are
+// still running, and `setActive` unfolds the group it lands in).
+export function orderedSessions(): Sess[] {
+  return groupedProjects().flatMap((s) => (s.kind === "project" ? s.project.sessions : s.projects.flatMap((p) => p.sessions)));
+}
 // When the active session is closed, decide which one takes over. Prefer staying in
 // the same project — the sibling directly above (as shown in the sidebar), else the
 // one below — and only leave the project (nearest session in sidebar order) once it

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,7 @@ import {
   addProject, addProjectPath, cycleSort, effectiveTheme, openProjectFolder,
   followSessionDrift, removeFavorite, resolvePermission, revealActiveFolder,
   copyPath, openTerminalIn, setActionsRenderAll, setPeekPrefs, setPermMode, setSort,
-  setTheme, setWtGroup, toggleInsp,
+  setTheme, setWtGroup, toggleInsp, toggleProjGroup,
   toggleRail, toggleTheme,
 } from "./actions";
 import {
@@ -501,7 +501,7 @@ document.addEventListener("click", (e) => {
   if (dot) { const owner = dot.closest<HTMLElement>("[data-key]"); if (owner?.dataset.key) { openColorPopover(owner.dataset.key, e.clientX, e.clientY + 6); return; } }
   // data-forget and data-resume sit INSIDE a data-past row, so they must be matched
   // (and dispatched) ahead of it or the row's own click would swallow them.
-  const el = t.closest<HTMLElement>("[data-perm],[data-driftfollow],[data-git],[data-diff],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-sel],[data-wtadd],[data-launch],[data-dash],[data-pal],[data-rail],[data-toast]");
+  const el = t.closest<HTMLElement>("[data-perm],[data-driftfollow],[data-git],[data-diff],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-sel],[data-wtadd],[data-launch],[data-gtoggle],[data-dash],[data-pal],[data-rail],[data-toast]");
   if (!el) return;
   if (el.dataset.perm) resolvePermission(el.dataset.permid || "", el.dataset.perm);
   else if (el.dataset.driftfollow) void followSessionDrift(el.dataset.driftfollow);
@@ -516,6 +516,9 @@ document.addEventListener("click", (e) => {
   else if (el.dataset.ext) openExternal(el.dataset.ext);
   else if (el.dataset.past) openDormant(el.dataset.past);
   else if (el.dataset.sel) { setActive(el.dataset.sel); closeAttnPop(); }
+  // The header of a user-defined project group: the whole bar folds it, the way its
+  // chevron says it does. Right-click is the group's own menu (./projmenu).
+  else if (el.dataset.gtoggle) toggleProjGroup(el.dataset.gtoggle);
   // A project header. This used to select whichever session sorted first, so one
   // click meant two different things depending on state; it now opens the project
   // dashboard, and the sessions are the rows directly beneath it.

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -32,7 +32,7 @@ import { fmtMb, fmtRate } from "./format";
 import { claudeInput, cleanTitle, clipboardKeys, fitSession, loadWebgl, MONO, shellKeys, winClaudePaste } from "./terminal";
 import { gitBusy, setGitBusy } from "./inspectorview";
 import { renderInspector } from "./inspector";
-import { renderMini, renderSidebar } from "./sidebar";
+import { renderMini, renderSidebar, revealProjGroup } from "./sidebar";
 import { renderFoot } from "./footer";
 import { closeExternalView, flushRoster, queueRosterSave } from "./mirror";
 import { openWt, refreshWtDialog } from "./worktree";
@@ -307,6 +307,10 @@ export function setActive(id: string) {
     fitSession(s);
     s.term.focus();
   }
+  // ⌘1–9, `nextAfterClose` and the tray can all land on a session filed inside a
+  // collapsed project group — and a rail with nothing selected while a pane is plainly
+  // on screen reads as the selection having been lost. Unfold it before painting.
+  revealProjGroup(s.colorKey);
   renderHeader(s); renderInspector(s); renderSidebar(); renderMini(); renderFoot();
   // Show the branch that's really checked out right now, immediately on activate.
   void refreshBranch(s).then((changed) => { if (changed) { renderSidebar(); if (activeId === id) renderHeader(s); } });

--- a/src/projgroups.ts
+++ b/src/projgroups.ts
@@ -1,0 +1,137 @@
+// Project groups — a named, collapsible heading over several projects in the sidebar.
+//
+// WHY THIS EXISTS. The rail lists every project flat, so a machine with a dozen repos
+// open spends a dozen headers on repos you are not working in today. A group is the
+// user's own answer to that: name a set of projects, fold it away, and the rail shows
+// what you are actually doing.
+//
+// WHAT A GROUP IS NOT: an ordering. A group holds a name, a collapsed flag and a set of
+// project paths, and nothing else. *Where* it sits in the sidebar is decided by its
+// members under whichever sort is active (./grouping's `groupedProjects`), so there is
+// no second order to keep in step with `cc-proj-order` and therefore no way for the two
+// to disagree — drag a project and the group it is in follows it.
+//
+// THE RULES ARE HERE AND THE STATE IS NOT. Everything below is pure over an explicit
+// store — no ./state, no DOM, no renderer — the same shape ./peek takes, and for the
+// same concrete reason: ./state imports this module for its validator, so anything here
+// that reached back into ./state would be an import cycle. Every mutator returns a NEW
+// store, and returns the one it was given unchanged when there is nothing to do, which
+// is what lets the call site skip a repaint on a no-op.
+//
+// See test/projgroups.test.ts.
+
+/// One group. `id` is opaque and stable — it is what `of` below points at, what the
+/// sidebar writes into `data-fold`, and what a rename must not change.
+export interface GroupDef { id: string; name: string; collapsed: boolean }
+/// `of` maps a project path (the same key `cc-proj-order`, `cc-colors` and `FAVORITES`
+/// all use) to a group id. A path with no entry is ungrouped and renders top-level.
+export interface GroupStore { groups: GroupDef[]; of: Record<string, string> }
+
+export const NO_GROUPS: GroupStore = { groups: [], of: {} };
+
+/// A name has to fit a 220px rail, and the count is only a guard against a corrupt or
+/// hand-edited store — nobody reaches either by hand.
+const MAX_NAME = 40;
+const MAX_GROUPS = 40;
+
+/** Whatever the user typed, made fit: one-line, trimmed, bounded. May return "". */
+export function cleanGroupName(raw: unknown): string {
+  return String(raw ?? "").replace(/\s+/g, " ").trim().slice(0, MAX_NAME);
+}
+
+/**
+ * Whatever came out of `localStorage`, made safe.
+ *
+ * Two invariants matter and both are repaired rather than trusted: group ids are
+ * unique, and every membership points at a group that exists. A dangling membership
+ * would render as a project that has simply vanished from the rail — it belongs to a
+ * fold nothing draws — which is the one failure mode of this feature a user could not
+ * diagnose.
+ */
+export function clampGroups(raw: unknown): GroupStore {
+  const src = (raw ?? null) as Partial<GroupStore> | null;
+  const groups: GroupDef[] = [];
+  const ids = new Set<string>();
+  for (const g of Array.isArray(src?.groups) ? src.groups : []) {
+    if (groups.length >= MAX_GROUPS) break;
+    const id = typeof g?.id === "string" ? g.id : "";
+    if (!id || ids.has(id)) continue;
+    ids.add(id);
+    groups.push({ id, name: cleanGroupName(g?.name) || "Group", collapsed: g?.collapsed === true });
+  }
+  const of: Record<string, string> = {};
+  const rawOf = src?.of;
+  if (rawOf && typeof rawOf === "object") {
+    for (const [path, gid] of Object.entries(rawOf)) {
+      if (path && typeof gid === "string" && ids.has(gid)) of[path] = gid;
+    }
+  }
+  return { groups, of };
+}
+
+/// The lowest `g<n>` this store isn't already using. Derived rather than random or
+/// timestamped so a test can name the group it just created, and so nothing here needs
+/// `Date.now()` — the store is written from a `renderAll` path under fake timers.
+export function nextGroupId(st: GroupStore): string {
+  const used = new Set(st.groups.map((g) => g.id));
+  let n = 1;
+  while (used.has("g" + n)) n++;
+  return "g" + n;
+}
+
+export const groupById = (st: GroupStore, gid: string): GroupDef | null => st.groups.find((g) => g.id === gid) ?? null;
+export const groupOf = (st: GroupStore, path: string): string | null => st.of[path] ?? null;
+export const groupPaths = (st: GroupStore, gid: string): string[] => Object.keys(st.of).filter((p) => st.of[p] === gid);
+
+/** Create a group and file `paths` into it in one step — the only way one is born. */
+export function createGroup(st: GroupStore, name: string, paths: string[] = []): GroupStore {
+  if (st.groups.length >= MAX_GROUPS) return st;
+  const id = nextGroupId(st);
+  const of = { ...st.of };
+  for (const p of paths) if (p) of[p] = id;
+  return { groups: [...st.groups, { id, name: cleanGroupName(name) || "Group", collapsed: false }], of };
+}
+
+/** File a project into a group, or (gid === null) back out to the top level. */
+export function assignGroup(st: GroupStore, path: string, gid: string | null): GroupStore {
+  if (!path) return st;
+  if (gid === null) {
+    if (!(path in st.of)) return st;
+    const of = { ...st.of };
+    delete of[path];
+    return { ...st, of };
+  }
+  // Filing into a group that doesn't exist would produce exactly the dangling
+  // membership `clampGroups` repairs, so it is refused at the source too.
+  if (!groupById(st, gid) || st.of[path] === gid) return st;
+  return { ...st, of: { ...st.of, [path]: gid } };
+}
+
+export function renameGroup(st: GroupStore, gid: string, name: string): GroupStore {
+  const n = cleanGroupName(name);
+  // An empty name is a slip, not an instruction — a nameless heading is unusable and
+  // the group would be unreachable except by dragging things out of it one at a time.
+  if (!n || !groupById(st, gid)) return st;
+  return { ...st, groups: st.groups.map((g) => (g.id === gid ? { ...g, name: n } : g)) };
+}
+
+/// Deleting a group keeps every project in it — only the heading goes. There is
+/// nothing to confirm and nothing to undo: the projects reappear at the top level and
+/// making the group again is one right-click.
+export function deleteGroup(st: GroupStore, gid: string): GroupStore {
+  if (!groupById(st, gid)) return st;
+  const of: Record<string, string> = {};
+  for (const [p, g] of Object.entries(st.of)) if (g !== gid) of[p] = g;
+  return { groups: st.groups.filter((g) => g.id !== gid), of };
+}
+
+export function setCollapsed(st: GroupStore, gid: string, collapsed: boolean): GroupStore {
+  const g = groupById(st, gid);
+  if (!g || g.collapsed === collapsed) return st;
+  return { ...st, groups: st.groups.map((x) => (x.id === gid ? { ...x, collapsed } : x)) };
+}
+
+export function collapseAll(st: GroupStore, collapsed: boolean): GroupStore {
+  if (st.groups.every((g) => g.collapsed === collapsed)) return st;
+  return { ...st, groups: st.groups.map((g) => ({ ...g, collapsed })) };
+}

--- a/src/projmenu.ts
+++ b/src/projmenu.ts
@@ -16,11 +16,15 @@ import { closeFootMenus } from "./footer";
 import { openGraph } from "./graphview";
 import { clearIcon, customIcons, iconFor, pickCustomIcon, resetCustomIcon } from "./icons";
 import { openWt, removeWorktreeAt } from "./worktree";
-import { copyPath, openTerminalIn } from "./actions";
+import {
+  collapseAllProjGroups, copyPath, deleteProjectGroup, newProjectGroup, openTerminalIn,
+  renameProjectGroup, setProjectGroup, toggleProjGroup,
+} from "./actions";
+import { groupById, groupOf, groupPaths } from "./projgroups";
 import { isAgent } from "./types";
 import {
-  accentFor, activeId, colorOverrides, engineDef, externals, FAVORITES, sessions,
-  termEngine,
+  accentFor, activeId, colorOverrides, engineDef, externals, FAVORITES, projGroups,
+  sessions, termEngine,
 } from "./state";
 
 // The seven things a menu row does that this module does not own — panes, the project
@@ -134,10 +138,16 @@ const ctxRowHtml = (r: CtxRow) =>
 const ctxRowsHtml = (rows: (CtxRow | null)[]) =>
   rows.map((r) => (r ? ctxRowHtml(r) : `<div class="mp-sep"></div>`)).join("");
 
+// Where the menu was opened, so a drill-down (Move to group…) and its ‹ Back land on
+// the same pixels rather than jumping to wherever the pointer has since wandered.
+let menuX = 0, menuY = 0;
+
 function openCtxMenu(key: string, x: number, y: number) {
   closeColorPop();
-  wtTarget = null; // one #ctxMenu, one target — see the module header
+  wtTarget = gTarget = pickPath = null; // one #ctxMenu, one target — see the module header
   ctxKey = key;
+  menuX = x; menuY = y;
+  const grouped = groupById(projGroups, groupOf(projGroups, key) ?? "");
   const fav = FAVORITES.some((f) => f.path === key);
   const live = [...sessions.values()].filter((s) => s.colorKey === key && isAgent(s)).length;
   const ic = iconFor(key);
@@ -152,6 +162,12 @@ function openCtxMenu(key: string, x: number, y: number) {
     { act: "folder", ic: "⌂", label: "Open project folder", sub: FILE_MANAGER },
     { act: "copypath", ic: "⧉", label: "Copy path" },
     null,
+    // Named after where the project already is, when it is somewhere: "Group: Work"
+    // answers the question the row would otherwise raise, and the picker behind it is
+    // the same one either way.
+    grouped
+      ? { act: "movegroup", ic: "▤", label: `Group · ${grouped.name}`, sub: "move to another, or take it out", chev: true }
+      : { act: "movegroup", ic: "▤", label: "Add to group…", sub: "collect projects under one collapsible heading", chev: true },
     { act: "appearance", ic: "◐", label: "Appearance", sub: "color, logo", chev: true },
     null,
     // Not every group in the sidebar is pinned: a folder also shows up while it has
@@ -183,7 +199,7 @@ function openCtxMenu(key: string, x: number, y: number) {
     if (sub) sub.textContent = `branch off ${h.branch}`;
   }).catch(() => {});
 }
-export function closeCtxMenu() { $("ctxMenu").classList.remove("show"); ctxKey = wtTarget = null; }
+export function closeCtxMenu() { $("ctxMenu").classList.remove("show"); ctxKey = wtTarget = gTarget = pickPath = null; }
 export const ctxMenuOpen = () => $("ctxMenu").classList.contains("show");
 
 // ---------- worktree cluster context menu ----------
@@ -259,6 +275,140 @@ $("ctxMenu").addEventListener("click", (e) => {
   }
 });
 
+// ---------- project groups: the picker, and a group's own menu ----------
+// Two more modes of the one #ctxMenu, and they are drill-downs rather than submenus:
+// Appearance hangs a *panel* off the menu's edge because a colour grid is not a list of
+// rows, but "which group?" is exactly a list of rows, so it replaces the menu in place
+// and offers ‹ Back. One element, one skin, no second popover to position.
+//
+// Naming a group is an inline `<input>` in the menu (the `.sw-hex` field in the colour
+// panel is the precedent) rather than a dialog: it is one short string, and a modal for
+// it would be heavier than the thing it creates.
+let pickPath: string | null = null;   // the project being filed
+let gTarget: string | null = null;    // the group whose menu is open
+
+const groupCount = (gid: string) => groupPaths(projGroups, gid).length;
+const nameField = (placeholder: string, value = "") =>
+  `<div class="mp-new"><input class="mp-in" type="text" spellcheck="false" autocomplete="off" maxlength="40"`
+  + ` placeholder="${esc(placeholder)}" value="${esc(value)}" /></div>`;
+const focusField = () => setTimeout(() => $("ctxMenu").querySelector<HTMLInputElement>(".mp-in")?.focus(), 30);
+
+function openGroupPicker(key: string, x: number, y: number) {
+  closeColorPop();
+  ctxKey = wtTarget = gTarget = null;
+  pickPath = key;
+  const cur = groupOf(projGroups, key);
+  const rows: (CtxRow | null)[] = [
+    { act: "gback", ic: "‹", label: "Back", sub: projName(key) },
+    null,
+    ...projGroups.groups.map((g) => ({
+      act: `gpick:${g.id}`, ic: g.id === cur ? "✓" : "▪", label: g.name,
+      sub: `${groupCount(g.id)} project${groupCount(g.id) === 1 ? "" : "s"}`,
+    })),
+    cur ? { act: "gclear", ic: "⊘", label: "Remove from group", sub: "back to the top level" } : null,
+  ];
+  const menu = $("ctxMenu");
+  menu.innerHTML =
+    `<div class="mp-head"><span class="mp-hsw" style="background:${accentFor(key)}"></span>`
+    + `<span class="mp-hmain"><span class="mp-hname">Group</span><span class="mp-hpath">${esc(projName(key))}</span></span></div>`
+    + ctxRowsHtml(rows) + nameField("New group…");
+  placePop(menu, x, y);
+  focusField();
+}
+
+function openGroupMenu(gid: string, x: number, y: number) {
+  closeColorPop();
+  ctxKey = wtTarget = pickPath = null;
+  gTarget = gid;
+  menuX = x; menuY = y;
+  const g = groupById(projGroups, gid);
+  if (!g) return;
+  const n = groupCount(gid);
+  const many = projGroups.groups.length > 1;
+  const rows: (CtxRow | null)[] = [
+    g.collapsed
+      ? { act: "gopen", ic: "▾", label: "Expand group", sub: `show its ${n} project${n === 1 ? "" : "s"}` }
+      : { act: "gopen", ic: "▸", label: "Collapse group", sub: n ? `fold ${n} project${n === 1 ? "" : "s"} away` : "it is empty" },
+    { act: "grename", ic: "✎", label: "Rename group…" },
+    // Only worth offering once there is more than one group to act on — otherwise
+    // "collapse all" is a longer way of saying the row directly above it.
+    ...(many ? [null, { act: "gcollapseall", ic: "⇱", label: "Collapse all groups" }, { act: "gexpandall", ic: "⇲", label: "Expand all groups" }] as (CtxRow | null)[] : []),
+    null,
+    // Not destructive to anything but the heading, and the sub says so — "Delete" over
+    // a list of someone's repos has to be unmistakable about what it takes with it.
+    { act: "gdelete", ic: "✕", label: "Delete group", sub: "the projects stay, at the top level", cls: "mp-danger" },
+  ];
+  const menu = $("ctxMenu");
+  menu.innerHTML =
+    `<div class="mp-head"><span class="mp-hsw mp-hfold"></span>`
+    + `<span class="mp-hmain"><span class="mp-hname">${esc(g.name)}</span>`
+    + `<span class="mp-hpath">${n} project${n === 1 ? "" : "s"}</span></span></div>`
+    + ctxRowsHtml(rows);
+  placePop(menu, x, y);
+}
+
+function openRenameGroup(gid: string) {
+  const g = groupById(projGroups, gid);
+  if (!g) return;
+  gTarget = gid;
+  const menu = $("ctxMenu");
+  menu.innerHTML =
+    `<div class="mp-head"><span class="mp-hsw mp-hfold"></span>`
+    + `<span class="mp-hmain"><span class="mp-hname">Rename</span><span class="mp-hpath">${esc(g.name)}</span></span></div>`
+    + nameField("Group name", g.name);
+  placePop(menu, menuX, menuY);
+  focusField();
+  setTimeout(() => menu.querySelector<HTMLInputElement>(".mp-in")?.select(), 40);
+}
+
+/// A row that REPLACES this menu's markup instead of committing has to stop the click
+/// there, and the reason is not obvious enough to leave unwritten: main.ts's outside-
+/// click closer asks `t.closest("#ctxMenu")` of the original target, and by the time it
+/// runs the innerHTML has been swapped — so the node it is asking about is detached,
+/// answers null, and the menu we just opened is closed as an outside click. Appearance
+/// never hit this because it only adds a class; every drill-down here re-renders.
+const keepMenuOpen = (e: Event) => e.stopPropagation();
+
+// One listener for both, guarded on their own targets exactly as the project and
+// worktree menus guard on theirs — three modes, one element, no shared branch.
+$("ctxMenu").addEventListener("click", (e) => {
+  const b = (e.target as HTMLElement).closest<HTMLElement>("[data-ctx]");
+  if (!b || b.classList.contains("dis")) return;
+  const act = b.dataset.ctx || "";
+  if (pickPath) {
+    const path = pickPath;
+    // Back is the one row that reopens rather than commits — same coordinates, so the
+    // menu appears not to have moved at all.
+    if (act === "gback") { keepMenuOpen(e); closeCtxMenu(); openCtxMenu(path, menuX, menuY); return; }
+    closeCtxMenu();
+    if (act === "gclear") setProjectGroup(path, null);
+    else if (act.startsWith("gpick:")) setProjectGroup(path, act.slice(6));
+    return;
+  }
+  if (!gTarget) return;
+  const gid = gTarget;
+  if (act === "grename") { keepMenuOpen(e); openRenameGroup(gid); return; }
+  closeCtxMenu();
+  if (act === "gopen") toggleProjGroup(gid);
+  else if (act === "gcollapseall") collapseAllProjGroups(true);
+  else if (act === "gexpandall") collapseAllProjGroups(false);
+  else if (act === "gdelete") deleteProjectGroup(gid);
+});
+// The inline name field: Enter commits, Esc backs out. It carries no `data-ctx`, so
+// every click listener above already ignores it and the menu stays open while typing.
+$("ctxMenu").addEventListener("keydown", (e: KeyboardEvent) => {
+  const t = e.target as HTMLElement;
+  if (!t.classList.contains("mp-in")) return;
+  if (e.key === "Escape") { e.preventDefault(); closeCtxMenu(); return; }
+  if (e.key !== "Enter") return;
+  e.preventDefault();
+  const value = (t as HTMLInputElement).value;
+  const path = pickPath, gid = gTarget;
+  closeCtxMenu();
+  if (path) newProjectGroup(value, path);
+  else if (gid) renameProjectGroup(gid, value);
+});
+
 // Appearance is the one row that opens rather than commits: the menu stays put and
 // the swatch panel hangs off its edge. Re-entrant — `mouseover` fires again for
 // every child span the pointer crosses, and re-rendering the panel under the
@@ -284,6 +434,10 @@ $("ctxMenu").addEventListener("click", (e) => {
   const key = ctxKey, name = projName(key);
   // Clicking it is the keyboard/touch path to the same thing hover already did.
   if (b.dataset.ctx === "appearance") { openAppearanceSub(b); return; }
+  // The other row that opens rather than commits — it replaces this menu in place
+  // (see openGroupPicker), so it must not fall through to the close below, and the
+  // click must not reach main.ts's outside-click closer (see keepMenuOpen).
+  if (b.dataset.ctx === "movegroup") { keepMenuOpen(e); openGroupPicker(key, menuX, menuY); return; }
   closeCtxMenu(); closeColorPop();
   switch (b.dataset.ctx) {
     case "launch": host.requestLaunch(name, key); break;
@@ -299,7 +453,17 @@ $("ctxMenu").addEventListener("click", (e) => {
 // `data-wt` is matched first and on its own element: a ⑃ cluster header sits inside a
 // project group, so a single `[data-key],[data-wt]` closest() would be decided by
 // which happens to be nearer in the tree rather than by what was actually clicked.
+//
+// `data-gid` is the same rule one level up, and is why it sits on the fold's HEADER
+// and not on the fold: a project inside the group would find a wrapper's `data-gid` as
+// an ancestor and open the group's menu instead of its own.
 document.addEventListener("contextmenu", (e) => {
+  const fold = (e.target as HTMLElement).closest<HTMLElement>("[data-gid]");
+  if (fold?.dataset.gid) {
+    e.preventDefault();
+    openGroupMenu(fold.dataset.gid, e.clientX, e.clientY);
+    return;
+  }
   const wt = (e.target as HTMLElement).closest<HTMLElement>("[data-wt]");
   if (wt?.dataset.wt) {
     e.preventDefault();

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -14,15 +14,16 @@ import { $, chord, toast } from "./dom";
 import { dlog } from "./debug";
 import { esc, tilde } from "./format";
 import { iconFor, projGlyph } from "./icons";
-import { projectList } from "./grouping";
+import { groupedProjects, groupSummary, projectList, type ProjGroup } from "./grouping";
 import {
   PEEK_IDLE, peekEnter, peekLeave, peekLeaveAll, peekNextDeadline, peekTick,
   type PeekState,
 } from "./peek";
-import { dormantRows, groupBody, peekBody } from "./sidebarview";
+import { groupOf, setCollapsed, type GroupDef } from "./projgroups";
+import { dormantRows, foldEmpty, foldHead, groupBody, peekBody } from "./sidebarview";
 import {
-  activeId, extMirrorId, FAVORITES, folderDirty, peekPrefs, saveProjOrder, sessions,
-  setProjOrder, sortMode, type SortMode,
+  activeId, extMirrorId, FAVORITES, folderDirty, peekPrefs, projGroups, saveProjGroups,
+  saveProjOrder, sessions, setProjGroups, setProjOrder, sortMode, type SortMode,
 } from "./state";
 
 // Two things a finished reorder needs that this module does not own: the sort mode
@@ -77,36 +78,72 @@ function invalidateSidebarCache() { lastHtml = null; }
 export function renderSidebar() {
   // Don't stomp the DOM the browser is mid-drag on — see draggingProjects.
   if (draggingProjects) return;
-  const html = projectList().map((p) => {
-    const rows = groupBody(p) + dormantRows(p);
-    const total = p.sessions.length + p.externals.length;
-    const isFav = FAVORITES.some((f) => f.path === p.path);
-    // Any member folder (a session's workdir or an external's cwd) with uncommitted
-    // changes lights the project's dot — so a dirty worktree marks its parent too.
-    const dirty = p.sessions.some((s) => folderDirty(s.workdir)) || p.externals.some((e) => folderDirty(e.cwd));
-    const dot = dirty ? `<span class="pdirty" title="Uncommitted changes in this project"></span>` : "";
-    const wtSuffix = p.wtBranch ? `<span class="pwt">· ${esc(p.wtBranch)}</span>` : "";
-    let head: string;
-    if (p.sessions.length) {
-      head = `<div class="phead" data-dash="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}${wtSuffix}</span>${dot}<span class="pcount">${total}</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}">＋</span><span class="parm"></span></div>`;
-    } else if (isFav) {
-      const tail = p.externals.length ? `<span class="pcount ext">${p.externals.length} ext</span>` : `<span class="plaunch">open →</span>`;
-      head = `<div class="phead empty-p" data-dash="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="premove" data-remove="${esc(p.path)}" title="Remove project">✕</span><span class="parm"></span></div>`;
-    } else {
-      // discovered via an external session or a restorable one only — not a saved project
-      const tail = p.externals.length
-        ? `<span class="pcount ext">${p.externals.length} ext</span>`
-        : `<span class="pcount ext">${p.dormants.length} past</span>`;
-      head = `<div class="phead ext-only" data-key="${esc(p.path)}" title="${esc(tilde(p.path))}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" title="Launch an Episko session here">＋</span><span class="parm"></span></div>`;
-    }
-    return `<div class="pgroup" data-path="${esc(p.path)}">${head}${rows ? `<div class="psessions">${rows}</div>` : ""}${peekBody(p)}</div>`;
-  }).join("");
+  const html = groupedProjects().map((slot) =>
+    slot.kind === "project" ? projectHtml(slot.project) : foldHtml(slot.group, slot.projects)).join("");
   if (html === lastHtml) return; // nothing the sidebar shows has changed
   lastHtml = html;
   $("projects").innerHTML = html;
   // The DOM the expansion lives on was just replaced, so re-apply it. This is the
   // whole reason ./peek tracks a project *path* rather than an element.
   applyPeek();
+}
+
+// One user-defined group: its header, and its projects nested inside a body that
+// animates open and shut.
+//
+// **The members are rendered whether or not the group is collapsed**, and that is what
+// buys the height animation — `grid-template-rows: 0fr → 1fr` needs the content to be
+// there to have a height to animate to. Unlike peek, the collapsed flag IS part of the
+// markup string: hover changes many times a second and would shred `lastHtml`, but a
+// collapse is a deliberate click, so it costs exactly one repaint and keeps the state
+// in the one place a re-render can't lose it.
+function foldHtml(g: GroupDef, projects: ProjGroup[]): string {
+  const body = projects.length ? projects.map(projectHtml).join("") : foldEmpty();
+  return `<div class="pfold${g.collapsed ? " collapsed" : ""}" data-fold="${esc(g.id)}">`
+    + foldHead(g, groupSummary(projects), projects.length)
+    + `<div class="pfbody"><div class="pfbody-in">${body}</div></div></div>`;
+}
+
+function projectHtml(p: ProjGroup): string {
+  const rows = groupBody(p) + dormantRows(p);
+  const total = p.sessions.length + p.externals.length;
+  const isFav = FAVORITES.some((f) => f.path === p.path);
+  // Any member folder (a session's workdir or an external's cwd) with uncommitted
+  // changes lights the project's dot — so a dirty worktree marks its parent too.
+  const dirty = p.sessions.some((s) => folderDirty(s.workdir)) || p.externals.some((e) => folderDirty(e.cwd));
+  const dot = dirty ? `<span class="pdirty" title="Uncommitted changes in this project"></span>` : "";
+  const wtSuffix = p.wtBranch ? `<span class="pwt">· ${esc(p.wtBranch)}</span>` : "";
+  let head: string;
+  if (p.sessions.length) {
+    head = `<div class="phead" data-dash="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}${wtSuffix}</span>${dot}<span class="pcount">${total}</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}">＋</span><span class="parm"></span></div>`;
+  } else if (isFav) {
+    const tail = p.externals.length ? `<span class="pcount ext">${p.externals.length} ext</span>` : `<span class="plaunch">open →</span>`;
+    head = `<div class="phead empty-p" data-dash="${esc(p.path)}" data-proj="${esc(p.name)}" data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="premove" data-remove="${esc(p.path)}" title="Remove project">✕</span><span class="parm"></span></div>`;
+  } else {
+    // discovered via an external session or a restorable one only — not a saved project
+    const tail = p.externals.length
+      ? `<span class="pcount ext">${p.externals.length} ext</span>`
+      : `<span class="pcount ext">${p.dormants.length} past</span>`;
+    head = `<div class="phead ext-only" data-key="${esc(p.path)}" title="${esc(tilde(p.path))}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" title="Launch an Episko session here">＋</span><span class="parm"></span></div>`;
+  }
+  return `<div class="pgroup" data-path="${esc(p.path)}">${head}${rows ? `<div class="psessions">${rows}</div>` : ""}${peekBody(p)}</div>`;
+}
+
+/// Expand the group a project is filed in, if it is collapsed. Called when a session
+/// takes the stage (./panes' `setActive`), because ⌘1–9, `nextAfterClose` and the tray
+/// can all land on a session inside a folded group — and a rail showing nothing
+/// selected while a pane is plainly on screen reads as the selection having been lost.
+///
+/// Persists here rather than in ./actions for the reason the reorder below does: this
+/// module is already the one that writes a sidebar preference straight after a gesture,
+/// and ./panes cannot import ./actions (which imports ./panes).
+export function revealProjGroup(path: string) {
+  const gid = groupOf(projGroups, path);
+  if (!gid) return;
+  const next = setCollapsed(projGroups, gid, false);
+  if (next === projGroups) return; // already open — no write, no repaint
+  setProjGroups(next);
+  saveProjGroups();
 }
 
 // ---------- peek: resting on a project reveals its idle checkouts ----------
@@ -224,6 +261,13 @@ export function closePeek() {
 // separator line (.dropmark) shows where the group will land; the dragged group is only
 // physically moved on release, then the DOM order is read back and saved. A drag only
 // begins once the pointer crosses DRAG_SLOP, so a plain click still selects the project.
+//
+// GROUPS MADE THIS NESTED, AND THE READ-BACK IS WHY IT STILL WORKS. A `.pgroup` may now
+// live inside a `.pfold`, so the marker can no longer be inserted into `#projects` (that
+// throws outright once the reference node is a fold's child) — it goes into whatever
+// parent the drop target has, which is also what makes dragging a project INTO a group
+// the same gesture as reordering it. Membership is then read back off the DOM exactly
+// as the order always has been, so the two can never come out of a drag disagreeing.
 export function initProjectDnD() {
   const container = $("projects");
   const DRAG_SLOP = 5; // px before a press becomes a drag rather than a click
@@ -233,8 +277,13 @@ export function initProjectDnD() {
   let candidate: HTMLElement | null = null;   // pressed group, promoted to dragEl past the slop
   let startX = 0, startY = 0;
 
+  // A collapsed fold has no visible body to drop into, so the header lights up instead
+  // — the marker is in there, it just has nowhere to be seen.
+  const clearFoldTarget = () => container.querySelector(".pfold.droptarget")?.classList.remove("droptarget");
+
   const cleanup = () => {
     marker.remove();
+    clearFoldTarget();
     container.classList.remove("reordering");
     dragEl?.classList.remove("dragging");
     dragEl = candidate = null;
@@ -250,7 +299,9 @@ export function initProjectDnD() {
     // Leave the interactive bits (launch +, per-worktree +, remove ✕, colour dot) to
     // their own clicks.
     if (t.closest(".padd, .wtadd, .plaunch, .premove, .pdot, .pdirty")) return;
-    const g = t.closest<HTMLElement>(".pgroup");
+    // A fold header drags the whole group; anything else drags the project it is in.
+    // `closest` returns the nearer of the two, which is exactly that rule.
+    const g = t.closest<HTMLElement>(".pgroup, .pfold");
     if (!g) return;
     candidate = g;
     startX = e.clientX; startY = e.clientY;
@@ -270,20 +321,34 @@ export function initProjectDnD() {
     e.preventDefault();
     // Place the marker relative to whichever group the pointer is over.
     const over = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
-    const grp = over?.closest<HTMLElement>(".pgroup");
-    if (!grp || grp === dragEl) return;
+    let grp = over?.closest<HTMLElement>(".pgroup, .pfold") ?? null;
+    const draggingFold = dragEl.classList.contains("pfold");
+    // Groups don't nest. Dragging one aims at whatever fold the pointer is inside,
+    // never at a project within it.
+    if (grp && draggingFold) grp = grp.closest<HTMLElement>(".pfold") ?? grp;
+    // `dragEl.contains(grp)` — a fold being dragged over its own members.
+    if (!grp || grp === dragEl || dragEl.contains(grp)) return;
+    clearFoldTarget();
+    // The pointer resolved to a fold rather than to a project in it, which means it is
+    // over the header or an empty body: both mean "this group". Dropping a project
+    // there files it, which is the whole gesture — and the only way in for a group with
+    // nothing in it yet. (Out again is the fold's own body → a top-level project, or
+    // the context menu's "Remove from group".)
+    if (!draggingFold && grp.classList.contains("pfold")) {
+      const body = grp.querySelector<HTMLElement>(".pfbody-in");
+      if (body) { body.appendChild(marker); if (grp.classList.contains("collapsed")) grp.classList.add("droptarget"); return; }
+    }
     const r = grp.getBoundingClientRect();
     const after = e.clientY > r.top + r.height / 2;
-    container.insertBefore(marker, after ? grp.nextSibling : grp);
+    grp.parentElement?.insertBefore(marker, after ? grp.nextSibling : grp);
   });
 
   const finish = (e: PointerEvent) => {
     try { container.releasePointerCapture(e.pointerId); } catch { /* */ }
     if (!dragEl) { candidate = null; return; } // never crossed the slop: it was a click
-    if (marker.parentNode) container.insertBefore(dragEl, marker);
+    if (marker.parentNode) marker.parentNode.insertBefore(dragEl, marker);
     cleanup();
-    setProjOrder([...container.querySelectorAll<HTMLElement>(".pgroup")].map((el) => el.dataset.path!).filter(Boolean));
-    saveProjOrder();
+    saveSidebarArrangement(container);
     // A manual drag captures the current visual order and reasserts manual mode
     // (in a sorted mode the drag would otherwise be immediately overridden).
     if (sortMode !== "manual") setSort("manual", false);
@@ -296,6 +361,30 @@ export function initProjectDnD() {
   };
   container.addEventListener("pointerup", finish);
   container.addEventListener("pointercancel", (e) => { try { container.releasePointerCapture(e.pointerId); } catch { /* */ } cleanup(); });
+}
+
+/// What the drag actually left on screen: the flat project order, and which fold each
+/// project ended up inside. One pass, because they are one arrangement — persisting the
+/// order from the DOM and the membership from anywhere else is how the two would drift.
+///
+/// **Memberships for projects that are not on screen are carried over untouched.** In
+/// toplevel mode a repo can be rendered only as its worktrees (`splitByWorktree` drops
+/// an empty root group), so rebuilding `of` from scratch here would quietly unfile every
+/// such repo on the next drag.
+function saveSidebarArrangement(container: HTMLElement) {
+  const order: string[] = [];
+  const of = { ...projGroups.of };
+  for (const el of container.querySelectorAll<HTMLElement>(".pgroup")) {
+    const path = el.dataset.path;
+    if (!path) continue;
+    order.push(path);
+    const gid = el.closest<HTMLElement>(".pfold")?.dataset.fold;
+    if (gid) of[path] = gid; else delete of[path];
+  }
+  setProjOrder(order);
+  saveProjOrder();
+  setProjGroups({ groups: projGroups.groups, of });
+  saveProjGroups();
 }
 
 // External file drops. With dragDropEnabled:true the webview no longer navigates to a
@@ -326,6 +415,10 @@ export function initFileDrop() {
 function shellEscapePath(p: string): string {
   return p.replace(/[^A-Za-z0-9_@%+=:,./-]/g, "\\$&");
 }
+// The 44px rail. Flat — `projectList()`, not `groupedProjects()`: it is already the
+// most compressed view of the fleet there is, and a heading you cannot read plus a
+// fold you cannot see the contents of would cost rows to say nothing. Grouping is an
+// answer to a long sidebar, and this is the short one.
 export function renderMini() {
   const activeProj = activeId ? sessions.get(activeId)?.project : null;
   $("railmini").innerHTML =

--- a/src/sidebarview.ts
+++ b/src/sidebarview.ts
@@ -17,7 +17,45 @@ import {
   accentFor, activeId, externals, extMirrorId, folderDirty, pastMirrorId, peekPrefs,
   sessions, wtGroup,
 } from "./state";
-import { clusterByWorktree, clusterIsLive, type ProjGroup, type WtCluster } from "./grouping";
+import { clusterByWorktree, clusterIsLive, type GroupSummary, type ProjGroup, type WtCluster } from "./grouping";
+import type { GroupDef } from "./projgroups";
+
+// ---------- the header of a user-defined project group ----------
+// `.pf*`, not `.pg*`. The prefix is load-bearing: `.pgroup` is a *project* and
+// `.pgpeek` is its idle checkouts, both of which live INSIDE one of these, and
+// `applyPeek`, the peek hover and the reorder all reach for `.pgroup` by class. A fold
+// called `.pgroup-something` would be found by half of them. (Same trap the commit
+// graph hit with `gc-*` vs `gco-*`, and the same fix: a different prefix, not a longer
+// name.)
+//
+// `data-gtoggle` is the click (collapse), `data-gid` is the right-click (the group
+// menu), and both sit on the HEADER rather than on the wrapper — a project head inside
+// the fold would otherwise find the wrapper's `data-gid` with `closest()` and open the
+// group's menu instead of its own.
+export function foldHead(g: GroupDef, sum: GroupSummary, n: number): string {
+  const plural = (c: number, word: string) => `${c} ${word}${c === 1 ? "" : "s"}`;
+  // Only while collapsed. Open, the rows beneath say all of this themselves, and a
+  // header repeating them is noise; collapsed, this is the whole point — a group that
+  // could hide a session waiting on a permission would be a trap, not a tidy-up.
+  const hidden = g.collapsed
+    ? (sum.dirty ? `<span class="pfdirty" title="Uncommitted changes in this group"></span>` : "")
+      + (sum.urgent ? `<span class="pfattn ${GCLASS[statusKey(sum.urgent)]}" title="${esc(`${sum.urgent.title || sum.urgent.project} needs you`)}">${GLYPH[statusKey(sum.urgent)]}</span>` : "")
+    : "";
+  // Panes when it has any, projects otherwise — and the pill is what says which, so
+  // the number never has to be read twice. A count that silently meant one thing on one
+  // group and the other on its neighbour is the wart this shape avoids.
+  const count = sum.count
+    ? `<span class="pfcount live" title="${esc(plural(sum.count, "session"))}">${sum.count}</span>`
+    : `<span class="pfcount">${n}</span>`;
+  const tip = `${g.name} — ${plural(n, "project")}${sum.count ? `, ${plural(sum.count, "session")}` : ""}`
+    + ` · click to ${g.collapsed ? "expand" : "collapse"}`;
+  return `<div class="pfhead" data-gtoggle="${esc(g.id)}" data-gid="${esc(g.id)}" title="${esc(tip)}">`
+    + `<span class="pfchev"></span><span class="pfname">${esc(g.name)}</span>${hidden}${count}</div>`;
+}
+// A group you took the last project out of. It keeps its place (at the end — it has no
+// member to be ranked by) and says what it is for, because the alternative reads as
+// Episko having quietly deleted a heading you named.
+export const foldEmpty = () => `<div class="pfempty">Drag a project here</div>`;
 
 // The status glyph vocabulary. Shared with the mini-rail, the tray and the
 // inspector pill, which is why it sits beside the rows rather than inside them.

--- a/src/state.ts
+++ b/src/state.ts
@@ -22,6 +22,7 @@
 // this module's import (see test/localstorage.ts).
 import { basename, hslToHex } from "./format";
 import { clampPeekPrefs, type PeekPrefs } from "./peek";
+import { clampGroups, type GroupStore } from "./projgroups";
 import type { DiffStat, Engine, ExtSession, PermMode, Res, Restorable, Sess, WtHead } from "./types";
 
 export interface Favorite { name: string; path: string }
@@ -38,6 +39,18 @@ export function saveFavorites() { localStorage.setItem("cc-favorites", JSON.stri
 export let projOrder: string[] = JSON.parse(localStorage.getItem("cc-proj-order") || "null") || [];
 export function setProjOrder(o: string[]) { projOrder = o; }
 export function saveProjOrder() { localStorage.setItem("cc-proj-order", JSON.stringify(projOrder)); }
+// The user's named, collapsible groups of projects, and which project is in which.
+// One JSON blob under cc-proj-groups rather than a key each, for the same reason
+// cc-peek is one: the two halves are only ever read together, and a membership that
+// outlived its group is the one corruption a user could not diagnose. The rules and
+// the validator are ./projgroups, which is pure — this only holds the value.
+//
+// Deliberately NOT an ordering: where a group sits is derived from its members under
+// the active sort (./grouping's `groupedProjects`), so `projOrder` above stays the one
+// answer to "what order is the sidebar in".
+export let projGroups: GroupStore = clampGroups(safeParse(localStorage.getItem("cc-proj-groups")));
+export function setProjGroups(g: GroupStore) { projGroups = clampGroups(g); }
+export function saveProjGroups() { localStorage.setItem("cc-proj-groups", JSON.stringify(projGroups)); }
 // Sidebar sort: "manual" honours the drag order above; "active" floats the most
 // recently-active sessions/projects to the top; "attention" floats the ones that
 // need you first (permission > error > your-turn), longest-waiting within a tier.
@@ -79,9 +92,11 @@ export function setWtGroup(m: WtGroup) { wtGroup = WT_GROUPS.includes(m) ? m : "
 // than three keys, because the three are only ever read together.
 export let peekPrefs: PeekPrefs = clampPeekPrefs(safeParse(localStorage.getItem("cc-peek")));
 export function setPeekPrefs(p: PeekPrefs) { peekPrefs = clampPeekPrefs(p); }
-function safeParse(raw: string | null): Partial<PeekPrefs> | null {
-  // A corrupt or hand-edited value must not take the app down during module import,
-  // the same stance ./tasks and ./notes take with their own stores.
+// Shared by every preference stored as a JSON blob (peek above, the project groups
+// higher up). A corrupt or hand-edited value must not take the app down during module
+// import, the same stance ./tasks and ./notes take with their own stores — and the
+// clamp each caller runs on the result is what turns "parsed" into "usable".
+function safeParse<T>(raw: string | null): Partial<T> | null {
   try { return raw ? JSON.parse(raw) : null; } catch { return null; }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -205,6 +205,55 @@ html.win .wctl { display: flex; }
 .rail-add::before { width: 10px; height: 1.6px; }
 .rail-add::after { width: 1.6px; height: 10px; }
 
+/* ---------- project folds: the user's named groups of projects -------------------
+   `.pf*`, never `.pg*`: `.pgroup` (a project) and `.pgpeek` (its idle checkouts) live
+   INSIDE one of these, and the reorder, the peek hover and applyPeek all reach for
+   `.pgroup` by class. See the note in sidebarview.ts.
+
+   Same `0fr → 1fr` collapse as .pgpeek and the dashboard's day rows — it animates an
+   unknown height with nothing measured; `.pfbody-in` carries the overflow/min-height
+   that makes the 0fr row clip rather than spill. */
+.pfold { margin-bottom: 7px; }
+/* Quieter than a project header by design: this is a label over the list, not a row in
+   it. Uppercase + tracking is what says "heading" at a size where weight alone can't. */
+.pfhead { display: flex; align-items: center; gap: 6px; padding: 3px 7px; border-radius: var(--radius-sm); cursor: grab; user-select: none; }
+.pfhead:hover { background: var(--surface); }
+.pfhead:hover .pfchev, .pfhead:hover .pfname { color: var(--text); }
+/* Drawn, not typed — same call as .rail-add's plus above. A `▾` at the size this
+   heading wants is a smudge, and the rotated form is indistinguishable from it, which
+   makes the one affordance that says "this folds" unreadable. Two borders on a rotated
+   box are crisp at 4px and the rotation reads unmistakably. */
+.pfchev { flex: none; position: relative; width: 9px; height: 9px; color: var(--muted-2); transition: color .12s; }
+.pfchev::before {
+  content: ""; position: absolute; top: 50%; left: 50%; width: 4px; height: 4px;
+  border-right: 1.4px solid currentColor; border-bottom: 1.4px solid currentColor;
+  transform: translate(-50%, -70%) rotate(45deg);
+  transition: transform .2s cubic-bezier(.32,.72,0,1);
+}
+.pfold.collapsed .pfchev::before { transform: translate(-65%, -50%) rotate(-45deg); }
+.pfname { min-width: 0; font: 700 9.5px var(--font-ui); letter-spacing: .075em; text-transform: uppercase; color: var(--muted-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; transition: color .12s; }
+/* Bare number = projects; the pill = sessions, which is the shape `.pcount` already
+   means one row down. So the badge never has to be read twice to know which it is. */
+.pfcount { flex: none; margin-left: auto; font: 600 9px var(--font-mono); color: var(--muted-2); }
+.pfcount.live { padding: 1px 6px; border-radius: 6px; background: var(--surface-2); }
+/* Both are collapsed-only (see foldHead): folding a group away must not fold away the
+   fact that something inside it is dirty or waiting on you. */
+.pfdirty { flex: none; width: 5px; height: 5px; border-radius: 50%; background: var(--st-working); box-shadow: 0 0 5px color-mix(in srgb, var(--st-working) 70%, transparent); }
+.pfattn { flex: none; font-size: 9px; line-height: 1; }
+.pfbody { display: grid; grid-template-rows: 1fr; transition: grid-template-rows .24s cubic-bezier(.32,.72,0,1); }
+.pfold.collapsed .pfbody { grid-template-rows: 0fr; }
+/* The inset is the only nesting cue — a third border rail (after .psessions and
+   .wtsessions) would stripe the rail for a heading that already reads as one. */
+.pfbody-in { overflow: hidden; min-height: 0; padding-left: 5px; }
+.pfempty { padding: 5px 8px 6px 3px; font-size: 10.5px; color: var(--muted-2); opacity: .7; font-style: italic; }
+/* A collapsed fold has no visible body for the .dropmark to sit in, so the header
+   itself says "this one" while a project is held over it. */
+.pfold.droptarget > .pfhead { background: var(--accent-wash); box-shadow: inset 0 0 0 1px var(--accent-line); }
+.pfold.droptarget > .pfhead .pfname { color: var(--accent-ink); }
+.pfold.dragging { opacity: .38; }
+.pfold.dragging .pfhead { cursor: grabbing; }
+@media (prefers-reduced-motion: reduce) { .pfbody, .pfchev { transition: none; } }
+
 .pgroup { margin-bottom: 3px; }
 /* While reordering (pointer-driven), suppress text selection across the whole list —
    and hold the grabbing cursor over every row the pointer crosses, since the buttons
@@ -1418,6 +1467,15 @@ select.in-ctl { cursor: pointer; }
    "Episko forgot how to do this". Same shape the branch popover uses for its own. */
 .ctxmenu .mp-item.dis { cursor: not-allowed; opacity: .55; }
 .ctxmenu .mp-item.dis:hover { background: transparent; }
+/* A group has no folder and no colour, so its head wears the fold glyph instead of the
+   swatch every other #ctxMenu head shows. */
+.ctxmenu .mp-hfold { background: transparent; box-shadow: inset 0 0 0 1.5px var(--muted-2); border-radius: 3px; }
+/* Naming or renaming a group, inline. A dialog for one short string would weigh more
+   than the thing it makes — the colour panel's .sw-hex field is the same call. */
+.ctxmenu .mp-new { padding: 4px 7px 2px; }
+.ctxmenu .mp-in { width: 100%; height: 28px; padding: 0 9px; border-radius: 7px; border: 1px solid var(--hair-strong); background: var(--bg-2); color: var(--text); font: 500 12px var(--font-ui); outline: none; }
+.ctxmenu .mp-in:focus { border-color: var(--accent-line); }
+.ctxmenu .mp-in::placeholder { color: var(--muted-2); }
 
 /* "x needs you" dropdown (multiple sessions awaiting attention) */
 .attn-badge.multi::after { content: "▾"; font-size: 8px; margin-left: 1px; opacity: .7; }

--- a/test/grouping.test.ts
+++ b/test/grouping.test.ts
@@ -2,14 +2,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { ExtSession, Restorable, Sess, WtHead } from "../src/types";
 import { store } from "./localstorage"; // must precede the subject imports
 import {
-  accentFor, colorOverrides, sessions, setDormants, setExternals, setFavorites,
-  setProjOrder, setSortMode, setWtGroup, worktreesByRepo,
+  accentFor, colorOverrides, dirtyByFolder, sessions, setDormants, setExternals,
+  setFavorites, setProjGroups, setProjOrder, setSortMode, setWtGroup, worktreesByRepo,
 } from "../src/state";
 import {
-  allProjects, clusterByWorktree, clusterIsLive, needsYou, needsYouSessions,
-  nextAfterClose, orderedSessions, projectList, reactorLabel, reactorState,
-  splitByWorktree, urgencyRank, type ProjGroup,
+  allProjects, clusterByWorktree, clusterIsLive, groupedProjects, groupSummary,
+  needsYou, needsYouSessions, nextAfterClose, orderedSessions, projectList,
+  reactorLabel, reactorState, splitByWorktree, urgencyRank,
+  type ProjGroup, type SidebarSlot,
 } from "../src/grouping";
+import { NO_GROUPS } from "../src/projgroups";
 import { taskPrefs } from "../src/tasks";
 
 const NOW_MS = 1800000000000; // 2027-01-15T08:00:00Z
@@ -45,8 +47,9 @@ beforeEach(() => {
   vi.setSystemTime(NOW_MS);
   sessions.clear();
   setExternals([]); setDormants([]); setFavorites([]); setProjOrder([]);
-  setSortMode("manual"); setWtGroup("off");
+  setSortMode("manual"); setWtGroup("off"); setProjGroups(NO_GROUPS);
   worktreesByRepo.clear();
+  dirtyByFolder.clear();
   for (const k of Object.keys(colorOverrides)) delete colorOverrides[k];
   taskPrefs.attention = true; // needsYou reads it; restore the shipped default
   store.clear();
@@ -440,6 +443,97 @@ describe("projectList — worktree grouping", () => {
   });
 });
 
+describe("groupedProjects — the user's named groups folded over that list", () => {
+  // What each slot is, flattened to something an assertion can read: a project by its
+  // path, a group as "Name[member, member]".
+  const shape = (l: SidebarSlot[]) =>
+    l.map((s) => (s.kind === "project" ? s.project.path : `${s.group.name}[${s.projects.map((p) => p.path).join(", ")}]`));
+  const threeFavs = () => setFavorites([{ name: "a", path: "/w/a" }, { name: "b", path: "/w/b" }, { name: "c", path: "/w/c" }]);
+
+  it("passes everything through untouched when there are no groups", () => {
+    threeFavs();
+    expect(shape(groupedProjects())).toEqual(["/w/a", "/w/b", "/w/c"]);
+  });
+
+  it("collects a group's members and leaves the rest at the top level", () => {
+    threeFavs();
+    setProjGroups({ groups: [{ id: "g1", name: "Work", collapsed: false }], of: { "/w/a": "g1", "/w/c": "g1" } });
+    expect(shape(groupedProjects())).toEqual(["Work[/w/a, /w/c]", "/w/b"]);
+  });
+
+  it("puts the group where its FIRST member sits, not where the group was made", () => {
+    // The whole reason there is no group order to persist: the position is derived, so
+    // a drag that moves a member moves the group with it and the two cannot disagree.
+    threeFavs();
+    setProjOrder(["/w/b", "/w/c", "/w/a"]);
+    setProjGroups({ groups: [{ id: "g1", name: "Work", collapsed: false }], of: { "/w/a": "g1", "/w/c": "g1" } });
+    expect(shape(groupedProjects())).toEqual(["/w/b", "Work[/w/c, /w/a]"]);
+  });
+
+  it("floats a group up in the attention sort when one of its projects needs you", () => {
+    setSortMode("attention");
+    open(
+      sess({ id: "quiet", project: "b", colorKey: "/w/b", phase: "idle" }),
+      sess({ id: "blocked", project: "a", colorKey: "/w/a", attention: "Bash" }),
+    );
+    setProjGroups({ groups: [{ id: "g1", name: "Work", collapsed: false }], of: { "/w/a": "g1" } });
+    expect(shape(groupedProjects())).toEqual(["Work[/w/a]", "/w/b"]);
+  });
+
+  it("keeps an emptied group, at the end — it has no member to be ranked by", () => {
+    // Dropping it would read as Episko having deleted a heading the user named, and it
+    // is also the only drop target that could ever refill it.
+    threeFavs();
+    setProjGroups({ groups: [{ id: "g1", name: "Work", collapsed: false }], of: {} });
+    expect(shape(groupedProjects())).toEqual(["/w/a", "/w/b", "/w/c", "Work[]"]);
+  });
+
+  it("ignores a membership pointing at a group that is gone", () => {
+    // clampGroups repairs this on load; this is the render side refusing to lose a
+    // project to a fold nothing draws even if one ever got through.
+    threeFavs();
+    setProjGroups({ groups: [{ id: "g1", name: "Work", collapsed: false }], of: { "/w/a": "ghost" } });
+    expect(shape(groupedProjects())).toEqual(["/w/a", "/w/b", "/w/c", "Work[]"]);
+  });
+
+  it("keeps a grouped repo's worktrees together in toplevel mode", () => {
+    // There the repo has exploded into one group per checkout, each keyed by its own
+    // dir — but the user filed the *repo*, so every checkout has to answer with it or a
+    // grouped repo scatters across the rail the moment a second worktree opens.
+    setWtGroup("toplevel");
+    open(sess({ id: "a", workdir: "/w/epi", branch: "main" }), sess({ id: "b", workdir: "/w/wt", branch: "feature" }));
+    setProjGroups({ groups: [{ id: "g1", name: "Work", collapsed: false }], of: { "/w/epi": "g1" } });
+    expect(shape(groupedProjects())).toEqual(["Work[/w/epi, /w/wt]"]);
+  });
+});
+
+describe("groupSummary — what a collapsed group still has to say", () => {
+  it("counts sessions and externals across every project in it", () => {
+    const l = [grp({ path: "/w/a", sessions: [sess({ id: "x" }), sess({ id: "y" })] }),
+               grp({ path: "/w/b", externals: [ext()] })];
+    expect(groupSummary(l).count).toBe(3);
+  });
+  it("reports the most urgent session, so folding never hides one waiting on you", () => {
+    const blocked = sess({ id: "blocked", attention: "Bash" });
+    const l = [grp({ path: "/w/a", sessions: [sess({ id: "done", phase: "done" })] }),
+               grp({ path: "/w/b", sessions: [blocked] })];
+    expect(groupSummary(l).urgent).toBe(blocked);
+  });
+  it("breaks a tie on who has been waiting longest", () => {
+    const older = sess({ id: "older", phase: "done", phaseSince: 10 });
+    const l = [grp({ sessions: [sess({ id: "newer", phase: "done", phaseSince: 99 }), older] })];
+    expect(groupSummary(l).urgent).toBe(older);
+  });
+  it("has no urgent session when nothing in it wants anything", () => {
+    expect(groupSummary([grp({ sessions: [sess({ phase: "working" })] })]).urgent).toBeNull();
+  });
+  it("lights dirty when ANY member folder has uncommitted changes", () => {
+    expect(groupSummary([grp({ sessions: [sess({ workdir: "/w/a" })] })]).dirty).toBe(false);
+    dirtyByFolder.set("/w/a", { added: 3, removed: 1, files: 2, untracked: 0, dirty: 2, upstream: null, ahead: 0, behind: 0 });
+    expect(groupSummary([grp({ sessions: [sess({ workdir: "/w/a" })] })]).dirty).toBe(true);
+  });
+});
+
 describe("urgencyRank — who needs you first", () => {
   it("ranks a blocking permission above everything else", () => {
     expect(urgencyRank(sess({ attention: "Bash", phase: "working" }))).toBe(0);
@@ -486,6 +580,23 @@ describe("orderedSessions — the sidebar read as one flat list", () => {
     setExternals([ext()]);
     setDormants([dorm()]);
     expect(ids(orderedSessions())).toEqual(["a1"]);
+  });
+  it("follows the order GROUPS put the sidebar in, not the ungrouped one", () => {
+    // A group physically moves its members, so reading the ungrouped list would make
+    // ⌘4 land on the fourth session in an order nothing on screen is in.
+    open(
+      sess({ id: "a", project: "a", colorKey: "/w/a" }),
+      sess({ id: "b", project: "b", colorKey: "/w/b" }),
+      sess({ id: "c", project: "c", colorKey: "/w/c" }),
+    );
+    expect(ids(orderedSessions())).toEqual(["a", "b", "c"]);
+    setProjGroups({ groups: [{ id: "g1", name: "W", collapsed: false }], of: { "/w/a": "g1", "/w/c": "g1" } });
+    expect(ids(orderedSessions())).toEqual(["a", "c", "b"]);
+  });
+  it("keeps a collapsed group's sessions reachable — they are still running", () => {
+    open(sess({ id: "a", project: "a", colorKey: "/w/a" }), sess({ id: "b", project: "b", colorKey: "/w/b" }));
+    setProjGroups({ groups: [{ id: "g1", name: "W", collapsed: true }], of: { "/w/a": "g1" } });
+    expect(ids(orderedSessions())).toEqual(["a", "b"]);
   });
 });
 

--- a/test/projgroups.test.ts
+++ b/test/projgroups.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  assignGroup, clampGroups, cleanGroupName, collapseAll, createGroup, deleteGroup,
+  groupById, groupOf, groupPaths, nextGroupId, NO_GROUPS, renameGroup, setCollapsed,
+  type GroupStore,
+} from "../src/projgroups";
+
+// A store as the app would hold one. Written out rather than built with the mutators,
+// so a bug in one of them can't make its own fixture agree with it.
+const store = (o: Partial<GroupStore> = {}): GroupStore => ({ groups: [], of: {}, ...o });
+const work = { id: "g1", name: "Work", collapsed: false };
+const side = { id: "g2", name: "Side", collapsed: true };
+const names = (st: GroupStore) => st.groups.map((g) => g.name);
+
+describe("cleanGroupName — what a heading is allowed to be", () => {
+  it("trims and collapses whitespace to one line", () => {
+    expect(cleanGroupName("  Work   stuff \n here ")).toBe("Work stuff here");
+  });
+  it("bounds the length — a 220px rail cannot show more", () => {
+    expect(cleanGroupName("x".repeat(200))).toHaveLength(40);
+  });
+  it("returns empty for nothing at all, so callers can refuse it", () => {
+    expect(cleanGroupName("   ")).toBe("");
+    expect(cleanGroupName(null)).toBe("");
+    expect(cleanGroupName(undefined)).toBe("");
+  });
+});
+
+describe("clampGroups — what comes back out of localStorage", () => {
+  it("passes a sound store through", () => {
+    const st = clampGroups({ groups: [work, side], of: { "/w/a": "g1" } });
+    expect(names(st)).toEqual(["Work", "Side"]);
+    expect(st.of).toEqual({ "/w/a": "g1" });
+    expect(st.groups[1].collapsed).toBe(true);
+  });
+  it("survives null, junk and a hand-edited half-store", () => {
+    expect(clampGroups(null)).toEqual(NO_GROUPS);
+    expect(clampGroups("nonsense")).toEqual(NO_GROUPS);
+    expect(clampGroups({ groups: "no" })).toEqual(NO_GROUPS);
+    expect(clampGroups({ groups: [work] }).of).toEqual({});
+  });
+  it("DROPS a membership whose group is gone — the one corruption a user can't see", () => {
+    // The project would belong to a fold nothing draws, so it would simply vanish from
+    // the sidebar with no row, no error and nothing to right-click.
+    const st = clampGroups({ groups: [work], of: { "/w/a": "g1", "/w/b": "ghost" } });
+    expect(st.of).toEqual({ "/w/a": "g1" });
+  });
+  it("drops a duplicate id rather than letting two groups answer to one key", () => {
+    const st = clampGroups({ groups: [work, { id: "g1", name: "Other", collapsed: false }] });
+    expect(names(st)).toEqual(["Work"]);
+  });
+  it("drops an id-less group and names an unnamed one", () => {
+    const st = clampGroups({ groups: [{ name: "x" }, { id: "g9" }] });
+    expect(st.groups).toEqual([{ id: "g9", name: "Group", collapsed: false }]);
+  });
+  it("treats a missing collapsed flag as open", () => {
+    expect(clampGroups({ groups: [{ id: "g1", name: "W" }] }).groups[0].collapsed).toBe(false);
+  });
+});
+
+describe("nextGroupId — deterministic, so nothing here needs a clock", () => {
+  it("takes the lowest free slot rather than the next number", () => {
+    expect(nextGroupId(NO_GROUPS)).toBe("g1");
+    expect(nextGroupId(store({ groups: [work, side] }))).toBe("g3");
+    // g1 was deleted: reuse it rather than climbing forever.
+    expect(nextGroupId(store({ groups: [side] }))).toBe("g1");
+  });
+});
+
+describe("createGroup — a group is born with something in it", () => {
+  it("files the paths it was given under the new id", () => {
+    const st = createGroup(NO_GROUPS, "Work", ["/w/a", "/w/b"]);
+    expect(st.groups).toEqual([{ id: "g1", name: "Work", collapsed: false }]);
+    expect(st.of).toEqual({ "/w/a": "g1", "/w/b": "g1" });
+  });
+  it("moves a project that already had a group — one project, one group", () => {
+    const st = createGroup(store({ groups: [work], of: { "/w/a": "g1" } }), "Side", ["/w/a"]);
+    expect(st.of).toEqual({ "/w/a": "g2" });
+  });
+  it("falls back to a name rather than minting an unlabelled heading", () => {
+    expect(createGroup(NO_GROUPS, "   ").groups[0].name).toBe("Group");
+  });
+});
+
+describe("assignGroup — filing a project, and taking it back out", () => {
+  const st = store({ groups: [work, side], of: { "/w/a": "g1" } });
+  it("moves it between groups", () => {
+    expect(assignGroup(st, "/w/a", "g2").of).toEqual({ "/w/a": "g2" });
+  });
+  it("null returns it to the top level", () => {
+    expect(assignGroup(st, "/w/a", null).of).toEqual({});
+  });
+  it("refuses a group that doesn't exist — that's the dangling membership again", () => {
+    expect(assignGroup(st, "/w/a", "ghost")).toBe(st);
+  });
+  it("returns the SAME store for a no-op, so the call site can skip the repaint", () => {
+    // The whole reason these are pure: `commitProjGroups` compares by identity, and a
+    // sidebar repaint measures 7ms.
+    expect(assignGroup(st, "/w/a", "g1")).toBe(st);
+    expect(assignGroup(st, "/w/b", null)).toBe(st);
+    expect(assignGroup(st, "", "g1")).toBe(st);
+  });
+});
+
+describe("renameGroup", () => {
+  const st = store({ groups: [work, side] });
+  it("renames without touching the id the memberships point at", () => {
+    const next = renameGroup(store({ groups: [work], of: { "/w/a": "g1" } }), "g1", " Day  job ");
+    expect(next.groups[0]).toEqual({ id: "g1", name: "Day job", collapsed: false });
+    expect(next.of).toEqual({ "/w/a": "g1" });
+  });
+  it("refuses an empty name — a nameless heading is unreachable", () => {
+    expect(renameGroup(st, "g1", "  ")).toBe(st);
+  });
+  it("ignores an unknown group", () => {
+    expect(renameGroup(st, "ghost", "x")).toBe(st);
+  });
+});
+
+describe("deleteGroup — the heading goes, the projects stay", () => {
+  it("drops the group and every membership pointing at it, and nothing else", () => {
+    const st = deleteGroup(store({ groups: [work, side], of: { "/w/a": "g1", "/w/b": "g2" } }), "g1");
+    expect(names(st)).toEqual(["Side"]);
+    expect(st.of).toEqual({ "/w/b": "g2" });
+  });
+  it("ignores an unknown group", () => {
+    const st = store({ groups: [work] });
+    expect(deleteGroup(st, "ghost")).toBe(st);
+  });
+});
+
+describe("setCollapsed / collapseAll", () => {
+  const st = store({ groups: [work, side] });
+  it("folds one group without touching its neighbour", () => {
+    expect(setCollapsed(st, "g1", true).groups.map((g) => g.collapsed)).toEqual([true, true]);
+  });
+  it("is a no-op when it already is that way", () => {
+    expect(setCollapsed(st, "g1", false)).toBe(st);
+    expect(setCollapsed(st, "ghost", true)).toBe(st);
+  });
+  it("collapseAll moves every group, and no-ops when they all agree", () => {
+    expect(collapseAll(st, true).groups.every((g) => g.collapsed)).toBe(true);
+    expect(collapseAll(store({ groups: [side] }), true)).toEqual(store({ groups: [side] }));
+    const already = store({ groups: [side] });
+    expect(collapseAll(already, true)).toBe(already);
+  });
+});
+
+describe("the readers", () => {
+  const st = store({ groups: [work, side], of: { "/w/a": "g1", "/w/b": "g1", "/w/c": "g2" } });
+  it("groupOf answers null for an ungrouped project rather than undefined", () => {
+    expect(groupOf(st, "/w/a")).toBe("g1");
+    expect(groupOf(st, "/w/zzz")).toBeNull();
+  });
+  it("groupById answers null for one that is gone", () => {
+    expect(groupById(st, "g2")).toEqual(side);
+    expect(groupById(st, "ghost")).toBeNull();
+  });
+  it("groupPaths lists a group's members", () => {
+    expect(groupPaths(st, "g1").sort()).toEqual(["/w/a", "/w/b"]);
+    expect(groupPaths(st, "ghost")).toEqual([]);
+  });
+});


### PR DESCRIPTION
A named, collapsible heading over several projects in the rail. Right-click a project → **Add to group…** (type a name, or pick an existing one); click a heading to fold it; right-click the heading to rename, collapse/expand all, or delete. Dragging a project onto a group files it — including onto a collapsed one, whose heading lights up as the drop target — and dragging a heading moves the whole group.

## Three decisions worth reviewing

**A group is not an ordering.** It holds a name, a collapsed flag and a set of paths; where it *sits* is derived — the position of its first member under whichever sort is active. So there is no second order to keep in step with `cc-proj-order`, dragging a project takes its group with it, and a group floats up in the attention sort exactly when one of its projects does. Persisting a group order as well is the thing I deliberately didn't do: the two would disagree within a day.

**Folding never hides urgency.** A collapsed heading carries `groupSummary`'s most-urgent glyph and a dirty dot; ⌘1–9 still reaches inside; `setActive` calls `revealProjGroup` so landing on a session in a folded group unfolds it rather than leaving the rail with nothing selected. This is also why `orderedSessions()` now walks the *grouped* order — groups physically move their members, so reading the ungrouped list would make ⌘4 land on the fourth session in an order nothing on screen is in.

**An empty group is kept, at the end.** It has no member to be ranked by. It is a heading someone named and the drop target that refills one; vanishing on the last removal would read as Episko having deleted it.

## Shape

- **`src/projgroups.ts`** — new pure leaf (the `peek.ts` shape, and for the same concrete reason: `state.ts` imports its validator, so anything reaching back into `state` would be a cycle). Every mutator returns the store it was handed when there is nothing to do, which is what lets the call site skip a 7ms repaint on a no-op.
- **`grouping.ts`** — `groupedProjects()` / `groupSummary()`; `ProjGroup` gains `wtRoot` so a grouped repo's worktrees stay together in toplevel mode.
- **`sidebar.ts`** — the fold markup, and the drag taught about nesting. Two things there are load-bearing: the marker goes into the drop target's *parent* (inserting into `#projects` throws outright once the reference node is a fold's child), and `saveSidebarArrangement` carries over memberships for projects **not on screen** — in toplevel mode a repo can render only as its worktrees, so rebuilding `of` from scratch would silently unfile it on the next drag.
- **`projmenu.ts`** — the picker and the group menu as drill-downs of the one `#ctxMenu`, with an inline name field (the `.sw-hex` precedent) rather than a dialog.
- Classes are `.pf*`, never `.pg*`: `.pgroup` and `.pgpeek` live *inside* a fold and `applyPeek`, the peek hover and the reorder all reach for `.pgroup` by class. Same trap as the commit graph's `gc-*`/`gco-*`.

## Verification

`tsc` clean · **686 vitest** (from 644 — new `test/projgroups.test.ts`, plus `groupedProjects` / `groupSummary` / `orderedSessions` cases in `grouping.test.ts`) · no import cycles across the now-50 modules · `CHANGELOG.md` and `CLAUDE.md` updated in the same commit.

Also run in the browser against the real render path — collapse, both menus, create/rename/remove, and drags into a collapsed group, between two groups, and of a whole group. That found two real bugs, both fixed here:

- **The drill-down menu closed itself.** Replacing `#ctxMenu.innerHTML` detaches the clicked node, so main.ts's outside-click closer asks `t.closest("#ctxMenu")` of a detached target, gets null, and closes the menu that was just opened. Appearance never hit this because it only adds a class. Hence `keepMenuOpen`.
- **The `▾` chevron was an illegible smudge** at heading size, and its rotated form indistinguishable from it — so the one affordance saying "this folds" couldn't be read. Now drawn in CSS, the way `.rail-add` already draws its plus.

Not covered by tests, as the render layer never is: the collapsed heading's dirty/attention badges need live sessions, so they're `groupSummary` unit tests plus three lines of markup. Worth a click-through.

## Deliberate limits

- The mini-rail stays flat — it is already the most compressed view there is.
- Dragging a project *out* to the top level needs a top-level project to aim at; otherwise **Remove from group** is the way. Pointer-over-a-fold means "into this fold", which is what makes an empty group reachable at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
