### PR TITLE
sound: the fleet can finally reach you from another window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
++ **Episko can now reach you from another window.** Every signal it had until now was
+  visual — the sidebar glyph, the attention badge, the tray — and all three need the
+  window in front of you, which is the opposite of why you run six agents at once. A
+  blocked permission was the worst of it: Claude stopped, doing nothing, until you
+  happened to look. **Settings › Sounds** gives ten moments a noise — a permission, your
+  turn, a failed turn, a run passing or failing, a usage-limit mark, a session starting
+  or ending — each with its own sound from a palette of ten, a master volume, and an
+  *only when Episko is in the background* mode. Every button in the pane plays what it
+  does, because a list of names is unusable until you have heard one.
+  Three of the ten start switched off (a tool call failing, a session ending, a session
+  launching): they fire on routine activity, and a set of alerts you learn to ignore
+  makes the permission chime worthless too. For the same reason a burst is one sound,
+  not six — the same moment genuinely reaches the app twice, and a fleet moving together
+  is still one moment — except that a *more urgent* event always cuts through, so a
+  permission landing right after a "your turn" is never the one that gets swallowed.
 ! ⌘⇧B / ⌘⇧T prefill a task's inputs like every other run surface — the dialog opens only for an input that has no answer anywhere
 ! The footer's usage, spend and attention popovers no longer swallow a click when telemetry repaints them mid-press
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,13 +85,13 @@ The disk-I/O accounting behind `io_samples`/`io_retired` — run vs. day vs. all
 - **Telemetry server** (`run_telemetry_server`) forwards `/hook` and `/statusline` POSTs as one `telemetry` event each; `/permission` is the blocking path described above.
 - Commands are registered in the `invoke_handler![...]` list at the bottom of `run()` — add new `#[tauri::command]` fns there.
 
-## Frontend (`src/`, `index.html`, `src/styles.css`) — 51 modules
+## Frontend (`src/`, `index.html`, `src/styles.css`) — 53 modules
 
