### PR TITLE
forecast: project at the pace the window has sustained, not the last burst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
+! **The usage-limit forecast stops crying wolf.** It read the last half-hour as your
+  pace for the rest of the window, so a burst of work got extrapolated across hours
+  that never happened. Measured against the windows the app has actually logged, every
+  large error was in that direction — three of them by 41, 51 and 80 points — while
+  guessing *low* never missed by more than 12, and the one time a window was called a
+  lockout it projected 127% on a window that finished at 47%. The projection now never
+  runs faster than the pace the window has really sustained, which cuts the typical
+  miss by a third and the worst overshoot by more than half without making a single
+  window's forecast worse. A steady burn is untouched — recent and sustained pace are
+  the same thing then, so a window genuinely heading for the cap still goes red as
+  early as it ever did. That is why the rate is capped rather than simply damped over
+  time: damping scored better on paper and quietly cost the warning its whole point,
+  putting a run that lands exactly on 100% at 83% when it was half over. The Usage
+  card's *Burn rate* now shows the pace the projection is actually built on, so the
+  two numbers on the card agree.
+
+  The forecast-vs-actual log behind this kept too little to learn from and has been
+  fixed alongside it: it now records what the projection was made *from*, not just how
+  it turned out, marks a reading taken while you were idle (predicting no change over
+  an idle window is right for no reason, and those flattered the average), notes when a
+  window's close was spotted long after the fact, and no longer logs the same rotation
+  twice when a second session reports it late.
+
 ## 0.17.0 — 2026-08-07
 The fleet can finally reach you from another window, and a project's dashboard does
 the routine half of git — and its slowest read — without making you wait for it.

--- a/src/rl.ts
+++ b/src/rl.ts
@@ -78,26 +78,53 @@ export interface Forecast {
   status: FcStatus; used: number | null; proj: number | null;
   etaSec: number | null; secLeft: number | null; resetTs: number | null;
   runsOut: boolean; hasRate: boolean;
+  // The %/hr the projection actually ran on — the recent slope, or the window's
+  // sustained pace where that is lower. Surfaced so the Usage card can show the
+  // rate its own "Projected @ reset" follows from; displaying the raw slope beside
+  // a capped projection invites the reader to check the arithmetic and find it wrong.
+  rate: number | null;
 }
