### PR TITLE
io: say why a day of agents writes a gigabyte, and label the units it actually computes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
++ **The disk-I/O box explains itself.** A day of agents reads as a gigabyte written, which
+  looks like a bug and isn't, so the `i` on the box now opens the three reasons the
+  figures look the way they do. Claude Code appends to its transcript and fsyncs after
+  every message, and each flush commits whole blocks — measured here at **~32× the
+  transcript's own growth**. That is Claude Code's own journalling; Episko only reports
+  the counters, and there is nothing here it can batch away. The panel also says why
+  *reads* look small (a page-cache hit never reaches the disk) and why child processes
+  are absent — a child that wrote 120 MiB moved its parent's counter by exactly zero, so
+  the `git`, `ripgrep` and `node` work under an agent is invisible no matter how the
+  process tree is walked.
+
+! **The I/O figures were labelled in the wrong units.** Every one of them divides by
+  1024, so they were always KiB, MiB and GiB — calling them KB, MB and GB understated
+  what you were reading by 2.4%, 4.9% and 7.4% respectively. The labels now match the
+  arithmetic, in the resource box and in History's transcript sizes. The rate column
+  grew to fit and can no longer wrap: at its old width the longer string silently
+  reflowed onto a second line instead of overflowing where anyone would see it.
+
 ## 0.17.0 — 2026-08-07
 The fleet can finally reach you from another window, and a project's dashboard does
 the routine half of git — and its slowest read — without making you wait for it.

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -20,10 +20,10 @@ import { renderSettings } from "./settings";
 import { waitForExit } from "./tasks";
 import { queueRosterSave } from "./mirror";
 import {
-  dashMirror, FAVORITES, IO_SCOPES, ioScope, markWorkdirStale, peekPrefs, permMode,
+  dashMirror, FAVORITES, IO_SCOPES, ioInfo, ioScope, markWorkdirStale, peekPrefs, permMode,
   permModeDef, projGroups,
   saveFavorites, saveProjGroups, sessions, termEngine,
-  setFavorites, setIoScope, setPeekPrefs as setPeekPrefsState, setPermMode as setPermModeState,
+  setFavorites, setIoInfo, setIoScope, setPeekPrefs as setPeekPrefsState, setPermMode as setPermModeState,
   setProjGroups, setSortMode, SORT_META, SORT_MODES,
   soundPrefs, setSoundPrefs as setSoundPrefsState,
   sortMode, setWtGroup as setWtGroupState, wtGroup,
@@ -215,6 +215,8 @@ export function cycleIoScope() {
   localStorage.setItem("cc-io-scope", ioScope);
   renderAll();
 }
+/// Open/close the I/O box's explanation. Nothing is persisted — see `ioInfo` in state.ts.
+export function toggleIoInfo() { setIoInfo(!ioInfo); renderAll(); }
 export function toggleRail() { $("app").classList.toggle("rail-mini"); }
 // ⌘I / ◨. On a session this hides the inspector outright — nothing in it is
 // unreachable from that header. **On the dashboard it collapses to a 44px icon rail

--- a/src/format.ts
+++ b/src/format.ts
@@ -89,17 +89,23 @@ export function fmtDwell(ms: number): string {
   return h > 0 ? `${h}h ${m}m` : `${m}:${String(ss).padStart(2, "0")}`;
 }
 export function fmtLatency(ms: number): string { return ms >= 1000 ? (ms / 1000).toFixed(1) + "s" : Math.round(ms) + "ms"; }
-/// A disk-I/O rate, in the unit a human reads it in. Whole bytes and whole KB — a
-/// fractional B/s is noise — but MB/s keeps one decimal, because that is the range
+/// A disk-I/O rate, in the unit a human reads it in. Whole bytes and whole KiB — a
+/// fractional B/s is noise — but MiB/s keeps one decimal, because that is the range
 /// where the difference between 1.2 and 4.8 is the thing you are looking at.
+///
+/// **Binary units, and labelled as such.** These divide by 1024, so they were always
+/// KiB and MiB; calling them KB/MB understated every figure by 2.4% and 4.9%. The
+/// source is a byte counter, so the binary unit is the honest one — the label moved to
+/// meet the arithmetic rather than the other way round.
 export function fmtRate(bps: number): string {
   if (bps < 1024) return `${Math.round(bps)} B/s`;
-  if (bps < 1024 * 1024) return `${(bps / 1024).toFixed(0)} KB/s`;
-  return `${(bps / (1024 * 1024)).toFixed(1)} MB/s`;
+  if (bps < 1024 * 1024) return `${(bps / 1024).toFixed(0)} KiB/s`;
+  return `${(bps / (1024 * 1024)).toFixed(1)} MiB/s`;
 }
-/// A size already in MiB, promoted to GB once it stops being readable as MB.
+/// A size already in MiB, promoted to GiB once it stops being readable as MiB. Same
+/// binary-unit reasoning as `fmtRate` above — at GiB the mislabel was worth 7.4%.
 export function fmtMb(mb: number): string {
-  return mb >= 1024 ? `${(mb / 1024).toFixed(1)} GB` : `${mb.toFixed(0)} MB`;
+  return mb >= 1024 ? `${(mb / 1024).toFixed(1)} GiB` : `${mb.toFixed(0)} MiB`;
 }
 export function fmtShort(ms: number): string {
   const s = Math.round(ms / 1000);

--- a/src/historyui.ts
+++ b/src/historyui.ts
@@ -153,7 +153,8 @@ function histDetailHtml(h: HistEntry | undefined): string {
   const busy = histBusy(h);
   const p = histProject(h);
   const when = new Date(h.mtime * 1000).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
-  const size = h.bytes >= 1048576 ? `${(h.bytes / 1048576).toFixed(1)} MB` : `${Math.max(1, Math.round(h.bytes / 1024))} KB`;
+  // Binary units, spelled binary — this divides by 1024, same as `fmtMb`/`fmtRate`.
+  const size = h.bytes >= 1048576 ? `${(h.bytes / 1048576).toFixed(1)} MiB` : `${Math.max(1, Math.round(h.bytes / 1024))} KiB`;
   const facts = histFacts([
     ["project", `<span class="em">${esc(p.project)}</span>`],
     ["path", `${esc(tilde(h.cwd))}${h.exists ? "" : ` <span class="warn">· gone</span>`}`],

--- a/src/inspectorview.ts
+++ b/src/inspectorview.ts
@@ -15,7 +15,7 @@
 import { basename, esc, fmtDur, fmtDwell, fmtLatency, fmtMb, fmtRate, sparkline, tilde } from "./format";
 import type { DiffHunk } from "./diff";
 import { apiErrText, isAgent, statusKey, type DiffStat, type Risk, type Sess } from "./types";
-import { ioAll, ioScope, sessions, type IoScope } from "./state";
+import { ioAll, ioInfo, ioScope, sessions, type IoScope } from "./state";
 import { dayIo, ioDayCount, ioSameNote, ioTotal, todayKey } from "./usage";
 
 // Which session has a fetch/pull/push in flight, if any — the git buttons are
@@ -218,8 +218,8 @@ export function timelineHtml(s: Sess): string {
 // your tree and writes files — and a runaway agent shows up as sustained throughput
 // long before it shows up as CPU.
 //
-// The bar is log-scaled against a 32 MB/s reference rather than linear: real rates span
-// idle-KB/s to burst-MB/s, and a linear bar would sit at zero for everything short of a
+// The bar is log-scaled against a 32 MiB/s reference rather than linear: real rates span
+// idle-KiB/s to burst-MiB/s, and a linear bar would sit at zero for everything short of a
 // pathological write storm, which is precisely the case it needs to show.
 const IO_REF_BPS = 32 * 1024 * 1024;
 function ioPct(bps: number): number {
@@ -246,6 +246,35 @@ function ioText(scope: IoScope): string {
   const f = ioFigures(scope);
   return f.known ? `${fmtMb(f.r)} read · ${fmtMb(f.w)} written` : "not recorded";
 }
+/// Why the figures in this box look the way they do.
+///
+/// Every number here is **physical** disk I/O — what the kernel's per-process counters
+/// (`proc_pid_rusage` on macOS, and its equivalents elsewhere, via sysinfo) actually
+/// charged the claude processes Episko spawned. Three things about that surprise people
+/// enough to be worth a panel, and all three were measured on this machine rather than
+/// reasoned about:
+///
+/// - Writes ran ~32× the transcript's own growth (3.11 MiB of physical writes against
+///   0.10 MiB of transcript in 90s). Claude Code appends and fsyncs after every message,
+///   and a flush commits whole blocks; that is its journalling, not Episko's overhead
+///   and not something Episko can batch away.
+/// - Reads ran far *below* what the agents obviously read, because a page-cache hit
+///   never reaches the disk — a hot repo re-read costs nothing here.
+/// - Children are absent, and not by omission: a child that wrote 120 MiB moved its
+///   parent's counter by exactly 0.00 MiB. The OS never adds an exited child's bytes to
+///   its parent, so walking the process tree would still miss every sub-second `rg` or
+///   `git` that lives and dies between two four-second polls.
+///
+/// Kept as data rather than one blob of markup so the shape stays obvious and the strings
+/// stay greppable.
+const IO_INFO: Array<[string, string]> = [
+  ["Writes run far above the conversation",
+    "Claude Code appends to its transcript and fsyncs after every message, and each flush commits whole blocks — measured here at ~32× the transcript's own growth. That is Claude Code's own journalling; Episko only reports it."],
+  ["Reads look small",
+    "Anything already in the page cache never reaches the disk, so re-reading a warm repo costs nothing on this meter."],
+  ["Child processes are not counted",
+    "The git, ripgrep and node work an agent spawns churns invisibly: the OS never adds a child's bytes to its parent when it exits."],
+];
 export function resHtml(): string {
   const r = ioAll;
   // Before the second sample there is no window to average over, so the rate is unknown
@@ -268,11 +297,14 @@ export function resHtml(): string {
   // indistinguishable from a broken one unless the row says why.
   const note = ioSameNote(ioText("today"), ioText("run"), ioText("all"), ioDayCount());
   return `<div class="res" title="Disk I/O across every claude session Episko is running (${n}) · ${fmtMb(r.readMb)} read, ${fmtMb(r.writtenMb)} written this run">
-    <div class="rr rall"><span class="rk">all sessions</span><span class="rvall">${n} running</span></div>
+    <div class="rr rall"><span class="rk">all sessions</span><span class="rvall">${n} running</span><button class="rinfob${ioInfo ? " on" : ""}" data-ioinfo="1" aria-expanded="${ioInfo}" title="${ioInfo ? "Hide" : "Why these figures look the way they do"}">i</button></div>
     <div class="rr"><span class="rk">read</span><span class="rbar ${mc(rp)}"><i style="width:${rp}%"></i></span><span class="rv">${rd}</span></div>
     <div class="rr"><span class="rk">write</span><span class="rbar ${mc(wp)}"><i style="width:${wp}%"></i></span><span class="rv">${wr}</span></div>
     <button class="rr rtot" data-ioscope="1" title="${esc(IO_SCOPE_TITLE[ioScope])}"><span class="rk">${IO_SCOPE_LABEL[ioScope]}</span><span class="rcyc">⟳</span><span class="rvtot">${tot}</span></button>
-    ${note ? `<p class="rnote">${esc(note)}</p>` : ""}</div>`;
+    ${note ? `<p class="rnote">${esc(note)}</p>` : ""}
+    ${ioInfo ? `<div class="rinfo"><p class="rinfo-lead">Physical disk I/O charged to the claude processes Episko launched — not their logical reads and writes.</p>${
+      IO_INFO.map(([h, b]) => `<p><b>${esc(h)}</b>${esc(b)}</p>`).join("")
+    }</div>` : ""}</div>`;
 }
 /// Spelled out per scope rather than one generic hint, because the difference between
 /// them is the whole point and two of the three have a caveat worth one sentence.

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ import {
   followSessionDrift, removeFavorite, resolvePermission, revealActiveFolder,
   copyPath, openTerminalIn, setActionsRenderAll, setPeekPrefs, setPermMode, setSort,
   setSoundPrefs, setTheme, setWtGroup, setCmpBase, toggleInsp, toggleProjGroup,
-  toggleRail, toggleTheme,
+  toggleIoInfo, toggleRail, toggleTheme,
 } from "./actions";
 import { playSound, setSoundLogger } from "./chime";
 import { exitSound, hookSound, limitCrossed, soundSnap } from "./sound";
@@ -597,7 +597,7 @@ document.addEventListener("click", (e) => {
   // for free — but only if its attribute is in this list. A data- attribute the
   // selector doesn't name resolves to the enclosing row instead, silently doing the
   // wrong thing: that is what makes this list load-bearing rather than bookkeeping.
-  const el = t.closest<HTMLElement>("[data-perm],[data-driftfollow],[data-git],[data-diff],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-rgtoggle],[data-gtoggle],[data-closerun],[data-rungroup],[data-sel],[data-wtadd],[data-launch],[data-dash],[data-pal],[data-rail],[data-ioscope],[data-toast]");
+  const el = t.closest<HTMLElement>("[data-perm],[data-driftfollow],[data-git],[data-diff],[data-close],[data-remove],[data-add],[data-jump],[data-resume],[data-forget],[data-ext],[data-past],[data-rgtoggle],[data-gtoggle],[data-closerun],[data-rungroup],[data-sel],[data-wtadd],[data-launch],[data-dash],[data-pal],[data-rail],[data-ioscope],[data-ioinfo],[data-toast]");
   if (!el) return;
   if (el.dataset.perm) resolvePermission(el.dataset.permid || "", el.dataset.perm);
   else if (el.dataset.driftfollow) void followSessionDrift(el.dataset.driftfollow);
@@ -642,6 +642,7 @@ document.addEventListener("click", (e) => {
   // because there are three values and no sub-choices — a menu would be one more click
   // to reach a number that is already on screen.
   else if (el.dataset.ioscope) cycleIoScope();
+  else if (el.dataset.ioinfo) toggleIoInfo();
   else if (el.dataset.toast) toast(el.dataset.toast);
 });
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -297,3 +297,10 @@ export let ioScope: IoScope =
   (IO_SCOPES as string[]).includes(localStorage.getItem("cc-io-scope") || "")
     ? localStorage.getItem("cc-io-scope") as IoScope : "today";
 export function setIoScope(s: IoScope) { ioScope = s; }
+
+// Whether the I/O box's explanation panel is open. Deliberately NOT persisted and not a
+// `cc-` key: the figures in that box are startling on first sight (a day of agents reads
+// as a gigabyte written) and the panel exists to say why once, not to be a preference
+// somebody carries between runs. Reset by a restart is the right lifetime for it.
+export let ioInfo = false;
+export function setIoInfo(v: boolean) { ioInfo = v; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -892,7 +892,13 @@ html.win .wctl { display: flex; }
 .res .rbar { flex: 1; height: 4px; border-radius: 2px; background: var(--hair-strong); overflow: hidden; }
 .res .rbar > i { display: block; height: 100%; border-radius: 2px; background: var(--st-done); }
 .res .rbar.warn > i { background: var(--st-working); } .res .rbar.hot > i { background: var(--st-error); }
-.res .rv { font: 11px var(--font-mono); width: 62px; text-align: right; color: var(--muted); font-variant-numeric: tabular-nums; flex: none; }
+/* 74px and `nowrap`, both load-bearing. The column is fixed-width and the rate strings
+   are as long as "999.9 MiB/s" — at 62px that wrapped to a second line, silently doubling
+   the row's height rather than overflowing where anyone would notice. `nowrap` is the
+   part that keeps this from coming back: it makes a too-long unit overflow visibly
+   instead of reflowing the box. (The binary-unit relabel added a character to every
+   rate; the wrap was already reachable before it at "999.9 MB/s".) */
+.res .rv { font: 11px var(--font-mono); width: 74px; text-align: right; color: var(--muted); font-variant-numeric: tabular-nums; flex: none; white-space: nowrap; }
 /* Totals: context for the rates above, so it reads as a footnote not a third gauge.
    A button, because the window it covers cycles on click (today → this run → recorded)
    — reset to look exactly like the row it replaced. */
@@ -917,6 +923,22 @@ html.win .wctl { display: flex; }
 .res .rall { padding-bottom: 8px; border-bottom: 1px solid var(--hair); }
 .res .rall .rk { width: auto; flex: 1; color: var(--muted); }
 .res .rvall { font: 10px var(--font-mono); color: var(--muted-2); font-variant-numeric: tabular-nums; }
+/* The `i` disc opens the explanation below. It sits ON the heading row rather than
+   beside the total, because what it explains is every figure in the box, not the one
+   window the total happens to be showing. Round, hairline and muted at rest: this box is
+   reference, and an info affordance that competes with the meters defeats the point. */
+.res .rinfob { flex: none; margin-left: 7px; width: 13px; height: 13px; padding: 0; border-radius: 50%;
+  border: 1px solid var(--hair-strong); background: transparent; cursor: pointer;
+  font: italic 600 9px/1 var(--font-ui); color: var(--muted-2); opacity: .7;
+  display: flex; align-items: center; justify-content: center; transition: opacity .15s ease, color .15s ease, border-color .15s ease; }
+.res .rinfob:hover { opacity: 1; color: var(--fg); border-color: var(--muted-2); }
+.res .rinfob.on { opacity: 1; color: var(--fg); border-color: var(--muted-2); background: var(--surface-2); }
+/* Hairline-separated from the meters for the same reason `.rall` is: this is prose about
+   the box, not another row in it. */
+.res .rinfo { margin-top: 2px; padding-top: 8px; border-top: 1px solid var(--hair); display: flex; flex-direction: column; gap: 6px; }
+.res .rinfo p { margin: 0; font: 9.5px/1.4 var(--font-ui); color: var(--muted-2); }
+.res .rinfo b { display: block; font-weight: 600; color: var(--muted); }
+.res .rinfo .rinfo-lead { opacity: .8; }
 
 /* --- risk badge on the pending-permission block --- */
 .attn-h { justify-content: flex-start; }

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -103,20 +103,33 @@ describe("fmtLatency — the Pre→Post tool gap", () => {
 });
 
 describe("fmtRate / fmtMb — the inspector's disk-I/O readout", () => {
-  it("picks the unit the number is readable in, and keeps a decimal only for MB/s", () => {
+  it("picks the unit the number is readable in, and keeps a decimal only for MiB/s", () => {
     expect(fmtRate(0)).toBe("0 B/s");
     expect(fmtRate(512)).toBe("512 B/s");
     expect(fmtRate(1023)).toBe("1023 B/s");
-    expect(fmtRate(1024)).toBe("1 KB/s");        // whole KB — a fractional one is noise
-    expect(fmtRate(1024 * 1023)).toBe("1023 KB/s");
-    expect(fmtRate(1024 * 1024)).toBe("1.0 MB/s"); // …but MB/s keeps one, 1.2 vs 4.8 matters
-    expect(fmtRate(1024 * 1024 * 32.45)).toBe("32.5 MB/s");
+    expect(fmtRate(1024)).toBe("1 KiB/s");        // whole KiB — a fractional one is noise
+    expect(fmtRate(1024 * 1023)).toBe("1023 KiB/s");
+    expect(fmtRate(1024 * 1024)).toBe("1.0 MiB/s"); // …but MiB/s keeps one, 1.2 vs 4.8 matters
+    expect(fmtRate(1024 * 1024 * 32.45)).toBe("32.5 MiB/s");
   });
-  it("promotes a total to GB only once it stops reading as MB", () => {
-    expect(fmtMb(0)).toBe("0 MB");
-    expect(fmtMb(1023.4)).toBe("1023 MB");
-    expect(fmtMb(1024)).toBe("1.0 GB");
-    expect(fmtMb(3891.2)).toBe("3.8 GB");
+  it("promotes a total to GiB only once it stops reading as MiB", () => {
+    expect(fmtMb(0)).toBe("0 MiB");
+    expect(fmtMb(1023.4)).toBe("1023 MiB");
+    expect(fmtMb(1024)).toBe("1.0 GiB");
+    expect(fmtMb(3891.2)).toBe("3.8 GiB");
+  });
+  /// The units are BINARY, and the labels have to say so — these divide by 1024, so a
+  /// "MB" label understated every figure by 4.9% and a "GB" one by 7.4%. Asserted on the
+  /// boundary values because that is where a future edit would most plausibly "tidy" the
+  /// suffix back to the decimal spelling without touching the arithmetic under it.
+  it("labels the binary units it actually computes", () => {
+    expect(fmtRate(1024)).toContain("KiB");
+    expect(fmtRate(1024 * 1024)).toContain("MiB");
+    expect(fmtMb(1)).toContain("MiB");
+    expect(fmtMb(1024)).toContain("GiB");
+    for (const s of [fmtRate(1024), fmtRate(1024 * 1024), fmtMb(1), fmtMb(1024)]) {
+      expect(s).not.toMatch(/(?<!i)[KMG]B/);
+    }
   });
 });
 


### PR DESCRIPTION
The resource box shows figures that look like a bug and aren't: a day of agents reads as **1.2 GiB written** while the sessions on screen have written single-digit megabytes. This started as a check of that number against the kernel and turned into two changes.

## The number is right

Verified against `proc_pid_rusage` — the same counters sysinfo wraps — sampled beside Episko's own `cc-io` rollup over the same 4½-minute window:

| | kernel Δ | Episko Δ | |
|---|---|---|---|
| read | +1.63 MiB | +1.63 MiB | exact |
| written | +3.83 MiB | +3.92 MiB | +2.3% |

The per-pid differencing, the `io_retired` banking and `splitIo`'s day attribution all hold up. **No accounting change in this PR** — the residual 2% is the 60s flush floor. What was missing was any way for the reader to know that.

## An `i` that explains the box

Three things, each measured rather than reasoned about:

- **Writes run ~32× the transcript's own growth** — 3.11 MiB physical against 0.10 MiB of transcript over 90s. Claude Code appends and fsyncs after every message and each flush commits whole blocks. That is Claude Code's journalling; Episko only reports the counters and can't batch it away.
- **Reads look small** — a page-cache hit never reaches the disk.
- **Children aren't counted** — and this is the interesting one. A child that wrote **120 MiB** moved its parent's counter by **exactly 0.00 MiB**; there is no `ri_child_diskio` to go with `ri_child_pageins`. So a process-tree walk would only catch children alive at the instant of the poll and would still miss every sub-second `rg` or `git` between two 4s polls. It is cheap (54µs/poll via `proc_listchildpids`, against 4µs today) — it just doesn't work, and it would trade the "one sysinfo refresh, every OS" property for a macOS-only path. Documented in the UI instead of closed.

Not persisted, no new `cc-` key: it answers the question once rather than being a preference carried between runs. Follows the `ioScope` path exactly — assign-only setter in `state.ts`, toggle + `renderAll()` in `actions.ts`, markup-only in `inspectorview.ts`, and the attribute in **both** halves of the click dispatcher (`dispatch.test.ts` enforces that join, so the branch can't ship dead).

## The units were wrong

`fmtRate` and `fmtMb` divide by 1024, so they were always KiB/MiB/GiB. The KB/MB/GB labels understated every figure by 2.4%, 4.9% and 7.4%. The source is a byte counter, so the label moved to meet the arithmetic rather than the other way round. History's transcript size had the identical defect.

The new test asserts the binary spelling directly (`/(?<!i)[KMG]B/`), because the plausible regression is someone tidying the suffix back without touching the divisor.

**One latent bug this exposed:** the extra character pushed the rate past the fixed 62px readout column, and with no `white-space` rule it *wrapped to a second line* — silently doubling the row height instead of overflowing where anyone would notice (29px against 14.5px, measured in the browser). Now 74px + `nowrap`; the `nowrap` is the part that keeps it from returning. The wrap was already reachable before this change at `999.9 MB/s`.

## Verification

`tsc` clean · 892/892 vitest · `pnpm build` clean · `changelog check` passes. No Rust touched.

Rendered headlessly at the real 300px inspector width in both themes, and the three worst-case rate strings (`1023 KiB/s`, `999.9 MiB/s`, `32.5 MiB/s`) confirmed on one line with the bars keeping their room.

Branched off `dev` in a separate worktree — it shares no files with `fix/limit-forecast-sustained-rate`, which is in flight on the same checkout. Both touch `## Unreleased`, so whichever lands second needs the usual union of entries.