-**No framework, and no longer one file.** 51 modules; `main.ts` is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly. **`renderAll()` is coalesced**: a call only marks the pass due, and one flush per animation frame paints whatever state every event in that frame left behind — a telemetry burst from N sessions costs one paint, not N. The rAF is paired with a 250ms `setTimeout` fallback, and that is not belt-and-braces: rAF never fires while the window is hidden, and the tray this pass repaints is exactly the surface being read then. The 🐞 console counts paints beside received events (`paints` in the stats line), so the batching is checkable while the app runs.
+**No framework, and no longer one file.** 53 modules; `main.ts` is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing — follow this render-everything pattern rather than mutating DOM directly. **`renderAll()` is coalesced**: a call only marks the pass due, and one flush per animation frame paints whatever state every event in that frame left behind — a telemetry burst from N sessions costs one paint, not N. The rAF is paired with a 250ms `setTimeout` fallback, and that is not belt-and-braces: rAF never fires while the window is hidden, and the tray this pass repaints is exactly the surface being read then. The 🐞 console counts paints beside received events (`paints` in the stats line), so the batching is checkable while the app runs.
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (the seam map — it belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, the window controls (see docs/native-ui.md), and the `setInterval`s.
 
-**Tested logic modules** (twenty — no DOM, no Tauri, no render imports; these are what the vitest suites cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it, plus `dispatch.test.ts` and `ipc.test.ts` which read source instead of importing it):
+**Tested logic modules** (twenty-one — no DOM, no Tauri, no render imports; these are what the vitest suites cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it, plus `dispatch.test.ts` and `ipc.test.ts` which read source instead of importing it):
 
 | Module | What |
 | --- | --- |
@@ -115,16 +115,17 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 | `ghwork.ts` | issues and PRs: recency buckets, what triage dares suggest, who already has one |
 | `changelog.ts` | CHANGELOG.md → releases, `inlineMd`'s bold/italic/code, and the one moment *What's new* opens by itself |
 | `claim.ts` | what Episko writes when you dispatch at shared work, and who decides |
+| `sound.ts` | which moments are worth hearing, the tones as data, and — the hard part — what stops a fleet becoming a fruit machine |
 
 **Shared**: `state.ts` (the session map, the stage pointer, every persisted preference) and `dom.ts` (`$`, `toast`, the shared scrim, `IS_MAC`/`MOD`/`chord`).
 
 **Markup-only views**, untested by design: `usageview`, `inspectorview`, `sidebarview`.
 
-**DOM-owning / render**, untested by design: `sidebar`, `footer`, `tray`, `inspector`, `debug`, `worktree` (the new-session dialog and the worktree removal flows — the biggest single module), `settings`, `taskui`, `palui`, `projmenu`, `caffeinate`, `diffview`, `graphview` (the paged commit-graph panel), `mirror`, `historyui`, `update`.
+**DOM-owning / render**, untested by design: `sidebar`, `footer`, `tray`, `inspector`, `debug`, `worktree` (the new-session dialog and the worktree removal flows — the biggest single module), `settings`, `taskui`, `palui`, `projmenu`, `caffeinate`, `diffview`, `graphview` (the paged commit-graph panel), `mirror`, `historyui`, `update`, `chime` (the only file that touches Web Audio — a live browser resource, so a test would only assert against its own mock).
 
 **Behaviour** — IPC and DOM all the way down, so untested too, and therefore the thinnest ice in the app: `panes` (the three spawners + a pane's lifecycle), `terminal` (the xterm plumbing), `taskrun` (run on stop), `actions` (the app-level verbs), `icons` (the per-project glyph store).
 
-Four rules keep that graph honest. **There are no import cycles across the 51 modules; re-run a cycle check after any change that adds an import.**
+Four rules keep that graph honest. **There are no import cycles across the 53 modules; re-run a cycle check after any change that adds an import.**
 
 - **Dependency direction is state ← render ← wiring.** A logic module must not import render code or `main.ts`.
 - **When an extracted function needs something that lives further up**, resolve it in this order: (1) **move the callee down too** if it is itself leaf-shaped — that is why `icons.ts` sits below `sidebar.ts` and `usage.ts` below `phase.ts`; (2) **a settable hook defaulting to a no-op** (`setRlLogger`, `setPanesRenderAll`) when the callee genuinely belongs to the render layer; (3) **an extra parameter** only as a last resort, since it changes a signature the move was supposed to leave alone. A control panel touching many things it doesn't own may take **one host object** instead of N setters (`settings`, `palui`, `projmenu`); prefer per-callee setters below ~4.
@@ -162,6 +163,7 @@ And the things that hold however the files are arranged:
 - **Episko writes almost nothing outside its own storage.** In a user's repo: only `.episko/{tasks.toml,episko.toml,notes.toml,digest.md}`, always through `toml_edit`/read-modify-write so hand-written formatting survives, and always asking before creating a new committable file. The single write inside `~/.claude` is *Move session*'s transcript move. Everything else is `localStorage` and the app dirs.
 - **The stage has one owner**: `activeId` and the `mirror` pointer (`{kind:"ext"|"past"|"dash"}`) are mutually exclusive, and `takeStage(show)` in `dom.ts` is the only code that may touch `#extPane`/`#dashPane`/`#empty`/`insp-mini`. Add a stage kind by extending `Stage`, never by poking `hidden` at a call site.
 - **`termEngine` picks where a terminal lives** (embedded xterm pane / ghostty / Terminal / iTerm); the per-launch instrumentation and telemetry are identical for all four. `permMode` is orthogonal — the *starting* permission mode only (`docs/sessions.md`).
+- **A sound is raised, never decided at the call site.** Every trigger calls `playSound(ev)` unconditionally and lets `sound.ts` answer; a second "are sounds on?" test anywhere is a switch that turns half the feature off (`docs/sounds.md`).
 
 ## Deep dives (`docs/`)
 
@@ -176,6 +178,7 @@ The full design notes — the shipped-bug histories and every invariant's reason
 - **`docs/worktrees.md`** — project groups, the peek rows, the worktree roster and polls (`worktree_heads` is spawn-free and pollable; `list_worktrees` is neither), removal (a failed `git worktree remove` does **not** mean nothing happened), and drift (`Drift.via` decides the repair: follow in place vs. kill-wait-move-relaunch).
 - **`docs/sessions.md`** — launch engines, permission modes (a whitelist, never a passthrough), external sessions (filter owned ones by pid, never by session id), restore (`resumeId`, not `id`; `costDelta` baselines — anything that diffs a cumulative telemetry figure against a `Sess` field repeats a shipped bug), and History.
 - **`docs/native-ui.md`** — the title bar (the window is built in `setup()`, not by config; drag-region gotchas) and the tray menu (icons exist because menu text is always menu-coloured; project headers must be disabled items).
+- **`docs/sounds.md`** — sound alerts. The hard part is not playing a sound, it is not playing six: the same moment reaches the frontend twice *by design*, so every play is gated — except that a more urgent event still gets through the burst window, which is the point. Anything that fires on routine activity ships switched off.
 
 ## Notes on scope & doc drift
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -155,6 +155,33 @@ All CSS/markup or native chrome, so `tsc` and the suites say nothing about any o
       stack. This is a cascade order that has broken once (`.set-inline` has to stay
       after `.set-group`), and it fails silently and only visually.
 
+### Sound alerts
+
+Unit tests cover every decision (`test/sound.test.ts`); what they cannot cover is
+whether anything comes out of the speakers, and **every failure mode here is silent** —
+a broken alert is indistinguishable from a switched-off one.
+
+- [ ] **The pane auditions itself.** Settings ⌘, → **Sounds**: click each row's ▶.
+      Ten rows must each make a *distinguishable* noise, and the volume steppers must
+      change how loud the next one is. Then click a row's sound name — the strip of ten
+      tones opens under it, and picking one plays it and closes nothing else.
+- [ ] **The first sound of a cold start is audible.** The real trap: autoplay policy
+      leaves the context suspended until a gesture, so **quit, reopen, and without
+      clicking anything in the window** let a session reach a permission (or ⌘, and
+      click ▶ as the very first click). If the first one is silent and the second is
+      not, the unlock listener in `chime.ts` is broken.
+- [ ] **A permission chimes from the background.** Set *Play* → **Only when Episko is
+      in the background**, put another window in front, and have a session ask for
+      approval. It must ring there and **not** ring when you are looking at Episko.
+- [ ] **A burst is one sound.** Start three or four agents and give them all the same
+      prompt so they finish together. That must be one chime, not four. Then check the
+      exception: a permission arriving right after another session's "your turn" must
+      **still** ring — the urgent one is never the one swallowed.
+- [ ] **A failed tool call is silent by default**, and a turn the API kills is not.
+      Run something that fails a Bash call mid-turn: no noise (that is `toolFail`, off
+      by default). Switch it on and it should sound — this is the split the phase
+      machine already draws for the label.
+
 ### The blocking path
 
 - [ ] **A permission is answerable.** Ask a session to run something needing

--- a/docs/sounds.md
+++ b/docs/sounds.md
@@ -1,0 +1,112 @@
+# Sound alerts
+
+**`sound.ts` decides, `chime.ts` plays.** The split is the same one `peek.ts`/`sidebar.ts`
+uses: everything that can be reasoned about — the catalogue, the tones as data, the
+clamping, the suppression rules — is pure and tested; the file that owns an
+`AudioContext` does nothing a test would want to assert.
+
+Settings › Sounds is the whole UI. State lives in `state.ts` (`soundPrefs`, one JSON
+blob under `cc-sound`), persistence and the repaint in `actions.ts`, exactly as the peek
+timings and the project groups do.
+
+## Why the app makes a noise at all
+
+Every signal Episko had before this one is visual — the sidebar glyph, the attention
+badge, the tray — and all three need the window in front of you. But the entire point of
+running six agents is that you have gone and done something else. A blocked permission is
+the extreme case: Claude is *stopped*, burning nothing, achieving nothing, until you
+answer, and until now nothing told you.
+
+## The rule that matters: not playing six sounds
+
+Playing a sound is trivial. Not playing six is the whole design, because the same
+real-world moment reaches the frontend more than once **by design**:
+
+- a permission arrives as both the blocking `PermissionRequest` hook **and** a
+  `Notification` — and the redundancy is what makes it reliable
+- a session ending arrives as both `SessionEnd` and `pty-exit`
+- N busy agents fire a lifecycle hook each within the same animation frame
+
+So `soundFor` gates every play behind two windows:
+
+| Window | Length | What it collapses |
+| --- | --- | --- |
+| `SOUND_REPEAT_MS` | 1200ms | **the same event** twice — the by-design duplicates above |
+| `SOUND_GAP_MS` | 350ms | **different events** in one burst — a fleet moving together is one moment |
+
+…with one exception, and it is the reason the gap is not just a mute: **inside the gap,
+a more urgent event still gets through.** A permission landing 80ms after a "your turn"
+is not a duplicate of it, it is the thing you actually needed to hear. That is what the
+`priority` field on each `SoundEventDef` is for and the only thing it is read for
+(3 urgent · 2 needs you · 1 informational · 0 background).
+
+Neither window is persisted or reset-on-quit: a fresh run must never suppress its first
+sound, so `chime.ts` holds the gate in a module variable and that is the right lifetime.
+
+## The catalogue, and why three events ship switched off
+
+`SOUND_EVENTS` is ten entries. Seven are on by default; `toolFail`, `ended` and
+`launched` are not, and that is not timidity — **a set of alerts that fires on every
+failed grep is a set of alerts you stop hearing**, which makes the permission chime
+worthless too. Anything that fires on routine activity is opt-in.
+
+The sharpest instance is a split this codebase already draws for the label and now draws
+again for the noise: `phase: "error"` is set BOTH by a tool call failing mid-turn and by
+a turn the API killed. Only the second is a new `apiErr` stamp (which only `StopFailure`
+writes), so only the second rings `error`; everything else that reddens the glyph is the
+opt-in `toolFail`. See `hookSound`, and `docs/architecture.md` for the original bug.
+
+## Where the events come from
+
+Nothing reads a hook payload twice. What a hook *means* is `phase.ts`'s decision, and a
+second reading here would be a second copy of that decision — the copy that drifts. So
+`main.ts` snapshots three fields off the `Sess`, applies the hook, and asks `hookSound`
+what changed:
+
+| Event | Raised by |
+| --- | --- |
+| `permission` | the blocking `permission` listener, and `hookSound` on a new `attention` matching /permission/ |
+| `question` | `hookSound` on any other new `attention` |
+| `done` `error` `toolFail` `ended` | `hookSound` on the phase the state machine settled into |
+| `taskDone` `taskFail` `ended` | `exitSound(kind, code)` in the `pty-exit` listener |
+| `limit` | `limitCrossed` over the account-wide `rl` readings, outside the per-session branch — one crossing, one chime, however many sessions report it |
+| `launched` | `launch()` in `panes.ts`, only on a spawn that worked |
+
+`limitCrossed` compares two readings rather than testing a threshold, so a window
+*reset* (the number falling) crosses nothing — and **the first reading of a run is a
+baseline, not a crossing**, or every launch above 50% would ring at the one moment the
+footer meter is already saying so on screen.
+
+## Two things `chime.ts` exists to get right
+
+Both are silent when wrong, which is why they are written down.
+
+**The context starts suspended.** Every autoplay policy refuses audio until the page has
+seen a gesture, and Episko's first sound is very often a permission that arrives while
+nobody has touched anything for ten minutes. The context is therefore created lazily,
+`resume()`d on every play, and woken by a one-shot capture-phase `pointerdown`/`keydown`
+listener. Without that, the failure is not an error anywhere — it is a permission that
+made no noise, which is indistinguishable from the feature being off.
+
+**A gate-shaped envelope clicks.** Starting an oscillator at full gain and stopping it
+puts a step discontinuity in the buffer. Every step gets a short attack and an
+exponential decay instead, and the ramps only ever run to a small positive value because
+`exponentialRampToValueAtTime` is undefined at zero. A step shorter than the attack has
+its attack clamped, or it would ramp up past its own end and never come back down.
+
+## The settings pane
+
+Every button in Settings › Sounds **plays what it does** — changing a tone, switching an
+event on, nudging the volume. That is not a flourish: a column of names ("Chime",
+"Drop", "Buzz") is unusable, because nobody knows what a Drop is until they have heard
+one, and a pane you cannot audition is one you set at random once and never revisit.
+
+Deliberately silent: switching an event **off**, and Reset. A burst of ten tones is not a
+useful answer to "make it quieter", and a sound as you switch something off says exactly
+the wrong thing.
+
+`previewTone`/`previewEvent` bypass the focus rule, the per-event switch and the burst
+gate — you are looking straight at the window, which is the one moment `away` would
+silence everything, and clicking through tones is meant to be rapid. They also leave the
+gate untouched, so an audition can never suppress a real alert that lands mid-click. The
+one thing they honour is the volume, because that is usually what is being judged.

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -25,6 +25,7 @@ import {
   saveFavorites, saveProjGroups, sessions, termEngine,
   setFavorites, setIoScope, setPeekPrefs as setPeekPrefsState, setPermMode as setPermModeState,
   setProjGroups, setSortMode, SORT_META, SORT_MODES,
+  soundPrefs, setSoundPrefs as setSoundPrefsState,
   sortMode, setWtGroup as setWtGroupState, wtGroup,
   type SortMode, type WtGroup,
 } from "./state";
@@ -33,6 +34,7 @@ import {
   renameGroup, setCollapsed, type GroupStore,
 } from "./projgroups";
 import type { PeekPrefs } from "./peek";
+import type { SoundPrefs } from "./sound";
 import type { PermMode } from "./types";
 
 // Every action here ends in a repaint of everything, which main.ts owns.
@@ -116,6 +118,16 @@ export function setPeekPrefs(p: PeekPrefs) {
   closePeek();
   renderSidebar();
   renderSettings(); // the live preview in the Worktrees tab reads these values
+}
+
+// And again for the sound alerts. `renderSettings` alone, not `renderAll`: nothing
+// outside the Sounds tab shows any of this — a sound is not a surface — so a repaint
+// of the sidebar, the tray and the inspector would be work for no pixels. (./chime
+// reads `soundPrefs` live at play time, so nothing has to be pushed to it.)
+export function setSoundPrefs(p: SoundPrefs) {
+  setSoundPrefsState(p);
+  localStorage.setItem("cc-sound", JSON.stringify(soundPrefs));
+  renderSettings();
 }
 
 // ---------- the user's named groups of projects ----------

--- a/src/chime.ts
+++ b/src/chime.ts
@@ -1,0 +1,162 @@
+// The player. ./sound decides *whether* and *which*; this turns a `Tone` into
+// oscillators and is the only file in the app that touches Web Audio.
+//
+// Untested by design, like every module that owns a live browser resource — an
+// `AudioContext` is not something a vitest node run can hold, and a test that mocked
+// one would be asserting against the mock. What is worth testing (the catalogue, the
+// clamping, the burst suppression) is in ./sound, which this imports and cannot be
+// imported by.
+//
+// TWO THINGS THIS FILE EXISTS TO GET RIGHT, both of which are silent when wrong:
+//
+// **The context starts suspended.** Every engine's autoplay policy refuses audio
+// until the page has seen a user gesture, and a WebView is no exception — Episko's
+// first sound is very often a permission alert that arrives while nobody has clicked
+// anything for ten minutes. So the context is created lazily and `resume()`d on every
+// play, and a one-shot gesture listener wakes it the moment the app is touched. The
+// failure without that is not an error anywhere: it is a permission that never made a
+// noise, which is indistinguishable from the feature being off.
+//
+// **A gate-shaped envelope clicks.** Starting an oscillator at full gain and stopping
+// it puts a step discontinuity in the buffer, which is a pop, and ten of those an hour
+// is worse than no sound at all. Every step gets a short attack and an exponential
+// decay instead, and the ramps only ever run to a small positive value because
+// `exponentialRampToValueAtTime` is undefined at zero.
+
+import { soundPrefs } from "./state";
+import {
+  soundFor, SOUND_GATE_IDLE, toneDef, toneMs,
+  type SoundEvent, type SoundGate, type ToneId,
+} from "./sound";
+
+// ./debug is a render-layer module, so it arrives as a settable hook rather than an
+// import (PLAN seam rule 2) — the same arrangement ./rl uses for the same reason.
+// Worth logging: "why was there no noise" is otherwise unanswerable from outside.
+let log: (lvl: "info" | "warn" | "error", msg: string) => void = () => {};
+export function setSoundLogger(fn: typeof log) { log = fn; }
+
+/// Peak amplitude of a single step at 100% volume. Low on purpose: several steps can
+/// overlap (see the bell), and the sum must not clip. Loudness lives in the volume
+/// curve below, not here.
+const PEAK = 0.22;
+const ATTACK = 0.008;
+/// The exponential ramps' floor — silence, as far as anyone can hear, and positive,
+/// which the Web Audio ramp requires.
+const ZERO = 0.0001;
+
+let ctx: AudioContext | null = null;
+let master: GainNode | null = null;
+/// Set once we have failed to build a context, so a browser without Web Audio (or a
+/// WebView that refused) costs one attempt rather than one per event forever.
+let dead = false;
+
+function audio(): AudioContext | null {
+  if (ctx || dead) return ctx;
+  const Ctor: typeof AudioContext | undefined =
+    typeof window === "undefined" ? undefined
+      : window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!Ctor) { dead = true; log("warn", "sound: no Web Audio in this webview — alerts are silent"); return null; }
+  try {
+    ctx = new Ctor();
+    master = ctx.createGain();
+    master.gain.value = 1;
+    master.connect(ctx.destination);
+  } catch (e) {
+    dead = true;
+    log("warn", `sound: could not open an audio context (${String(e)})`);
+    return null;
+  }
+  return ctx;
+}
+
+// The gesture that unlocks the context. Registered once at module scope — this module
+// is only ever imported by the wiring layer, which is what makes that legal — and
+// `once`, because after the first resume the context stays running for the app's life.
+// Nothing here plays: it exists purely so the FIRST alert is audible rather than the
+// second. `capture` so it still fires for handlers that stop propagation.
+if (typeof document !== "undefined") {
+  const wake = () => { const c = audio(); if (c && c.state === "suspended") void c.resume(); };
+  document.addEventListener("pointerdown", wake, { once: true, capture: true });
+  document.addEventListener("keydown", wake, { once: true, capture: true });
+}
+
+/// 0–100 → amplitude. Loudness is roughly the square of amplitude, so a linear slider
+/// spends its bottom half inaudible and its top half painful; this spreads the useful
+/// range across the whole control.
+const amplitude = (volume: number) => Math.pow(Math.max(0, Math.min(100, volume)) / 100, 1.8) * PEAK;
+
+function ring(id: ToneId, volume: number) {
+  const c = audio();
+  if (!c || !master || volume <= 0) return;
+  // Cheap and idempotent, and the only thing standing between a backgrounded app and
+  // silence: a WebView may suspend the context whenever it likes, not just at startup.
+  if (c.state === "suspended") void c.resume();
+  const tone = toneDef(id);
+  const amp = amplitude(volume);
+  // A hair in the future: scheduling at exactly `currentTime` is scheduling in the past
+  // by the time the node exists, and the runtime's repair for that is an audible click.
+  const t0 = c.currentTime + 0.01;
+  for (const st of tone.steps) {
+    const start = t0 + st.at / 1000;
+    const end = start + st.ms / 1000;
+    const osc = c.createOscillator();
+    const g = c.createGain();
+    osc.type = st.wave ?? "sine";
+    osc.frequency.setValueAtTime(st.hz, start);
+    // A step shorter than the attack would ramp up past its own end and never come
+    // back down — which is the one envelope that rings on forever.
+    const atk = Math.min(ATTACK, (end - start) * 0.4);
+    g.gain.setValueAtTime(ZERO, start);
+    g.gain.exponentialRampToValueAtTime(Math.max(ZERO, amp * (st.gain ?? 1)), start + atk);
+    g.gain.exponentialRampToValueAtTime(ZERO, end);
+    osc.connect(g);
+    g.connect(master);
+    osc.start(start);
+    osc.stop(end + 0.02);
+    // Nodes are not garbage until they are disconnected; an app that runs for days
+    // and rings a few thousand times would otherwise keep every one of them.
+    osc.onended = () => { osc.disconnect(); g.disconnect(); };
+  }
+}
+
+// What ./sound cannot see: whether anyone is looking, and what was last heard. Held
+// here rather than in ./state because nothing else in the app has any use for it and
+// it is not worth persisting — a fresh run should never suppress its first sound.
+let gate: SoundGate = SOUND_GATE_IDLE;
+
+/**
+ * An event happened. Rings if the user's preferences and the burst rules say so.
+ *
+ * Every caller fires this unconditionally and lets `soundFor` decide — the call sites
+ * (the telemetry handler, the exit handler, `launch`) must not grow a second copy of
+ * the "is sound on?" question, or turning it off in one place and not the other is a
+ * bug nobody can hear.
+ */
+export function playSound(ev: SoundEvent) {
+  const now = Date.now();
+  // `document.hasFocus()` and not `visibilityState`: a window that is merely behind
+  // another one is still "visible", and that is exactly the case the `away` setting
+  // is about.
+  const focused = typeof document !== "undefined" && document.hasFocus();
+  const tone = soundFor(soundPrefs, ev, now, { ...gate, focused });
+  if (!tone) return;
+  gate = { focused, lastAt: now, lastEv: ev };
+  ring(tone, soundPrefs.volume);
+  log("info", `sound ${ev} · ${tone}`);
+}
+
+/**
+ * Play something because the user asked to hear it, in Settings.
+ *
+ * Deliberately NOT `playSound`: a preview must ignore the focus rule (you are looking
+ * straight at the settings window, which is the one moment `away` would silence
+ * everything), the per-event switch (you are auditioning a row you may be about to
+ * switch on) and the burst gate (clicking through tones is meant to be rapid). The one
+ * thing it honours is the volume, because that is usually what is being judged. It
+ * also leaves `gate` alone, so an audition can never suppress a real alert that lands
+ * mid-click.
+ */
+export function previewTone(id: ToneId) { ring(id, soundPrefs.volume); }
+export function previewEvent(ev: SoundEvent) { previewTone(soundPrefs.events[ev].tone); }
+/// How long a preview will ring, so a caller can pace a sequence of them.
+export const previewMs = (id: ToneId) => toneMs(toneDef(id));

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,9 +23,11 @@ import {
   addProject, addProjectPath, cycleIoScope, cycleSort, effectiveTheme, openProjectFolder,
   followSessionDrift, removeFavorite, resolvePermission, revealActiveFolder,
   copyPath, openTerminalIn, setActionsRenderAll, setPeekPrefs, setPermMode, setSort,
-  setTheme, setWtGroup, toggleInsp, toggleProjGroup,
+  setSoundPrefs, setTheme, setWtGroup, toggleInsp, toggleProjGroup,
   toggleRail, toggleTheme,
 } from "./actions";
+import { playSound, setSoundLogger } from "./chime";
+import { exitSound, hookSound, limitCrossed, soundSnap } from "./sound";
 import {
   activeCwd, activeProjectCtx, closeRunGroup, closeSession, focusInGroup, handToTerminal,
   adoptOrphans, launch, launchShell, launchTask, launchWorktree, noteDrift,
@@ -59,7 +61,7 @@ import {
   toggleDbg,
 } from "./debug";
 import { basename, setHome } from "./format";
-import { setRlLogger } from "./rl";
+import { rl, setRlLogger } from "./rl";
 import { closeCafPop, reconcileCaf, setCafHost } from "./caffeinate";
 import { closeDiff, diffOpen, openDiff, setDiffCloseFootMenus } from "./diffview";
 // The commit-graph panel needs nothing from here — it is opened from the project
@@ -222,8 +224,10 @@ setMirrorRenderAll(renderAll);
 // what it can reach back for.
 setSettingsHost({
   setTheme, effectiveTheme, setSort, setEngine, bumpFont, applyFontSize, refreshTokens,
-  setWtGroup, setPermMode, setPeekPrefs,
+  setWtGroup, setPermMode, setPeekPrefs, setSoundPrefs,
 });
+// "Why was there no noise?" is otherwise unanswerable from outside the player.
+setSoundLogger(dlog);
 // The task panels run tasks, hand commands to terminals and put panes on stage —
 // none of which they own.
 // The dashboard acts on a project through verbs it does not own — the launcher, the
@@ -494,6 +498,10 @@ listen<{ sessionId: string; code: number }>("pty-exit", (e) => {
     // trims on the way off). See trimScrollback for why claude panes only.
     if (isAgent(s) && activeId !== s.id) trimScrollback(s);
   }
+  // A task's exit code is its verdict; anything else just stopped. After the branches
+  // above so a task has its `exitCode` before this reads the kind, and in one place
+  // rather than three so the two outcomes can never diverge.
+  playSound(exitSound(s.kind, code));
   renderAll();
 });
 
@@ -513,7 +521,19 @@ listen<{ kind: string; data: any }>("telemetry", (e) => {
     s.resumeId = rt;
     flushRoster(); // rare and load-bearing — never let a debounce lose this one
   }
+  // Sound alerts read the state machine's verdict rather than the raw payload: what a
+  // hook MEANS is ./phase's decision (done vs. error, a permission vs. any other
+  // notification), and a second reading of the payload here would be a second copy of
+  // that decision — the copy that drifts. So snapshot, apply, compare. Both snapshots
+  // are three fields; this costs nothing per event.
+  const before = soundSnap(s);
+  const rlBefore = { h5: rl.h5, d7: rl.d7 };
   if (kind === "statusline") applyStatusline(s, data); else { dlog("info", `hook ${data.hook_event_name ?? "?"} · ${sid!.slice(0, 8)}`); applyHook(s, data); }
+  const ev = hookSound(before, soundSnap(s));
+  if (ev) playSound(ev);
+  // Rate limits are account-wide, so this is deliberately outside the per-session
+  // branch above: one crossing, one chime, however many sessions report it.
+  if (limitCrossed(rlBefore.h5, rl.h5) !== null || limitCrossed(rlBefore.d7, rl.d7) !== null) playSound("limit");
   queueRosterSave();
   renderAll();
 });