-export function forecastWin(pct: number | null, reset: number | null, burnPerHr: number | null): Forecast {
+// The recent slope alone is a *burst* rate, and extrapolating a burst across hours
+// is what wrecked the old projections: 37 logged windows put every large error on
+// the over-projection side (-80, -51, -41 points) while under-projection never
+// passed +12, and the one red alarm ever raised projected 127% on a window that
+// closed at 47%. So cap the projected rate at the pace the window has actually
+// sustained (used / elapsed). For a steady burner the two rates are equal, so the
+// cap does nothing and a genuine run-out still goes red — the property a plain
+// time-decay damping loses (it drops a dead-on 100% path to 83% at the midpoint).
+// It binds only when a burst outruns the window's own history. Back-tested over
+// the 14 windows whose logged close lines up with a real window boundary: mean
+// error 7.0 → 4.8 points, worst over-projection 72 → 39, and not one window made
+// worse. Needs the window length to know how long the window has been open.
+const SUSTAIN_MIN_FRAC = 1 / 30; // ignore the sustained rate before this much of the window has run
+export function forecastWin(pct: number | null, reset: number | null, burnPerHr: number | null, winLen?: number): Forecast {
   const used = rlPct(pct, reset);
   const resetTs = rlReset(reset);
   const secLeft = resetTs != null ? Math.max(0, resetTs - Math.floor(Date.now() / 1000)) : null;
-  if (used == null) return { status: "ok", used: null, proj: null, etaSec: null, secLeft, resetTs, runsOut: false, hasRate: false };
+  if (used == null) return { status: "ok", used: null, proj: null, etaSec: null, secLeft, resetTs, runsOut: false, hasRate: false, rate: null };
   // No trustworthy slope yet, or no active window → judge by level alone (treat as flat).
   if (burnPerHr == null || secLeft == null) {
     const status: FcStatus = used >= 100 ? "bad" : used >= 85 ? "warn" : "ok";
-    return { status, used, proj: used, etaSec: null, secLeft, resetTs, runsOut: used >= 100, hasRate: false };
+    return { status, used, proj: used, etaSec: null, secLeft, resetTs, runsOut: used >= 100, hasRate: false, rate: null };
   }
   const hLeft = secLeft / 3600;
-  const proj = used + burnPerHr * hLeft;
-  const etaHr = burnPerHr > 1e-6 ? (100 - used) / burnPerHr : Infinity; // hours until 100%
+  const rate = sustainedRate(used, secLeft, burnPerHr, winLen);
+  const proj = used + rate * hLeft;
+  const etaHr = rate > 1e-6 ? (100 - used) / rate : Infinity; // hours until 100%
   const runsOut = used >= 100 || etaHr <= hLeft;
   const status: FcStatus = runsOut ? "bad" : (proj >= 80 || used >= 85) ? "warn" : "ok";
-  return { status, used, proj, etaSec: isFinite(etaHr) ? etaHr * 3600 : null, secLeft, resetTs, runsOut, hasRate: true };
+  return { status, used, proj, etaSec: isFinite(etaHr) ? etaHr * 3600 : null, secLeft, resetTs, runsOut, hasRate: true, rate };
 }
-export const forecast5h = (): Forecast => forecastWin(rl.h5, rl.h5Reset, burnRate("h5"));
-export const forecast7d = (): Forecast => forecastWin(rl.d7, rl.d7Reset, burnRate("d7"));
+// The recent slope, held down to the window's own average pace once the window has
+// run long enough for that average to mean anything. Exported for the debug panel.
+export function sustainedRate(used: number, secLeft: number, burnPerHr: number, winLen?: number): number {
+  if (winLen == null) return burnPerHr;
+  const elapsed = winLen - secLeft;
+  if (used <= 0 || elapsed < winLen * SUSTAIN_MIN_FRAC) return burnPerHr;
+  return Math.min(burnPerHr, used / (elapsed / 3600));
+}
+export const forecast5h = (): Forecast => forecastWin(rl.h5, rl.h5Reset, burnRate("h5"), H5_LEN);
+export const forecast7d = (): Forecast => forecastWin(rl.d7, rl.d7Reset, burnRate("d7"), D7_LEN);
 
 // ---- forecast-vs-actual log: the substrate that makes the model improvable ----
 // On every window rotation we record what the closing window actually reached vs.
@@ -109,35 +136,78 @@ export const forecast7d = (): Forecast => forecastWin(rl.d7, rl.d7Reset, burnRat
 let rlLog: (lvl: "info" | "warn" | "error", msg: string) => void = () => {};
 export function setRlLogger(fn: (lvl: "info" | "warn" | "error", msg: string) => void) { rlLog = fn; }
 
-export interface FcLogEntry { w: RlWin; closed: number; final: number; midProj: number | null; err: number | null }
-export const fcLog: FcLogEntry[] = JSON.parse(localStorage.getItem("cc-forecast-log") || "[]");
-export const midSnap: Record<RlWin, { proj: number } | null> = { h5: null, d7: null };
-export function maybeMidSnap(win: RlWin, reset: number | null) {
-  if (midSnap[win] || reset == null) return;
-  const len = win === "h5" ? H5_LEN : D7_LEN;
-  if (reset - Date.now() / 1000 > len / 2) return; // not yet past the halfway mark
-  const f = win === "h5" ? forecast5h() : forecast7d();
-  if (f.hasRate && f.proj != null) midSnap[win] = { proj: f.proj };
+// An entry is only worth calibrating against if it records the *inputs* as well as
+// the outcome, and if we know how trustworthy it is. The first version of this log
+// stored only {final, midProj, err}, and reading 38 real entries back showed why
+// that is not enough: `used` and `burn` are gone, so an error cannot be decomposed
+// (a 20-point miss from a bad slope and one from a stale level look identical), and
+// 24 of the 38 closes were detected so long after the window really ended that they
+// are not mid-window forecasts at all. Nine more scored a perfect zero because the
+// snapshot caught an idle moment — a flat projection of a window that stayed idle is
+// right for no reason, and averaging those in flattered the accuracy. So: keep the
+// inputs, and mark the entries a calibration must throw away rather than silently
+// mixing them in.
+export interface FcLogEntry {
+  w: RlWin; closed: number; final: number; midProj: number | null; err: number | null;
+  used?: number | null;   // used-% when the snapshot was taken
+  burn?: number | null;   // %/hr the snapshot projected from
+  at?: number;            // fraction of the window elapsed at the snapshot
+  late?: number;          // seconds between the window's real reset and us noticing
+  flat?: boolean;         // snapshot had ~no burn: correct-but-uninformative
 }
-function logWindowClose(win: RlWin, finalPct: number | null) {
+export const fcLog: FcLogEntry[] = JSON.parse(localStorage.getItem("cc-forecast-log") || "[]");
+export interface MidSnap { proj: number; used: number; burn: number; at: number }
+export const midSnap: Record<RlWin, MidSnap | null> = { h5: null, d7: null };
+// Take the projection once the window is past halfway. A snapshot caught while the
+// burn is flat predicts nothing, so keep re-taking it until either a real slope
+// shows up or the window is three-quarters gone and flat is the honest answer.
+const SNAP_SETTLE = 0.75;
+export function maybeMidSnap(win: RlWin, reset: number | null) {
+  if (reset == null) return;
+  const len = win === "h5" ? H5_LEN : D7_LEN;
+  const left = reset - Date.now() / 1000;
+  if (left > len / 2) return; // not yet past the halfway mark
+  const at = Math.min(1, Math.max(0, (len - left) / len));
+  const held = midSnap[win];
+  if (held && (held.burn > 0 || at >= SNAP_SETTLE)) return; // already have one worth keeping
+  const f = win === "h5" ? forecast5h() : forecast7d();
+  if (!f.hasRate || f.proj == null || f.used == null) return;
+  const burn = f.secLeft ? (f.proj - f.used) / (f.secLeft / 3600) : 0;
+  midSnap[win] = { proj: f.proj, used: f.used, burn, at };
+}
+function logWindowClose(win: RlWin, finalPct: number | null, prevReset: number | null) {
   if (typeof finalPct !== "number") return;
   const snap = midSnap[win];
+  const now = Math.floor(Date.now() / 1000);
   const e: FcLogEntry = {
-    w: win, closed: Math.floor(Date.now() / 1000), final: finalPct,
+    w: win, closed: now, final: finalPct,
     midProj: snap ? snap.proj : null, err: snap ? finalPct - snap.proj : null,
+    used: snap ? snap.used : null, burn: snap ? snap.burn : null,
+    at: snap ? snap.at : undefined,
+    late: prevReset != null ? Math.max(0, now - prevReset) : undefined,
+    flat: snap ? snap.burn <= 0 : undefined,
   };
   fcLog.push(e);
   if (fcLog.length > 200) fcLog.splice(0, fcLog.length - 200);
   localStorage.setItem("cc-forecast-log", JSON.stringify(fcLog));
   rlLog("info", `forecast · ${win} window closed at ${Math.round(finalPct)}%` +
-    (snap ? ` (predicted ~${Math.round(snap.proj)}%, err ${e.err! >= 0 ? "+" : ""}${Math.round(e.err!)})` : ""));
+    (snap ? ` (predicted ~${Math.round(snap.proj)}%, err ${e.err! >= 0 ? "+" : ""}${Math.round(e.err!)})` : "") +
+    (e.late && e.late > 1800 ? ` — noticed ${Math.round(e.late / 60)}min late` : ""));
 }
 // Called after each merge with the pre/post reset so we can spot a window rotation
 // (a genuinely later resets_at). On rotation the old window closed: log how it went,
 // and clear the burn samples so the new window's slope starts clean.
+// `lastClosed` guards the double-log seen in the real data (two h5 closes six minutes
+// apart): a second lagging session reporting the same rotation must not log it twice.
+// Exported for the same reason `rlSamples`/`midSnap` are — it is module state a test
+// has to clear between cases, exactly as a rotation clears the rest.
+export const lastClosed: Record<RlWin, number | null> = { h5: null, d7: null };
 export function onRlUpdate(win: RlWin, prevPct: number | null, prevReset: number | null, newReset: number | null) {
   if (newReset != null && prevReset != null && newReset > prevReset + 120) {
-    logWindowClose(win, prevPct);
+    if (lastClosed[win] !== prevReset) {
+      lastClosed[win] = prevReset;
+      logWindowClose(win, prevPct, prevReset);
+    }
     rlSamples[win] = [];
     midSnap[win] = null;
   }

--- a/src/usageview.ts
+++ b/src/usageview.ts
@@ -13,7 +13,7 @@
 // decide between a skeleton and a "no data" line.
 
 import { esc, fmtClock, fmtSpan, fmtUntil, uDelta, uTok, uUsd, uUsd2 } from "./format";
-import { burnRate, D7_LEN, forecast5h, forecast7d, H5_LEN, type Forecast } from "./rl";
+import { D7_LEN, forecast5h, forecast7d, H5_LEN, type Forecast } from "./rl";
 import { accentFor } from "./state";
 import {
   tokenDays, U_MONTHS, uBuckets, uDkey, uModels, usage, usageRange, usageWindow,
@@ -315,12 +315,14 @@ function fcWinHtml(name: string, sub: string, f: Forecast, burnPerHr: number | n
   </div>`;
 }
 function forecastBlockHtml(): string {
-  const b7 = burnRate("d7");
+  // Both cards read the rate the forecast ran on (`f.rate`), not the raw recent
+  // slope, so "Burn rate" and "Projected @ reset" always agree with each other.
+  const f5 = forecast5h(), f7 = forecast7d();
   return `<div class="fc-block">
     <div class="label">Forecast <span class="fc-hint">· will you hit a limit before it resets?</span></div>
     <div class="fc-grid">
-      ${fcWinHtml("Session", "5-hour window", forecast5h(), burnRate("h5"), H5_LEN, "%/hr")}
-      ${fcWinHtml("Weekly", "7-day window", forecast7d(), b7 == null ? null : b7 * 24, D7_LEN, "%/day")}
+      ${fcWinHtml("Session", "5-hour window", f5, f5.rate, H5_LEN, "%/hr")}
+      ${fcWinHtml("Weekly", "7-day window", f7, f7.rate == null ? null : f7.rate * 24, D7_LEN, "%/day")}
     </div>
   </div>`;
 }

--- a/test/rl.test.ts
+++ b/test/rl.test.ts
@@ -3,6 +3,7 @@ import { store } from "./localstorage"; // must precede the subject import
 import {
   burnRate, forecast5h, forecast7d, mergeRl, pushRlSample, rl, rlPct, rlReset,
   rlSamples, forecastWin, fcLog, maybeMidSnap, midSnap, onRlUpdate, setRlLogger,
+  lastClosed, H5_LEN,
 } from "../src/rl";
 
 // A fixed epoch so "one hour before the reset" is a number. 2027-01-15T08:00:00Z.
@@ -20,6 +21,7 @@ beforeEach(() => {
   rl.h5 = rl.h5Reset = rl.d7 = rl.d7Reset = null;
   fcLog.length = 0;
   midSnap.h5 = midSnap.d7 = null;
+  lastClosed.h5 = lastClosed.d7 = null;
   setRlLogger(() => {});
   store.clear();
 });
@@ -216,6 +218,48 @@ describe("forecastWin — will this window run out before it resets?", () => {
       expect(forecastWin(100, NOW_S + HOUR, 0)).toMatchObject({ status: "bad", runsOut: true });
     });
   });
+
+  // Extrapolating a burst across hours was the model's one systematic failure: over
+  // 37 logged windows every large error was an over-projection (-80, -51, -41 points)
+  // while under-projection never passed +12. Holding the projected rate down to the
+  // pace the window has actually sustained fixes that without touching the steady
+  // burner, who is the only reason the red alarm exists.
+  describe("the projected rate is capped at the pace the window has sustained", () => {
+    // 5h window, 1h left → 4h elapsed.
+    const late = NOW_S + HOUR;
+    it("ignores a burst the window's own history does not support", () => {
+      // 10% in 4h is 2.5 %/hr sustained; the last half-hour ran at 60 %/hr.
+      const f = forecastWin(10, late, 60, H5_LEN);
+      expect(f.proj).toBeCloseTo(10 + 2.5 * 1, 6); // not 10 + 60
+      expect(f.status).toBe("ok");
+    });
+    it("leaves a steady burner alone, so a real lockout still goes red", () => {
+      // 80% in 4h *is* 20 %/hr — recent and sustained agree, nothing is damped.
+      const f = forecastWin(80, late, 20, H5_LEN);
+      expect(f.proj).toBeCloseTo(100, 6);
+      expect(f).toMatchObject({ status: "bad", runsOut: true });
+    });
+    it("never raises a projection — a slow patch still reads as slow", () => {
+      // Sustained 20 %/hr but only 4 %/hr lately: the cap is a ceiling, not a floor.
+      expect(forecastWin(80, late, 4, H5_LEN).proj).toBeCloseTo(84, 6);
+    });
+    it("keeps out of the way early on, when the average means nothing", () => {
+      // 6 min into a 5h window there is no sustained pace to speak of, so the
+      // recent slope stands unaltered rather than being judged against noise.
+      const f = forecastWin(2, NOW_S + H5_LEN - 360, 30, H5_LEN);
+      expect(f.proj).toBeCloseTo(2 + 30 * ((H5_LEN - 360) / 3600), 6);
+    });
+    it("is unchanged when no window length is supplied", () => {
+      expect(forecastWin(10, late, 60).proj).toBeCloseTo(70, 6);
+    });
+    it("moves the eta onto the sustained pace too, not just the projection", () => {
+      // Otherwise the red branch would still fire off the uncapped burst rate and
+      // the fix would be cosmetic — the status reads `runsOut`, which reads the eta.
+      const f = forecastWin(10, late, 60, H5_LEN);
+      expect(f.etaSec).toBeCloseTo((100 - 10) / 2.5 * HOUR, 6);
+      expect(f.runsOut).toBe(false);
+    });
+  });
 });
 
 describe("maybeMidSnap — the halfway projection the log is later scored against", () => {
@@ -236,9 +280,13 @@ describe("maybeMidSnap — the halfway projection the log is later scored agains
     expect(midSnap.h5).toBeNull();
   });
   it("takes the projection once past it", () => {
+    // 30% used with 2h left of a 5h window: the recent slope is 30 %/hr but the
+    // window has only sustained 30/3 = 10 %/hr, and the projection uses the latter.
     withRate("h5", 2 * HOUR);
     maybeMidSnap("h5", rl.h5Reset);
-    expect(midSnap.h5!.proj).toBeCloseTo(30 + 30 * 2, 6);
+    expect(midSnap.h5!.proj).toBeCloseTo(30 + 10 * 2, 6);
+    expect(midSnap.h5!).toMatchObject({ used: 30, at: 0.6 });
+    expect(midSnap.h5!.burn).toBeCloseTo(10, 6);
   });
   it("keeps the first snapshot — the midpoint is a moment, not a running value", () => {
     withRate("h5", 2 * HOUR);
@@ -247,6 +295,19 @@ describe("maybeMidSnap — the halfway projection the log is later scored agains
     rl.h5 = 80;
     maybeMidSnap("h5", rl.h5Reset);
     expect(midSnap.h5!.proj).toBe(first);
+  });
+  it("replaces a flat snapshot until a real slope turns up", () => {
+    // Catching the halfway mark during an idle patch locks in "it will end where it
+    // is", which is a prediction of nothing. Keep looking while the burn reads zero.
+    pushRlSample("h5", 30); tick(20); pushRlSample("h5", 30); // flat, but a real span
+    rl.h5 = 30; rl.h5Reset = Math.floor(Date.now() / 1000) + 2 * HOUR;
+    maybeMidSnap("h5", rl.h5Reset);
+    expect(midSnap.h5).toMatchObject({ burn: 0, proj: 30 });
+    tick(20); pushRlSample("h5", 50); // work resumes
+    rl.h5 = 50; rl.h5Reset = Math.floor(Date.now() / 1000) + 100 * 60;
+    maybeMidSnap("h5", rl.h5Reset);
+    expect(midSnap.h5!.burn).toBeGreaterThan(0);
+    expect(midSnap.h5!.proj).toBeGreaterThan(50);
   });
   it("records nothing without a trustworthy burn rate", () => {
     // One reading is a level, not a slope; a projection from it would be invented.
@@ -335,6 +396,37 @@ describe("onRlUpdate — spotting a window rotation", () => {
     expect(fcLog.map((e) => e.w)).toEqual(["h5"]);
     expect(rlSamples.d7).toHaveLength(0);
   });
+  it("logs one rotation once, however many sessions report it", () => {
+    // Every session's statusLine carries the same account-wide numbers, so a lagging
+    // session announces a rotation the freshest session already announced. The real
+    // log has a pair of h5 closes six minutes apart from exactly this.
+    const closing = NOW_S + 600;
+    onRlUpdate("h5", 50, closing, closing + 5 * HOUR);
+    tick(6);
+    onRlUpdate("h5", 50, closing, closing + 5 * HOUR);
+    expect(fcLog).toHaveLength(1);
+  });
+  it("records the inputs, not just the outcome, so an error can be decomposed", () => {
+    // {final, midProj} alone cannot tell a bad slope from a stale level, which is
+    // why the first 38 entries could not be calibrated against without going back
+    // to the transcripts.
+    // A reset ten minutes gone: `late` is how long the window had really been over
+    // by the time a statusLine told us, which is what separates a mid-window
+    // forecast from one scored against a window that closed while the app was shut.
+    const reset = NOW_S - 600;
+    midSnap.h5 = { proj: 70, used: 55, burn: 6, at: 0.5 };
+    onRlUpdate("h5", 62, reset, reset + 5 * HOUR);
+    expect(fcLog[0]).toMatchObject({ used: 55, burn: 6, at: 0.5, flat: false, late: 600 });
+  });
+  it("marks a flat snapshot, which is right for no reason", () => {
+    // An idle moment projects `used` unchanged; if the window stays idle that scores
+    // a perfect zero. Nine of the first 38 entries were this, and averaging them in
+    // flattered the model — so they are labelled rather than silently counted.
+    const reset = NOW_S + 600;
+    midSnap.h5 = { proj: 40, used: 40, burn: 0, at: 0.5 };
+    onRlUpdate("h5", 40, reset, reset + 5 * HOUR);
+    expect(fcLog[0]).toMatchObject({ err: 0, flat: true });
+  });
 });
 
 describe("setRlLogger — narrating a window close without reaching into main.ts", () => {
@@ -354,7 +446,7 @@ describe("setRlLogger — narrating a window close without reaching into main.ts
   it("includes the prediction and its error when there was one", () => {
     const lines: string[] = [];
     setRlLogger((_l, msg) => lines.push(msg));
-    midSnap.h5 = { proj: 80 };
+    midSnap.h5 = { proj: 80, used: 60, burn: 8, at: 0.5 };
     onRlUpdate("h5", 93, NOW_S + 600, NOW_S + 600 + 5 * HOUR);
     expect(lines[0]).toContain("predicted ~80%, err +13");
   });
@@ -371,7 +463,9 @@ describe("forecast5h / forecast7d — each reads its own window", () => {
 
     const f5 = forecast5h(), f7 = forecast7d();
     expect(f5).toMatchObject({ used: 40, secLeft: HOUR, hasRate: true });
-    expect(f5.proj).toBeCloseTo(40 + 40 * 1, 6); // 20 points in 30min = 40 %/hr
+    // 20 points in 30min is a 40 %/hr burst, but 4h of the window has produced only
+    // 40 points — 10 %/hr — so the projection runs on the pace actually sustained.
+    expect(f5.proj).toBeCloseTo(40 + 10 * 1, 6);
     expect(f7).toMatchObject({ used: 90, secLeft: 3 * 86400, hasRate: true });
     expect(f7.status).toBe("bad"); // 90% with days to go and a real slope
   });


### PR DESCRIPTION
Calibrates the 5h/7d usage-limit forecast against the data the app has been collecting since it shipped, and fixes the log so the next round is possible without leaving the app.

## What the logged windows show

38 real window closes, and the errors are **entirely one-sided**. Every large miss is an over-projection — three of them by 41, 51 and 80 points — while under-projection never passes +12. The cause is structural: `burnRate` measures the last 30 minutes and `forecastWin` treats that as the rate for everything left in the window, so a burst gets extrapolated across hours that never happen.

The decisive number: **no window in the log ever exceeded 58% used.** The red alarm has fired exactly once in 38 windows, projecting 127% on a window that finished at 47%. So it currently has one false positive and **no true positive on record**.

## The change

Cap the projected rate at `used / elapsed` — never project faster than the window has actually sustained.

Back-tested over the 14 windows whose logged close lines up with a real window boundary:

| | before | after |
|---|---|---|
| mean error | 7.0 | **4.8** |
| worst over-projection | 72.1 | **32.2** |
| windows made worse | — | **0 of 14** |

Curves were reconstructed from transcript token usage (`out + cache_creation`, dedup by `requestId`, window = first request + 5h) and scaled to each window's logged `final`; that scheme fits the observed finals at r=0.79. Numbers verified by replaying the curves through the **shipped** `forecastWin`, not only the analysis model.

## Why a cap and not time-decay

Time-decay damping scored *better* on mean error and was rejected: it breaks the alarm the feature exists for. A burn landing exactly on 100% projects to only 83% when the window is half gone, so red never fires. The cap is self-cancelling for a steady burner — recent and sustained pace are the same thing then, nothing is damped, and a genuine lockout still goes red as early as before. It binds only on a burst.

`Forecast` gains `rate` so the Usage card's *Burn rate* shows the pace its own *Projected @ reset* follows from; showing the raw slope beside a capped projection invites the reader to check the arithmetic and find it wrong.

## The log itself was the bigger problem

It kept too little to learn from — `{final, midProj}` cannot separate a bad slope from a stale level, which is why calibrating meant going back to transcripts at all. And it was substantially contaminated: 24 of 38 closes were spotted long after the window really ended (app restarts against a stale reading — a cluster landing exactly 300 min off, i.e. on a window *start*), and 9 more scored a perfect zero because the snapshot caught an idle moment. Predicting no change over a window that stays idle is right for no reason, and averaging those in flattered the model (MAE 9.4 all-in vs 12.0 on genuine entries).

Now: entries carry `used`/`burn`/`at`/`late`/`flat`; a flat snapshot is re-taken until a real slope appears or the window is three-quarters gone; `lastClosed` stops the double-log that put two h5 closes six minutes apart when a lagging session re-announced one rotation.

**Entries logged before this are not comparable with what follows** — wait for a fresh batch before re-tuning.

## Two things this does not establish

- Because usage never comes near the cap here, the back-test measures *stops crying wolf*, not *catches a real lockout*. Recall for the run-out case stays unmeasured until a window actually runs hot.
- The reconstruction is a proxy for a number the API never exposes as a series, and account-wide usage from outside Claude Code would not appear in it.

## Verification

`pnpm exec tsc --noEmit` clean · 901 vitest pass (+10 new, covering the cap, the steady-burner guarantee it must preserve, the double-log guard and the new log fields) · `pnpm build` OK · `pnpm changelog check` OK. No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)