@@ -529,6 +549,11 @@ listen<{ id: string; data: any }>("permission", (e) => {
   s.pendingCmd = permCmd(data);
   s.pendingPermId = id;
   s.pendRisk = riskLevel(data.tool_name, data.tool_input);
+  // The one alert the whole feature is for: Claude is stopped until this is answered,
+  // and nothing else in the app can reach you from another window. The matching
+  // `PermissionRequest` hook usually rings a beat earlier or later — `SOUND_REPEAT_MS`
+  // is what makes the pair one sound rather than two.
+  playSound("permission");
   renderAll();
 });
 

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -22,6 +22,7 @@ import { ask } from "@tauri-apps/plugin-dialog";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { $, takeStage, toast } from "./dom";
+import { playSound } from "./chime";
 import { dlog } from "./debug";
 import { basename, esc, tilde } from "./format";
 import {
@@ -141,6 +142,10 @@ export async function launch(project: string, workdir: string, opts: { colorKey?
     if (term) term.writeln(`\r\n\x1b[31m[launch error] ${e}\x1b[0m`);
     else pane.innerHTML = `<div class="ext-pane"><h2>Couldn't launch ${esc(eng.label)}</h2><p>${esc(String(e))}</p></div>`;
   }
+  // Off by default — you were standing right here — but it is the one confirmation an
+  // EXTERNAL engine gives that the window really opened somewhere else. Only a spawn
+  // that worked: the failure above already toasts, and a chirp under it reads as success.
+  if (spawned) playSound("launched");
   invoke<string | null>("git_branch", { workdir }).then((b) => {
     if (b && !s.branch) { s.branch = b; renderSidebar(); if (activeId === id) renderHeader(s); }
   });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,9 +17,15 @@ import { basename, esc, tilde } from "./format";
 import type { Engine, PermMode } from "./types";
 import {
   ALL_PERM_MODES, availEngines, engineDef, peekPrefs, permMode, setTermFontSize,
-  SORT_META, SORT_MODES, sortMode, termEngine, termFontSize, wtGroup,
+  SORT_META, SORT_MODES, sortMode, soundPrefs, termEngine, termFontSize, wtGroup,
   type SortMode, type WtGroup,
 } from "./state";
+import {
+  isDefaultSoundPrefs, SOUND_EVENTS, soundDefaults, toneDef, TONES, VOLUME_RANGE,
+  VOLUME_STEP, type SoundEvent, type SoundEventDef, type SoundPrefs, type SoundWhen,
+  type ToneId,
+} from "./sound";
+import { previewEvent, previewTone } from "./chime";
 import {
   PEEK_CLOSE_RANGE, PEEK_DEFAULTS, PEEK_IDLE, PEEK_OPEN_RANGE, peekEnter, peekLeave,
   peekLeaveAll, peekNextDeadline, peekTick, type PeekPrefs, type PeekState,
@@ -51,11 +57,13 @@ export interface SettingsHost {
   setPermMode: (m: PermMode) => void;
   // Ditto. ./actions clamps through ./peek, persists and repaints the sidebar.
   setPeekPrefs: (p: PeekPrefs) => void;
+  // Ditto again — ./actions clamps through ./sound, persists and repaints this window.
+  setSoundPrefs: (p: SoundPrefs) => void;
 }
 let host: SettingsHost = {
   setTheme: () => {}, effectiveTheme: () => "dark", setSort: () => {}, setEngine: () => {},
   bumpFont: () => {}, applyFontSize: () => {}, refreshTokens: () => {},
-  setWtGroup: () => {}, setPermMode: () => {}, setPeekPrefs: () => {},
+  setWtGroup: () => {}, setPermMode: () => {}, setPeekPrefs: () => {}, setSoundPrefs: () => {},
 };
 export function setSettingsHost(h: SettingsHost) { host = h; }
 
@@ -74,6 +82,10 @@ type SetControl =
   // can actually hover to feel the numbers. A stepper alone is a guess — "is 1000ms
   // right?" has no answer until you have rested a pointer on something for 1000ms.
   | { kind: "peek"; label: string; hint?: string }
+  // Sound alerts: the master switch, the volume, the focus rule and a row per event.
+  // One control rather than a `render` tab for the same reason `peek` is one — they
+  // are one decision, and a `render` tab also widens the dialog (see renderSettings).
+  | { kind: "sound"; label: string; hint?: string }
   // A single on/off switch.
   | { kind: "toggle"; set: string; label: string; hint?: string; on: () => boolean }
   // Independently-toggled values — "which providers to scan" isn't a pick-one.
@@ -117,6 +129,13 @@ const SET_TABS: SetTab[] = [
       { kind: "seg", set: "sort", label: "Sidebar sort", hint: "How projects and sessions are ordered in the sidebar.",
         active: () => sortMode,
         segs: () => SORT_MODES.map((m) => ({ value: m, label: SORT_SHORT[m], sub: SORT_META[m].label, glyph: SORT_META[m].glyph })) },
+    ],
+  },
+  {
+    id: "sounds", label: "Sounds", glyph: "♪",
+    controls: () => [
+      { kind: "sound", label: "Sound alerts",
+        hint: "Episko is built for a fleet you are deliberately not watching, and every other signal it has — the glyph, the badge, the tray — needs the window in front of you. Click a row's sound name to change it; every button here plays what it does." },
     ],
   },
   {
@@ -314,6 +333,68 @@ function renderPeekControl(): string {
   </div>`;
 }
 
+// ---------- the sound control: a volume, a focus rule, and a row per event ----------
+// Every button in here PLAYS what it changes, and that is the design rather than a
+// flourish: a list of ten names ("Chime", "Drop", "Buzz") is unusable — nobody knows
+// what a "Drop" is until they have heard one, and a settings pane you cannot audition
+// is a pane you set once at random and never touch again. So changing a tone plays it,
+// switching an event on plays it, and nudging the volume plays at the new volume.
+//
+// Which row's tone strip is open. Module state like `setTab`, and deliberately not
+// persisted — it is where you are looking, not something you chose.
+let soundPick: SoundEvent | null = null;
+
+function volStepper(v: number): string {
+  return `<div class="set-font peekstep">
+    <span class="peekstep-l">Volume</span>
+    <button class="set-fbtn" data-setsound="vol:${-VOLUME_STEP}" ${v <= VOLUME_RANGE.min ? "disabled" : ""} aria-label="Quieter">−</button>
+    <span class="set-fval mono">${v}%</span>
+    <button class="set-fbtn" data-setsound="vol:${VOLUME_STEP}" ${v >= VOLUME_RANGE.max ? "disabled" : ""} aria-label="Louder">+</button>
+  </div>`;
+}
+// One event. The switch is the same `.sw` the rest of the window uses; the tone name is
+// a disclosure button, so ten tones × ten events stay out of sight until asked for.
+function soundRow(d: SoundEventDef): string {
+  const cfg = soundPrefs.events[d.id];
+  const open = soundPick === d.id;
+  const tone = toneDef(cfg.tone);
+  const strip = open
+    ? `<div class="chips sndtones">${TONES.map((t) =>
+        `<button class="chip-opt ${t.id === cfg.tone ? "on" : ""}" data-setsound="tone:${d.id}:${t.id}" title="${esc(t.hint)}">${esc(t.label)}</button>`).join("")}</div>`
+    : "";
+  return `<div class="sndev${cfg.on ? "" : " off"}">
+    <div class="sndev-h">
+      <span class="sndev-g">${d.glyph}</span>
+      <div class="sndev-t"><div class="sndev-l">${esc(d.label)}</div><div class="sndev-s">${esc(d.hint)}</div></div>
+      <button class="sndtone${open ? " on" : ""}" data-setsound="pick:${d.id}" aria-expanded="${open}">${esc(tone.label)}<span class="sndtone-c">▾</span></button>
+      <button class="sndplay" data-setsound="play:${d.id}" title="Play it" aria-label="Play ${esc(d.label)}">▶</button>
+      <button class="sw${cfg.on ? " on" : ""}" data-setsound="ev:${d.id}" role="switch" aria-checked="${cfg.on}"></button>
+    </div>${strip}
+  </div>`;
+}
+const WHEN_SEGS: { value: SoundWhen; label: string }[] = [
+  { value: "always", label: "Always" },
+  { value: "away", label: "Only when Episko is in the background" },
+];
+function renderSoundControl(): string {
+  const p = soundPrefs;
+  return `<div class="sndbox${p.enabled ? "" : " off"}">
+    <div class="peekrow">
+      ${volStepper(p.volume)}
+      <button class="set-freset" data-setsound="reset" ${isDefaultSoundPrefs(p) ? "disabled" : ""}>Reset</button>
+    </div>
+    <div class="sndwhen">
+      <div class="peekstep-l">Play</div>
+      <div class="chips">${WHEN_SEGS.map((w) =>
+        `<button class="chip-opt ${p.when === w.value ? "on" : ""}" data-setsound="when:${w.value}">${esc(w.label)}</button>`).join("")}</div>
+    </div>
+    <div class="sndlist">${SOUND_EVENTS.map(soundRow).join("")}</div>
+    <div class="peekhint">${p.enabled
+      ? "The last three start switched off: they fire on routine activity, or on something you did yourself. Turning everything on is exactly how a set of alerts becomes background noise you stop hearing — which costs you the permission chime too."
+      : "Sounds are off, so nothing below fires by itself. The rows keep what you picked, and ▶ still plays — auditioning is how you decide whether to switch them back on."}</div>
+  </div>`;
+}
+
 function renderSetControl(c: SetControl): string {
   const head = `<div class="set-glabel">${esc(c.label)}</div>${c.hint ? `<div class="set-hint">${esc(c.hint)}</div>` : ""}`;
   if (c.kind === "wtpreview") {
@@ -325,6 +406,13 @@ function renderSetControl(c: SetControl): string {
     return `<div class="set-group"><div class="set-inline"><div class="set-itxt">${head}</div>`
       + `<button class="sw${peekPrefs.enabled ? " on" : ""}" data-setpeek="toggle" role="switch"`
       + ` aria-checked="${peekPrefs.enabled}"></button></div>${renderPeekControl()}</div>`;
+  }
+  if (c.kind === "sound") {
+    // Same shape as `peek` above: the master switch rides the label row, the panel it
+    // governs sits under it, because they are one decision.
+    return `<div class="set-group"><div class="set-inline"><div class="set-itxt">${head}</div>`
+      + `<button class="sw${soundPrefs.enabled ? " on" : ""}" data-setsound="toggle" role="switch"`
+      + ` aria-checked="${soundPrefs.enabled}"></button></div>${renderSoundControl()}</div>`;
   }
   if (c.kind === "font") {
     return `<div class="set-group">${head}<div class="set-font">
@@ -398,6 +486,59 @@ function applyPeekSetting(cmd: string) {
   else if (which === "close") host.setPeekPrefs({ ...peekPrefs, closeMs: peekPrefs.closeMs + +delta });
 }
 
+/**
+ * A press in the sound panel. Everything routes through `host.setSoundPrefs`, which
+ * clamps, persists and re-renders this window — so the markup above is always painted
+ * from the stored value rather than from what a handler thought it had set.
+ *
+ * The previews are the other half. Note which ones deliberately do NOT play: switching
+ * an event *off*, and Reset — a burst of ten tones is not a useful answer to "make it
+ * quieter", and hearing a sound as you switch it off says the wrong thing entirely.
+ */
+function applySoundSetting(cmd: string) {
+  const p = soundPrefs;
+  const set = (next: SoundPrefs) => host.setSoundPrefs(next);
+  const withEvent = (id: SoundEvent, patch: Partial<SoundPrefs["events"][SoundEvent]>) =>
+    set({ ...p, events: { ...p.events, [id]: { ...p.events[id], ...patch } } });
+
+  if (cmd === "reset") { soundPick = null; set(soundDefaults()); return; }
+  if (cmd === "toggle") {
+    const enabled = !p.enabled;
+    set({ ...p, enabled });
+    // Say so out loud when switching on — the panel is otherwise a list of promises,
+    // and this is the moment the browser's autoplay gate is known to be open (a click
+    // just landed), so a silent one here is worth knowing about.
+    if (enabled) previewEvent("done");
+    return;
+  }
+  const [verb, a, b] = cmd.split(":");
+  if (verb === "vol") {
+    // Clamping is `clampSoundPrefs`' job; the buttons disable at the bounds and this
+    // catches the rest, exactly as the peek steppers do.
+    set({ ...p, volume: p.volume + Number(a) });
+    previewTone(soundPrefs.events.done.tone); // the NEW volume — soundPrefs is live
+    return;
+  }
+  if (verb === "when") { set({ ...p, when: a === "away" ? "away" : "always" }); return; }
+  if (verb === "ev") {
+    const id = a as SoundEvent;
+    const on = !p.events[id].on;
+    withEvent(id, { on });
+    if (on) previewEvent(id);
+    return;
+  }
+  // The disclosure. Only one strip is open at a time — ten open strips is the list you
+  // were trying not to show.
+  if (verb === "pick") { soundPick = soundPick === a ? null : (a as SoundEvent); renderSettings(); return; }
+  if (verb === "tone") {
+    const id = a as SoundEvent;
+    withEvent(id, { tone: b as ToneId });
+    previewTone(b as ToneId);
+    return;
+  }
+  if (verb === "play") previewEvent(a as SoundEvent);
+}
+
 // ---------- the preview's own peek driver ----------
 // Same reducer as the sidebar's, its own state. It reads `peekPrefs` at event time
 // rather than capturing it, so a stepper press is felt on the very next hover with
@@ -458,6 +599,8 @@ $("setBody").addEventListener("click", (e) => {
   if (f) { setFontFromSettings(f.dataset.setfont!); return; }
   const pk = (e.target as HTMLElement).closest<HTMLElement>("[data-setpeek]");
   if (pk) { applyPeekSetting(pk.dataset.setpeek!); return; }
+  const sd = (e.target as HTMLElement).closest<HTMLElement>("[data-setsound]");
+  if (sd) { applySoundSetting(sd.dataset.setsound!); return; }
   const r = (e.target as HTMLElement).closest<HTMLElement>("[data-urange]");
   if (r) { setUsageRange(+r.dataset.urange!); renderSettings(); return; }
   const o = (e.target as HTMLElement).closest<HTMLElement>("[data-set]");

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -1,0 +1,297 @@
+// Sound alerts — the catalogue of what is worth hearing, the tones themselves, and
+// the one function that decides whether a given moment actually rings.
+//
+// WHY THIS EXISTS. Episko is a cockpit for a fleet you are deliberately *not*
+// watching: the whole point of running six agents is that you go and do something
+// else. Every signal it has until now is visual — the sidebar glyph, the attention
+// badge, the tray — and all three require the window to be in front of you. A
+// blocked permission is the extreme case: Claude is stopped, doing nothing, until
+// you answer, and nothing tells you.
+//
+// THE RULES ARE HERE AND THE AUDIO IS NOT. Everything below is data and pure
+// functions over an explicit `now` — no `AudioContext`, no DOM, no ./state — so the
+// awkward parts (what suppresses what, what a corrupt preference decays to) are
+// unit-testable, and ./chime is left as a thin player that only has to turn a
+// `Tone` into oscillators. Same split as ./peek and ./sidebar. See test/sound.test.ts.
+//
+// THE HARD PART IS NOT PLAYING A SOUND, IT IS NOT PLAYING SIX. Telemetry arrives in
+// bursts — N agents each firing a hook per lifecycle event plus a statusLine — and
+// the same real-world moment reaches us twice by design (a permission arrives as both
+// the blocking `PermissionRequest` and a `Notification`; a session ending arrives as
+// both `SessionEnd` and `pty-exit`). An unguarded `play()` per event turns a fleet
+// into a fruit machine. `soundFor` is where that is prevented, and it is the reason
+// this module exists as a decision rather than a call.
+
+import type { Phase, Sess, SessKind } from "./types";
+
+// ---------- the tones ----------
+// Synthesised rather than shipped as audio files: a handful of oscillator envelopes
+// is a few hundred bytes of data, needs no bundler asset handling, no decode, no
+// network, and no license — and a two-note chime is not something a WAV does better.
+/// Deliberately our own union rather than lib.dom's `OscillatorType`. It is assignable
+/// to it, and this module promises to name no browser type.
+export type Wave = "sine" | "triangle" | "square" | "sawtooth";
+/// One oscillator in a tone. `at`/`ms` are milliseconds from the tone's start, so a
+/// tone is a tiny score rather than a chain of callbacks; `gain` is relative to the
+/// user's master volume, which is the only thing that scales the whole set.
+export interface ToneStep { hz: number; at: number; ms: number; gain?: number; wave?: Wave }
+export type ToneId =
+  | "chime" | "arp" | "bell" | "ping" | "pop"
+  | "knock" | "drop" | "alert" | "buzz" | "swell";
+export interface Tone { id: ToneId; label: string; hint: string; steps: ToneStep[] }
+
+// Pitches are real notes (A4 = 440) because intervals are what make two sounds
+// distinguishable from another room — a rising fifth reads as "finished" and a
+// falling one as "stopped" long before you have consciously identified either.
+export const TONES: Tone[] = [
+  { id: "chime", label: "Chime", hint: "Two-note rise", steps: [
+    { hz: 880, at: 0, ms: 180 }, { hz: 1318.5, at: 100, ms: 320, gain: 0.85 } ] },
+  { id: "arp", label: "Arpeggio", hint: "Three notes up", steps: [
+    { hz: 523.25, at: 0, ms: 130 }, { hz: 659.25, at: 70, ms: 130 }, { hz: 783.99, at: 140, ms: 300 } ] },
+  { id: "bell", label: "Bell", hint: "Struck, long decay", steps: [
+    { hz: 659.25, at: 0, ms: 900 }, { hz: 987.77, at: 0, ms: 700, gain: 0.4 }, { hz: 1318.5, at: 0, ms: 450, gain: 0.22 } ] },
+  { id: "ping", label: "Ping", hint: "One clear blip", steps: [
+    { hz: 1174.66, at: 0, ms: 220 } ] },
+  { id: "pop", label: "Pop", hint: "Barely there", steps: [
+    { hz: 1568, at: 0, ms: 70, wave: "triangle", gain: 0.7 } ] },
+  { id: "knock", label: "Knock", hint: "Two low taps", steps: [
+    { hz: 196, at: 0, ms: 110, wave: "triangle" }, { hz: 174.61, at: 130, ms: 140, wave: "triangle" } ] },
+  { id: "drop", label: "Drop", hint: "Two-note fall", steps: [
+    { hz: 659.25, at: 0, ms: 150 }, { hz: 392, at: 110, ms: 340, gain: 0.9 } ] },
+  { id: "alert", label: "Alert", hint: "Three urgent pips", steps: [
+    { hz: 987.77, at: 0, ms: 90, wave: "square", gain: 0.45 },
+    { hz: 987.77, at: 150, ms: 90, wave: "square", gain: 0.45 },
+    { hz: 1318.5, at: 300, ms: 190, wave: "square", gain: 0.45 } ] },
+  { id: "buzz", label: "Buzz", hint: "Low and wrong", steps: [
+    { hz: 146.83, at: 0, ms: 150, wave: "sawtooth", gain: 0.5 },
+    { hz: 110, at: 180, ms: 280, wave: "sawtooth", gain: 0.5 } ] },
+  { id: "swell", label: "Swell", hint: "Soft, unhurried", steps: [
+    { hz: 329.63, at: 0, ms: 700, gain: 0.7 }, { hz: 493.88, at: 120, ms: 640, gain: 0.45 } ] },
+];
+const TONE_IDS = TONES.map((t) => t.id);
+/// An unknown id falls back to the first tone rather than throwing — this is reached
+/// from a persisted preference, and a hand-edited `cc-sound` must not silence the app.
+export function toneDef(id: ToneId): Tone { return TONES.find((t) => t.id === id) || TONES[0]; }
+/// How long a tone rings, end to end. The player needs it to schedule; the settings
+/// preview needs it to not stack previews on top of each other.
+export function toneMs(t: Tone): number { return t.steps.reduce((n, s) => Math.max(n, s.at + s.ms), 0); }
+
+// ---------- the catalogue ----------
+/// Everything Episko is willing to make a noise about. Ordered by how much it wants
+/// you, which is also the order the settings list shows.
+export type SoundEvent =
+  | "permission" | "question" | "done" | "error" | "taskFail"
+  | "limit" | "taskDone" | "toolFail" | "ended" | "launched";
+
+export interface SoundEventDef {
+  id: SoundEvent; glyph: string; label: string; hint: string;
+  /// The tone a fresh install uses, and what Reset returns to.
+  tone: ToneId;
+  /// Whether a fresh install has it on. The three that are off by default are the
+  /// ones that fire *often* — a noise you learn to ignore has made every other
+  /// noise worse, so opting in to them is the honest default.
+  on: boolean;
+  /// 3 urgent · 2 needs you · 1 informational · 0 background. Only read by the
+  /// burst rule in `soundFor`: inside the gap, a louder event still gets through.
+  priority: number;
+}
+
+export const SOUND_EVENTS: SoundEventDef[] = [
+  { id: "permission", glyph: "◆", label: "Permission asked", priority: 3, tone: "alert", on: true,
+    hint: "Claude is blocked and doing nothing until you answer." },
+  { id: "question", glyph: "◇", label: "Notification", priority: 2, tone: "ping", on: true,
+    hint: "Anything else the session raises — a question, a nudge, a plan to accept." },
+  { id: "done", glyph: "●", label: "Your turn", priority: 2, tone: "chime", on: true,
+    hint: "An agent finished its turn and is waiting on you." },
+  { id: "error", glyph: "✕", label: "Turn failed", priority: 2, tone: "buzz", on: true,
+    hint: "The API killed the turn — overloaded, rate limited, auth. Not the same as a tool that failed." },
+  { id: "taskFail", glyph: "▶", label: "Run failed", priority: 2, tone: "buzz", on: true,
+    hint: "A task exited non-zero. Includes the ones that run by themselves after a turn." },
+  { id: "limit", glyph: "▦", label: "Usage limit", priority: 2, tone: "bell", on: true,
+    hint: "A rate-limit window crossed 50%, 80% or 95%. Account-wide, so it fires once, not once per session." },
+  { id: "taskDone", glyph: "▶", label: "Run passed", priority: 1, tone: "arp", on: true,
+    hint: "A task exited 0." },
+  { id: "toolFail", glyph: "!", label: "Tool call failed", priority: 0, tone: "pop", on: false,
+    hint: "A single tool errored mid-turn. Off by default: a failed grep is normal, and this fires every time." },
+  { id: "ended", glyph: "·", label: "Session ended", priority: 0, tone: "drop", on: false,
+    hint: "A session or terminal's process exited." },
+  { id: "launched", glyph: "+", label: "Session launched", priority: 0, tone: "knock", on: false,
+    hint: "You started a session. Off by default — you were there." },
+];
+const EVENT_IDS = SOUND_EVENTS.map((e) => e.id);
+export function soundEventDef(id: SoundEvent): SoundEventDef {
+  return SOUND_EVENTS.find((e) => e.id === id) || SOUND_EVENTS[0];
+}
+
+// ---------- the preferences ----------
+/// When sounds are allowed to play at all. `away` is the setting most people
+/// actually want: the noise exists to reach you in another window, and hearing it
+/// while you are looking straight at the pane that made it is pure annoyance.
+export type SoundWhen = "always" | "away";
+export interface SoundPrefs {
+  enabled: boolean;
+  /// 0–100. Not a raw amplitude — ./chime curves it, because linear gain sounds
+  /// like nothing at all until about 60 and then like a siren.
+  volume: number;
+  when: SoundWhen;
+  events: Record<SoundEvent, { on: boolean; tone: ToneId }>;
+}
+
+export const VOLUME_RANGE = { min: 0, max: 100 } as const;
+export const VOLUME_STEP = 10;
+
+function defaultEvents(): SoundPrefs["events"] {
+  const out = {} as SoundPrefs["events"];
+  for (const d of SOUND_EVENTS) out[d.id] = { on: d.on, tone: d.tone };
+  return out;
+}
+/// Built fresh each read rather than shared, so a caller spreading `SOUND_DEFAULTS`
+/// can never hand a mutated `events` map back to the store.
+export const soundDefaults = (): SoundPrefs => ({ enabled: true, volume: 60, when: "always", events: defaultEvents() });
+
+const clampNum = (n: number, lo: number, hi: number, dflt: number) =>
+  Number.isFinite(n) ? Math.min(hi, Math.max(lo, Math.round(n))) : dflt;
+
+/**
+ * Whatever came out of `localStorage` (or a settings control), made safe.
+ *
+ * The three things it has to survive, all of which have happened to the other JSON
+ * blob preferences: a key that is simply absent (an older install), a value that was
+ * hand-edited to nonsense, and — the one worth naming — an `events` map written
+ * before an event existed. A new entry in `SOUND_EVENTS` must arrive switched to its
+ * own default, not missing, or the row renders and the switch reads `undefined`.
+ */
+export function clampSoundPrefs(p: Partial<SoundPrefs> | null | undefined): SoundPrefs {
+  const d = soundDefaults();
+  const events = {} as SoundPrefs["events"];
+  const raw = (p?.events ?? {}) as Partial<SoundPrefs["events"]>;
+  for (const def of SOUND_EVENTS) {
+    const got = raw[def.id];
+    const tone = got?.tone as ToneId | undefined;
+    events[def.id] = {
+      on: typeof got?.on === "boolean" ? got.on : def.on,
+      // An id we no longer ship (a renamed tone) decays to this event's own default
+      // rather than to TONES[0] — the default is what the user would have picked.
+      tone: tone && TONE_IDS.includes(tone) ? tone : def.tone,
+    };
+  }
+  return {
+    enabled: p?.enabled !== false,
+    volume: clampNum(Number(p?.volume), VOLUME_RANGE.min, VOLUME_RANGE.max, d.volume),
+    when: p?.when === "away" ? "away" : "always",
+    events,
+  };
+}
+/// Whether these are still the shipped defaults — what disables the Reset button.
+export function isDefaultSoundPrefs(p: SoundPrefs): boolean {
+  const d = soundDefaults();
+  return p.enabled === d.enabled && p.volume === d.volume && p.when === d.when
+    && EVENT_IDS.every((id) => p.events[id].on === d.events[id].on && p.events[id].tone === d.events[id].tone);
+}
+
+// ---------- the decision ----------
+/// The two suppression windows. `GAP` is "these are the same burst" — telemetry from
+/// one moment across several sessions lands inside a frame or two, and hearing it
+/// once is the correct rendering of one event. `REPEAT` is longer and per-event,
+/// because the duplicates that matter are *by design*: a permission arrives as both
+/// the blocking hook and a Notification, and a session ending as both `SessionEnd`
+/// and `pty-exit`. Neither is a bug to fix upstream — both really are two signals of
+/// one fact, and one of the two is what makes the other reliable.
+export const SOUND_GAP_MS = 350;
+export const SOUND_REPEAT_MS = 1200;
+
+/// What the player knows that this module cannot: whether the window has focus, and
+/// what it last actually played.
+export interface SoundGate {
+  focused: boolean;
+  lastAt: number;
+  lastEv: SoundEvent | null;
+}
+export const SOUND_GATE_IDLE: SoundGate = { focused: true, lastAt: 0, lastEv: null };
+const priority = (e: SoundEvent | null) => (e === null ? -1 : soundEventDef(e).priority);
+
+/**
+ * Should this moment make a noise, and with which tone? `null` means silence.
+ *
+ * The order of the checks is the order of the reasons, cheapest and most absolute
+ * first: switched off, muted, the wrong side of the focus rule, this event switched
+ * off, then the two burst windows.
+ *
+ * The last rule is the only interesting one: **inside the gap, a more urgent event
+ * still gets through.** A permission landing 80ms after a "your turn" is not a
+ * duplicate of it — it is the thing you actually need to hear, and swallowing it to
+ * protect against bursts would suppress exactly the alert the feature exists for.
+ */
+export function soundFor(p: SoundPrefs, ev: SoundEvent, now: number, g: SoundGate): ToneId | null {
+  if (!p.enabled || p.volume <= 0) return null;
+  if (p.when === "away" && g.focused) return null;
+  const cfg = p.events[ev];
+  if (!cfg?.on) return null;
+  const since = now - g.lastAt;
+  if (g.lastEv === ev && since < SOUND_REPEAT_MS) return null;
+  if (since < SOUND_GAP_MS && priority(ev) <= priority(g.lastEv)) return null;
+  return cfg.tone;
+}
+
+// ---------- reading the moment off the session ----------
+/// The three fields that decide whether a hook was worth hearing. Taken before
+/// `applyHook` runs and again after, because the state machine is the thing that
+/// knows what happened — re-deriving it from the raw payload here would be a second
+/// copy of ./phase, and the second copy is always the one that gets it wrong.
+export interface SoundSnap { phase: Phase; attention: string | null; apiErrAt: number | null }
+export const soundSnap = (s: Sess): SoundSnap =>
+  ({ phase: s.phase, attention: s.attention, apiErrAt: s.apiErr?.at ?? null });
+
+/**
+ * What (if anything) a telemetry event changed that is worth a noise.
+ *
+ * Attention outranks the phase deliberately: a session that ends a turn *and* raises
+ * a permission in the same beat is asking you something, and "your turn" is the
+ * weaker way to say so.
+ *
+ * The `error` / `toolFail` split is this codebase's oldest live distinction, and it
+ * is a sound rule as much as a label one. `phase: "error"` is set by BOTH a failed
+ * tool call mid-turn and a turn the API killed, and the first is *routine* — a grep
+ * that matched nothing, a build that failed on purpose. Ringing the same alarm for
+ * both trains you to ignore it within an hour. So a new `apiErr` stamp (which only
+ * `StopFailure` writes) is the real failure, and everything else that reddens the
+ * glyph is the opt-in `toolFail`.
+ */
+export function hookSound(before: SoundSnap, after: SoundSnap): SoundEvent | null {
+  if (after.attention && after.attention !== before.attention) {
+    return /permission/i.test(after.attention) ? "permission" : "question";
+  }
+  if (after.apiErrAt !== null && after.apiErrAt !== before.apiErrAt) return "error";
+  if (after.phase === before.phase) return null;
+  if (after.phase === "done") return "done";
+  if (after.phase === "ended") return "ended";
+  if (after.phase === "error") return "toolFail";
+  return null;
+}
+
+/// A pane's process exited. A task's exit code IS its verdict; anything else just
+/// stopped. (A claude session normally rings this from `SessionEnd` a moment earlier
+/// — `SOUND_REPEAT_MS` is what makes the pair one sound.)
+export const exitSound = (kind: SessKind, code: number): SoundEvent =>
+  kind === "task" ? (code === 0 ? "taskDone" : "taskFail") : "ended";
+
+/// The rate-limit marks worth interrupting you for. Not a percentage-changed signal:
+/// the number climbs continuously, and a chime per statusLine would be unbearable.
+export const LIMIT_STEPS = [50, 80, 95];
+/**
+ * The highest mark this reading crossed that the previous one had not, or null.
+ *
+ * A window *reset* moves the number down, which crosses nothing — that is why this
+ * compares two readings rather than testing a threshold outright.
+ *
+ * **The first reading of a run is a baseline, not a crossing.** `rl.h5` is null until
+ * the first statusLine lands, and counting that from zero would ring the bell on
+ * every single launch that starts above 50% — the one moment the sound is worth
+ * least, because you are looking straight at the footer meter that already says so.
+ */
+export function limitCrossed(before: number | null, after: number | null): number | null {
+  if (after == null || before == null) return null;
+  let hit: number | null = null;
+  for (const step of LIMIT_STEPS) if (after >= step && before < step) hit = step;
+  return hit;
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -23,6 +23,7 @@
 import { basename, hslToHex } from "./format";
 import { clampPeekPrefs, type PeekPrefs } from "./peek";
 import { clampGroups, type GroupStore } from "./projgroups";
+import { clampSoundPrefs, type SoundPrefs } from "./sound";
 import type { DiffStat, Engine, ExtSession, PermMode, Res, Restorable, Sess, WtHead } from "./types";
 
 export interface Favorite { name: string; path: string }
@@ -92,6 +93,16 @@ export function setWtGroup(m: WtGroup) { wtGroup = WT_GROUPS.includes(m) ? m : "
 // than three keys, because the three are only ever read together.
 export let peekPrefs: PeekPrefs = clampPeekPrefs(safeParse(localStorage.getItem("cc-peek")));
 export function setPeekPrefs(p: PeekPrefs) { peekPrefs = clampPeekPrefs(p); }
+
+// --- sound alerts ---------------------------------------------------------------
+// Whether Episko makes a noise when something wants you, and which noise. One JSON
+// blob under cc-sound for the third time and the same reason as cc-peek above: the
+// master switch, the volume and the ten per-event rows are only ever read together,
+// and a per-event key that outlived its event is a corruption nobody could diagnose.
+// The rules, the catalogue and the clamping are ./sound, which is pure and tested;
+// this only holds the value.
+export let soundPrefs: SoundPrefs = clampSoundPrefs(safeParse(localStorage.getItem("cc-sound")));
+export function setSoundPrefs(p: SoundPrefs) { soundPrefs = clampSoundPrefs(p); }
 // Shared by every preference stored as a JSON blob (peek above, the project groups
 // higher up). A corrupt or hand-edited value must not take the app down during module
 // import, the same stance ./tasks and ./notes take with their own stores — and the

--- a/src/styles.css
+++ b/src/styles.css
@@ -1530,6 +1530,44 @@ select.in-ctl { cursor: pointer; }
 .peekdemo .pkgo { font-size: 10px; }
 .peekhint { font-size: 11px; line-height: 1.5; color: var(--muted-2); max-width: 58ch; }
 
+/* ---------- Settings › Sounds ----------
+   Deliberately built out of the peek control's parts (.peekrow, .peekstep, .peekhint)
+   and the shared .sw / .chip-opt, so the two panels read as one window rather than as
+   two people's work. What is new here is only the per-event row. */
+.sndbox { display: flex; flex-direction: column; gap: 13px; margin-top: 11px; }
+.sndbox.off { opacity: .55; }
+.sndbox .set-fbtn[disabled] { opacity: .35; cursor: default; }
+.sndbox .set-fbtn[disabled]:hover { border-color: var(--hair-strong); background: var(--surface); }
+.sndbox .set-freset[disabled] { opacity: .35; cursor: default; }
+.sndbox .set-freset[disabled]:hover { color: var(--muted); border-color: var(--hair); }
+.sndwhen { display: flex; flex-direction: column; gap: 6px; }
+.sndlist { display: flex; flex-direction: column; gap: 3px; }
+/* A row, not a card: ten cards is a wall. The switch, the sound name and ▶ all sit on
+   one line so the column of switches can be read straight down. */
+.sndev { border-radius: 9px; border: 1px solid transparent; padding: 7px 9px; transition: background .14s, border-color .14s, opacity .14s; }
+.sndev:hover { background: var(--surface); border-color: var(--hair); }
+/* Dimmed rather than hidden — a switched-off alert is still information, and you need
+   to see the whole list to judge how noisy the set is. */
+.sndev.off { opacity: .5; }
+.sndev.off:hover { opacity: .8; }
+.sndev-h { display: flex; align-items: center; gap: 9px; }
+.sndev-g { flex: none; width: 15px; text-align: center; font-size: 11px; color: var(--muted-2); }
+.sndev-t { flex: 1; min-width: 0; }
+.sndev-l { font-size: 12px; font-weight: 650; }
+.sndev-s { font-size: 10.5px; color: var(--muted-2); line-height: 1.4; margin-top: 1px; max-width: 46ch; }
+.sndtone { flex: none; display: inline-flex; align-items: center; gap: 4px; height: 24px; padding: 0 8px; border-radius: 7px; cursor: pointer;
+  font: 600 10.5px var(--font-ui); color: var(--muted); background: var(--surface); border: 1px solid var(--hair-strong); }
+.sndtone:hover { color: var(--text); border-color: var(--accent-line); }
+.sndtone.on { background: var(--accent-wash); border-color: var(--accent-line); color: var(--accent-ink); }
+.sndtone-c { font-size: 8px; opacity: .7; transition: transform .14s; }
+.sndtone.on .sndtone-c { transform: rotate(180deg); }
+.sndplay { flex: none; width: 24px; height: 24px; border-radius: 7px; cursor: pointer; display: grid; place-items: center;
+  font-size: 9px; color: var(--muted); background: var(--surface); border: 1px solid var(--hair); }
+.sndplay:hover { color: var(--accent-ink); border-color: var(--accent-line); background: var(--accent-wash); }
+.sndplay:active { transform: scale(.92); }
+/* Indented to the row's text, so an open strip visibly belongs to its event. */
+.sndtones { margin: 8px 0 3px 24px; }
+
 .toast { position: fixed; bottom: 40px; left: 50%; transform: translateX(-50%) translateY(14px); background: var(--text); color: var(--bg); padding: 8px 14px; border-radius: 9px; font-size: 11.5px; font-weight: 600; box-shadow: 0 18px 46px -20px rgba(0,0,0,.7); opacity: 0; pointer-events: none; transition: opacity .2s, transform .2s; z-index: 50; }
 .toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
 

--- a/test/sound.test.ts
+++ b/test/sound.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampSoundPrefs, exitSound, hookSound, isDefaultSoundPrefs, limitCrossed,
+  LIMIT_STEPS, soundDefaults, SOUND_EVENTS, SOUND_GAP_MS, SOUND_REPEAT_MS, soundFor,
+  soundSnap, toneDef, toneMs, TONES, VOLUME_RANGE,
+  type SoundEvent, type SoundGate, type SoundPrefs, type SoundSnap,
+} from "../src/sound";
+import type { Sess } from "../src/types";
+
+const T = 1_000_000;
+const prefs = (over: Partial<SoundPrefs> = {}): SoundPrefs => ({ ...soundDefaults(), ...over });
+const gate = (over: Partial<SoundGate> = {}): SoundGate =>
+  ({ focused: false, lastAt: 0, lastEv: null, ...over });
+/// Every event switched on, so a test about the burst rules isn't quietly measuring
+/// a default instead.
+function allOn(over: Partial<SoundPrefs> = {}): SoundPrefs {
+  const p = prefs(over);
+  for (const d of SOUND_EVENTS) p.events[d.id] = { ...p.events[d.id], on: true };
+  return p;
+}
+
+const snap = (over: Partial<SoundSnap> = {}): SoundSnap =>
+  ({ phase: "working", attention: null, apiErrAt: null, ...over });
+
+describe("the catalogue", () => {
+  it("gives every event a tone that exists and a real priority", () => {
+    const ids = new Set(TONES.map((t) => t.id));
+    for (const d of SOUND_EVENTS) {
+      expect(ids.has(d.tone), `${d.id} defaults to a tone that isn't shipped`).toBe(true);
+      expect(d.priority).toBeGreaterThanOrEqual(0);
+      expect(d.hint.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has no duplicate ids on either side — a duplicate silently shadows a row", () => {
+    expect(new Set(SOUND_EVENTS.map((d) => d.id)).size).toBe(SOUND_EVENTS.length);
+    expect(new Set(TONES.map((t) => t.id)).size).toBe(TONES.length);
+  });
+
+  it("keeps every tone short enough to be an alert rather than a jingle", () => {
+    for (const t of TONES) {
+      expect(toneMs(t), `${t.id} rings for too long`).toBeLessThanOrEqual(1000);
+      expect(toneMs(t)).toBeGreaterThan(0);
+    }
+  });
+
+  it("falls back rather than throwing on a tone id we no longer ship", () => {
+    expect(toneDef("gone" as never)).toBe(TONES[0]);
+  });
+
+  it("starts the events that fire constantly switched OFF", () => {
+    // The whole feature's credibility: a set of alerts that fires on every failed grep
+    // is a set of alerts you learn to ignore, which makes the permission chime useless.
+    const byId = Object.fromEntries(SOUND_EVENTS.map((d) => [d.id, d.on]));
+    expect(byId.toolFail).toBe(false);
+    expect(byId.ended).toBe(false);
+    expect(byId.launched).toBe(false);
+    expect(byId.permission).toBe(true);
+    expect(byId.done).toBe(true);
+  });
+
+  it("keeps the off-by-default ones LAST, because the settings hint says so", () => {
+    // Settings › Sounds reads "the last three start switched off". A reorder that left
+    // that sentence pointing at the wrong rows is exactly the kind of drift nothing
+    // else would catch.
+    const off = SOUND_EVENTS.filter((d) => !d.on).map((d) => d.id);
+    expect(off.length).toBe(3);
+    expect(SOUND_EVENTS.slice(-3).map((d) => d.id)).toEqual(off);
+  });
+
+  it("makes a permission the most urgent thing there is", () => {
+    const perm = SOUND_EVENTS.find((d) => d.id === "permission")!;
+    for (const d of SOUND_EVENTS) if (d.id !== "permission") expect(d.priority).toBeLessThan(perm.priority);
+  });
+});
+
+describe("clampSoundPrefs", () => {
+  it("defaults a missing or corrupt value rather than throwing", () => {
+    expect(clampSoundPrefs(null)).toEqual(soundDefaults());
+    expect(clampSoundPrefs({})).toEqual(soundDefaults());
+    expect(clampSoundPrefs({ volume: NaN, when: undefined })).toEqual(soundDefaults());
+    expect(clampSoundPrefs({ volume: "loud" } as never).volume).toBe(soundDefaults().volume);
+  });
+
+  it("holds the volume inside 0–100 and rounds it", () => {
+    expect(clampSoundPrefs({ volume: -40 }).volume).toBe(VOLUME_RANGE.min);
+    expect(clampSoundPrefs({ volume: 900 }).volume).toBe(VOLUME_RANGE.max);
+    expect(clampSoundPrefs({ volume: 61.4 }).volume).toBe(61);
+  });
+
+  it("only treats an explicit false as off, so a missing key stays enabled", () => {
+    expect(clampSoundPrefs({}).enabled).toBe(true);
+    expect(clampSoundPrefs({ enabled: false }).enabled).toBe(false);
+  });
+
+  it("fills in an event the stored blob has never heard of", () => {
+    // The realistic upgrade path: `cc-sound` written by a build with fewer events.
+    const old = clampSoundPrefs({ events: { permission: { on: false, tone: "pop" } } as never });
+    expect(old.events.permission).toEqual({ on: false, tone: "pop" });
+    for (const d of SOUND_EVENTS) {
+      expect(old.events[d.id], `${d.id} came back undefined`).toBeDefined();
+      if (d.id !== "permission") expect(old.events[d.id]).toEqual({ on: d.on, tone: d.tone });
+    }
+  });
+
+  it("drops an event key we no longer ship instead of carrying it forever", () => {
+    const p = clampSoundPrefs({ events: { subagent: { on: true, tone: "ping" } } as never });
+    expect(Object.keys(p.events).sort()).toEqual(SOUND_EVENTS.map((d) => d.id).sort());
+  });
+
+  it("decays an unknown tone to THAT event's default, not to the first tone", () => {
+    const p = clampSoundPrefs({ events: { done: { on: true, tone: "gong" } } as never });
+    expect(p.events.done.tone).toBe(SOUND_EVENTS.find((d) => d.id === "done")!.tone);
+  });
+
+  it("hands out a fresh events map each time, so a spread can't corrupt the defaults", () => {
+    const a = soundDefaults();
+    a.events.done.on = false;
+    expect(soundDefaults().events.done.on).toBe(true);
+  });
+});
+
+describe("isDefaultSoundPrefs", () => {
+  it("is true for a fresh install and false after any single change", () => {
+    expect(isDefaultSoundPrefs(soundDefaults())).toBe(true);
+    expect(isDefaultSoundPrefs(prefs({ volume: 30 }))).toBe(false);
+    expect(isDefaultSoundPrefs(prefs({ when: "away" }))).toBe(false);
+    expect(isDefaultSoundPrefs(prefs({ enabled: false }))).toBe(false);
+    const p = soundDefaults();
+    p.events.done = { ...p.events.done, tone: "bell" };
+    expect(isDefaultSoundPrefs(p)).toBe(false);
+  });
+});
+
+describe("soundFor: the absolute refusals", () => {
+  it("says nothing when sound is switched off", () => {
+    expect(soundFor(prefs({ enabled: false }), "permission", T, gate())).toBeNull();
+  });
+
+  it("treats volume 0 as mute rather than as an inaudible sound", () => {
+    // It matters: a "played" sound stamps the gate and would suppress the next one.
+    expect(soundFor(prefs({ volume: 0 }), "permission", T, gate())).toBeNull();
+  });
+
+  it("says nothing for an event whose own switch is off", () => {
+    expect(soundFor(prefs(), "toolFail", T, gate())).toBeNull();  // off by default
+    expect(soundFor(allOn(), "toolFail", T, gate())).not.toBeNull();
+  });
+});
+
+describe("soundFor: the focus rule", () => {
+  it("stays quiet while you are looking at Episko in `away` mode", () => {
+    const p = prefs({ when: "away" });
+    expect(soundFor(p, "permission", T, gate({ focused: true }))).toBeNull();
+    expect(soundFor(p, "permission", T, gate({ focused: false }))).toBe(p.events.permission.tone);
+  });
+
+  it("ignores focus entirely in `always` mode", () => {
+    expect(soundFor(prefs(), "permission", T, gate({ focused: true }))).not.toBeNull();
+  });
+});
+
+describe("soundFor: bursts", () => {
+  it("collapses the same event arriving twice — the duplicates are by design", () => {
+    // A permission is both a blocking hook and a Notification; an ending session is
+    // both SessionEnd and pty-exit. Two signals, one fact, one noise.
+    const g = gate({ lastAt: T, lastEv: "permission" });
+    expect(soundFor(allOn(), "permission", T + SOUND_REPEAT_MS - 1, g)).toBeNull();
+    expect(soundFor(allOn(), "permission", T + SOUND_REPEAT_MS, g)).not.toBeNull();
+  });
+
+  it("swallows a quieter event landing inside the gap after a louder one", () => {
+    const g = gate({ lastAt: T, lastEv: "permission" });
+    expect(soundFor(allOn(), "done", T + 50, g)).toBeNull();
+    expect(soundFor(allOn(), "done", T + SOUND_GAP_MS, g)).not.toBeNull();
+  });
+
+  it("lets a MORE urgent event through the gap — the whole point of the feature", () => {
+    // A permission 80ms after a "your turn" is not a duplicate of it; suppressing it
+    // would silence exactly the alert this exists for.
+    const g = gate({ lastAt: T, lastEv: "done" });
+    expect(soundFor(allOn(), "permission", T + 80, g)).toBe(allOn().events.permission.tone);
+  });
+
+  it("does not let an EQUALLY urgent event through — that is a burst", () => {
+    // N agents finishing together is one moment, not N.
+    const g = gate({ lastAt: T, lastEv: "done" });
+    expect(soundFor(allOn(), "error", T + 80, g)).toBeNull();   // both priority 2
+  });
+
+  it("rings on the very first event of a run, with nothing to compare against", () => {
+    expect(soundFor(allOn(), "done", T, gate({ lastAt: 0, lastEv: null }))).not.toBeNull();
+  });
+});
+
+describe("hookSound", () => {
+  it("hears a permission the moment attention appears", () => {
+    expect(hookSound(snap(), snap({ attention: "permission: Bash" }))).toBe("permission");
+  });
+
+  it("tells any other notification apart from a permission", () => {
+    expect(hookSound(snap(), snap({ attention: "idle_prompt" }))).toBe("question");
+  });
+
+  it("does not re-ring an attention that was already there", () => {
+    const a = snap({ attention: "permission: Bash", phase: "done" });
+    expect(hookSound(a, { ...a })).toBeNull();
+  });
+
+  it("rings for a NEW permission that replaced a different one", () => {
+    const before = snap({ attention: "permission: Read" });
+    expect(hookSound(before, snap({ attention: "permission: Bash" }))).toBe("permission");
+  });
+
+  it("puts attention above the phase — being asked outranks being finished", () => {
+    const after = snap({ phase: "done", attention: "permission: Bash" });
+    expect(hookSound(snap({ phase: "working" }), after)).toBe("permission");
+  });
+
+  it("rings `done` when a turn ends", () => {
+    expect(hookSound(snap({ phase: "working" }), snap({ phase: "done" }))).toBe("done");
+  });
+
+  it("says nothing for the phases nobody needs told about", () => {
+    expect(hookSound(snap({ phase: "idle" }), snap({ phase: "thinking" }))).toBeNull();
+    expect(hookSound(snap({ phase: "thinking" }), snap({ phase: "working" }))).toBeNull();
+  });
+
+  it("separates a turn the API killed from a tool call that failed", () => {
+    // The distinction this codebase already draws for the LABEL, drawn again for the
+    // noise — and here it matters more, because a failed grep is routine and an alarm
+    // you hear ten times an hour is an alarm you stop hearing.
+    const before = snap({ phase: "working" });
+    expect(hookSound(before, snap({ phase: "error", apiErrAt: T }))).toBe("error");
+    expect(hookSound(before, snap({ phase: "error" }))).toBe("toolFail");
+  });
+
+  it("rings `error` again for a SECOND API failure in the same red phase", () => {
+    const before = snap({ phase: "error", apiErrAt: T });
+    expect(hookSound(before, snap({ phase: "error", apiErrAt: T + 60_000 }))).toBe("error");
+  });
+
+  it("stays quiet when a retry clears the failure", () => {
+    const before = snap({ phase: "error", apiErrAt: T });
+    expect(hookSound(before, snap({ phase: "thinking" }))).toBeNull();
+  });
+
+  it("rings `ended` when the session stops", () => {
+    expect(hookSound(snap({ phase: "working" }), snap({ phase: "ended" }))).toBe("ended");
+  });
+
+  it("stays quiet when a statusline un-ends a session that is really alive", () => {
+    // applyStatusline flips "ended" back to "idle" — a rotation, not an event.
+    expect(hookSound(snap({ phase: "ended" }), snap({ phase: "idle" }))).toBeNull();
+  });
+});
+
+describe("soundSnap", () => {
+  it("reads the three fields the decision needs off a live session", () => {
+    const s = {
+      phase: "error", attention: "permission: Bash",
+      apiErr: { kind: "overloaded", detail: "", at: T },
+    } as unknown as Sess;
+    expect(soundSnap(s)).toEqual({ phase: "error", attention: "permission: Bash", apiErrAt: T });
+    expect(soundSnap({ phase: "idle", attention: null, apiErr: null } as unknown as Sess).apiErrAt).toBeNull();
+  });
+});
+
+describe("exitSound", () => {
+  it("turns a task's exit code into its verdict", () => {
+    expect(exitSound("task", 0)).toBe("taskDone");
+    expect(exitSound("task", 1)).toBe("taskFail");
+    expect(exitSound("task", 137)).toBe("taskFail");
+  });
+
+  it("treats anything else as merely having stopped, whatever the code", () => {
+    expect(exitSound("claude", 0)).toBe("ended");
+    expect(exitSound("claude", 1)).toBe("ended");
+    expect(exitSound("shell", 0)).toBe("ended");
+  });
+});
+
+describe("limitCrossed", () => {
+  it("fires once at each mark and not in between", () => {
+    expect(limitCrossed(48, 49)).toBeNull();
+    expect(limitCrossed(48, 51)).toBe(50);
+    expect(limitCrossed(51, 60)).toBeNull();
+    expect(limitCrossed(79, 81)).toBe(80);
+    expect(limitCrossed(94, 99)).toBe(95);
+  });
+
+  it("reports the HIGHEST mark when a reading jumps several at once", () => {
+    // An idle session's first statusLine can be a long way ahead of the last one.
+    expect(limitCrossed(10, 97)).toBe(95);
+  });
+
+  it("treats the first reading of a run as a baseline, not a crossing", () => {
+    // Otherwise every launch that starts above 50% rings — at the one moment the
+    // sound is worth least, because the footer meter is right there saying it.
+    expect(limitCrossed(null, 90)).toBeNull();
+    expect(limitCrossed(null, 12)).toBeNull();
+    // …and the very next reading behaves normally.
+    expect(limitCrossed(90, 96)).toBe(95);
+  });
+
+  it("crosses nothing when the window resets and the number falls", () => {
+    // The reason this compares readings instead of testing a threshold outright.
+    expect(limitCrossed(96, 0)).toBeNull();
+    expect(limitCrossed(96, 3)).toBeNull();
+  });
+
+  it("ignores a missing reading rather than treating it as zero", () => {
+    expect(limitCrossed(90, null)).toBeNull();
+  });
+
+  it("has marks that climb, so the highest-crossed scan is meaningful", () => {
+    expect([...LIMIT_STEPS].sort((a, b) => a - b)).toEqual(LIMIT_STEPS);
+  });
+});
+
+describe("the wiring the app depends on", () => {
+  it("routes every event the app can raise through a real catalogue entry", () => {
+    // main.ts and panes.ts call playSound with these literals; a rename that missed one
+    // would be a silent no-op, since `soundFor` returns null for an unknown key.
+    const raised: SoundEvent[] = [
+      "permission", "question", "done", "error", "toolFail",
+      "ended", "taskDone", "taskFail", "limit", "launched",
+    ];
+    const known = new Set(SOUND_EVENTS.map((d) => d.id));
+    for (const ev of raised) expect(known.has(ev), `${ev} is raised but not in the catalogue`).toBe(true);
+    expect(raised.length).toBe(SOUND_EVENTS.length);
+  });
+});


### PR DESCRIPTION
Every signal Episko had was visual — the sidebar glyph, the attention badge, the tray — and all three need the window in front of you, which is the opposite of why anyone runs six agents at once. A blocked permission was the worst of it: Claude stopped, achieving nothing, until you happened to look.

**Settings › Sounds** gives ten moments a noise, each with its own tone from a palette of ten, plus a master volume and an *only when Episko is in the background* mode.

| | Event | Default |
| --- | --- | --- |
| ◆ | Permission asked | Alert |
| ◇ | Notification | Ping |
| ● | Your turn | Chime |
| ✕ | Turn failed (the API killed it) | Buzz |
| ▶ | Run failed | Buzz |
| ▦ | Usage limit crossed 50/80/95% | Bell |
| ▶ | Run passed | Arpeggio |
| ! | Tool call failed | *off* |
| · | Session ended | *off* |
| + | Session launched | *off* |

Tones are synthesised oscillator envelopes rather than shipped audio — a two-note chime is not something a WAV does better, and it costs no asset handling, no decode and no license.

## The two decisions worth reviewing

**The hard part is not playing a sound, it is not playing six.** The same moment reaches the frontend twice *by design* — a permission arrives as both the blocking hook and a `Notification`, a session ending as both `SessionEnd` and `pty-exit` — and N agents burst inside one animation frame. So every play is gated by two windows (1200ms same-event, 350ms cross-event), with one deliberate exception: **a more urgent event still cuts through the gap**, because a permission landing 80ms after a "your turn" is precisely the alert that must not be swallowed.

**Three of the ten ship switched off.** A set of alerts that fires on every failed grep is a set you stop hearing, which costs you the permission chime too. The sharpest case reuses a split this codebase already draws for the *label*: `phase: "error"` is set both by a routine tool failure and by a turn the API killed, and only the second (a new `apiErr` stamp, which only `StopFailure` writes) rings by default.

## Shape

Split the way `peek.ts`/`sidebar.ts` is:

- **`src/sound.ts`** — the catalogue, the tones as data, the clamping and the decision. Pure, no DOM, no Tauri; 47 cases in `test/sound.test.ts`.
- **`src/chime.ts`** — the only file in the app that touches Web Audio. Untested, for the same reason every module owning a live browser resource is.

`soundPrefs` lives in `state.ts` (one `cc-sound` JSON blob, same argument as `cc-peek`), persistence and the repaint in `actions.ts`, the tab in `settings.ts`. No Rust changed, so no new IPC.

Nothing reads a hook payload twice: what an event *means* is `phase.ts`'s decision, so `main.ts` snapshots three fields off the `Sess`, applies the hook, and asks `hookSound` what changed. A second reading here would be the copy that drifts.

Two things `chime.ts` exists to get right, both **silent when wrong** and both written down in `docs/sounds.md`: the audio context starts suspended under every autoplay policy (hence the one-shot gesture unlock — otherwise the *first* alert of a cold start is inaudible and looks exactly like the feature being off), and a gate-shaped envelope clicks (hence attack/decay ramps, with the attack clamped for a step shorter than it).

## Every button plays what it does

A column of names — "Chime", "Drop", "Buzz" — is unusable, because nobody knows what a Drop is until they have heard one. So changing a tone plays it, switching an event on plays it, and nudging the volume plays at the new volume. Deliberately silent: switching an event *off*, and Reset.

## Verified

- `tsc --noEmit` clean · **860 vitest pass** (47 new) · `pnpm build` clean · no import cycles (53 modules)
- Drove the real frontend in a browser: the panel renders, **one click produces exactly one tone with the right frequencies** (`alert` → 988/988/1319, `arp` → 523/659/784), hover produces none, switching an event on auditions it while switching it off stays silent, `cc-sound` round-trips, and Reset restores exact defaults.
- The audible half can only be checked by ear, so `RELEASE.md` gains a section — including the cold-start autoplay check, which is the one failure nothing else would catch.

Docs: `docs/sounds.md`, `CLAUDE.md` (module tables, counts, docs index, one app-wide rule), and a `CHANGELOG.md` `Unreleased` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
