### PR TITLE
sidebar: the row that opened the dashboard says so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
+! **A project dashboard now shows in the sidebar as the thing you are looking at.**
+  Opening one changed the stage and left every row in the sidebar looking unselected, so
+  the only surface on screen had nothing pointing at it, and with the sidebar collapsed
+  to the rail there was nothing to say which project you were reading. The project's
+  header now carries the same selection a session row does, and its rail button lights
+  the same way. A repo split across its checkouts marks the project's own row, since
+  every one of those rows opens the same dashboard.
+
 ## 0.19.0 — 2026-08-10
 The inspector stops listing tool calls and starts listing files — what the agent
 created, edited and read, each one a click away from opening.

--- a/src/grouping.ts
+++ b/src/grouping.ts
@@ -205,6 +205,25 @@ export function projectList(): ProjGroup[] {
   return groups;
 }
 
+/// Which rows of that list the open dashboard belongs to — what the sidebar header and
+/// the mini-rail button mark as selected. `root` is the dash mirror's, or `null` when
+/// no dashboard holds the stage (in which case nothing is marked).
+///
+/// Not simply "the row whose path matches". Every project header opens the dashboard of
+/// `repoRoot ?? path`, so in toplevel mode a repo split across checkouts has SEVERAL
+/// rows pointing at the same one, and lighting all of them would claim the project is
+/// on stage several times over. The root row *is* the project (`splitByWorktree` is
+/// what leaves it without a `repoRoot`), so it wears the mark alone whenever it is in
+/// the list. The checkouts share it only in the one case that has no root row — a
+/// worktree-only repo, whose phantom root is dropped — because there the alternative is
+/// the bug this exists to fix: a click that opened a dashboard with no row to show it.
+export function dashHeads(list: ProjGroup[], root: string | null): Set<string> {
+  if (!root) return new Set();
+  const own = list.filter((p) => (p.repoRoot ?? p.path) === root);
+  const rootRow = own.find((p) => !p.repoRoot);
+  return new Set((rootRow ? [rootRow] : own).map((p) => p.path));
+}
+
 // ---------- the user's named groups, folded into that list ----------
 // `projectList()` above answers "which projects, in what order"; this layers the user's
 // own headings over the result without touching either question. ./projgroups owns the

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -14,7 +14,7 @@ import { $, IS_MAC, toast } from "./dom";
 import { dlog } from "./debug";
 import { esc, tilde } from "./format";
 import { iconFor, projGlyph } from "./icons";
-import { groupedProjects, groupSummary, projectList, type ProjGroup } from "./grouping";
+import { dashHeads, groupedProjects, groupSummary, projectList, type ProjGroup } from "./grouping";
 import {
   PEEK_IDLE, peekEnter, peekLeave, peekLeaveAll, peekNextDeadline, peekTick,
   type PeekState,
@@ -22,7 +22,7 @@ import {
 import { groupOf, setCollapsed, type GroupDef } from "./projgroups";
 import { dormantRows, foldEmpty, foldHead, groupBody, peekBody } from "./sidebarview";
 import {
-  activeId, extMirrorId, FAVORITES, folderDirty, keyPrefs, peekPrefs, projGroups,
+  activeId, dashMirror, extMirrorId, FAVORITES, folderDirty, keyPrefs, peekPrefs, projGroups,
   saveProjGroups, saveProjOrder, sessions, setProjGroups, setProjOrder, sortMode,
   type SortMode,
 } from "./state";
@@ -80,8 +80,13 @@ function invalidateSidebarCache() { lastHtml = null; }
 export function renderSidebar() {
   // Don't stomp the DOM the browser is mid-drag on — see draggingProjects.
   if (draggingProjects) return;
-  const html = groupedProjects().map((slot) =>
-    slot.kind === "project" ? projectHtml(slot.project) : foldHtml(slot.group, slot.projects)).join("");
+  const list = projectList();
+  // Which header(s) the open dashboard belongs to. ./grouping's rule rather than a
+  // `p.path === root` test here, because one repo can be several rows and they all
+  // open the same dashboard.
+  const dash = dashHeads(list, dashMirror()?.root ?? null);
+  const html = groupedProjects(list).map((slot) =>
+    slot.kind === "project" ? projectHtml(slot.project, dash) : foldHtml(slot.group, slot.projects, dash)).join("");
   if (html === lastHtml) return; // nothing the sidebar shows has changed
   lastHtml = html;
   $("projects").innerHTML = html;
@@ -99,14 +104,16 @@ export function renderSidebar() {
 // markup string: hover changes many times a second and would shred `lastHtml`, but a
 // collapse is a deliberate click, so it costs exactly one repaint and keeps the state
 // in the one place a re-render can't lose it.
-function foldHtml(g: GroupDef, projects: ProjGroup[]): string {
-  const body = projects.length ? projects.map(projectHtml).join("") : foldEmpty();
+function foldHtml(g: GroupDef, projects: ProjGroup[], dash: Set<string>): string {
+  // Wrapped rather than `projects.map(projectHtml)`: map would pass the index as the
+  // second argument, and every row after the first would think it was the dashboard's.
+  const body = projects.length ? projects.map((p) => projectHtml(p, dash)).join("") : foldEmpty();
   return `<div class="pfold${g.collapsed ? " collapsed" : ""}" data-fold="${esc(g.id)}">`
     + foldHead(g, groupSummary(projects), projects.length)
     + `<div class="pfbody"><div class="pfbody-in">${body}</div></div></div>`;
 }
 
-function projectHtml(p: ProjGroup): string {
+function projectHtml(p: ProjGroup, dash: Set<string>): string {
   const rows = groupBody(p) + dormantRows(p);
   const total = p.sessions.length + p.externals.length;
   const isFav = FAVORITES.some((f) => f.path === p.path);
@@ -130,18 +137,24 @@ function projectHtml(p: ProjGroup): string {
   // *inside* the project's dashboard, which is where a worktree belongs.
   const dashRoot = p.repoRoot ?? p.path;
   const opens = `data-dash="${esc(dashRoot)}" data-proj="${esc(p.name)}"`;
+  // A dashboard owns the stage exactly the way a session does, so the row that opened it
+  // says so — the same `.active` a session row wears. Without it the project header was
+  // the one selectable thing in the sidebar with no selected state, so the dashboard on
+  // screen appeared to belong to no project, and (with the rail collapsed) there was
+  // nothing to say which one you were looking at.
+  const on = dash.has(p.path) ? " active" : "";
   let head: string;
   if (p.sessions.length) {
-    head = `<div class="phead" ${opens} data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}${wtSuffix}</span>${dot}<span class="pcount">${total}</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}">＋</span><span class="parm"></span></div>`;
+    head = `<div class="phead${on}" ${opens} data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}${wtSuffix}</span>${dot}<span class="pcount">${total}</span><span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}">＋</span><span class="parm"></span></div>`;
   } else if (isFav) {
     const tail = p.externals.length ? `<span class="pcount ext">${p.externals.length} ext</span>` : `<span class="plaunch">open →</span>`;
-    head = `<div class="phead empty-p" ${opens} data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="premove" data-remove="${esc(p.path)}" title="Remove project">✕</span><span class="parm"></span></div>`;
+    head = `<div class="phead empty-p${on}" ${opens} data-key="${esc(p.path)}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}</span>${dot}${tail}<span class="premove" data-remove="${esc(p.path)}" title="Remove project">✕</span><span class="parm"></span></div>`;
   } else {
     // discovered via an external session or a restorable one only — not a saved project
     const tail = p.externals.length
       ? `<span class="pcount ext">${p.externals.length} ext</span>`
       : `<span class="pcount ext">${p.dormants.length} past</span>`;
-    head = `<div class="phead ext-only" ${opens} data-key="${esc(p.path)}" title="${esc(tilde(p.path))}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}${wtSuffix}</span>${dot}${tail}<span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" title="Launch an Episko session here">＋</span><span class="parm"></span></div>`;
+    head = `<div class="phead ext-only${on}" ${opens} data-key="${esc(p.path)}" title="${esc(tilde(p.path))}">${projGlyph(p.path, p.accent)}<span class="pname">${esc(p.name)}${wtSuffix}</span>${dot}${tail}<span class="padd" data-launch="${esc(p.path)}" data-proj="${esc(p.name)}" title="Launch an Episko session here">＋</span><span class="parm"></span></div>`;
   }
   return `<div class="pgroup" data-path="${esc(p.path)}">${head}${rows ? `<div class="psessions">${rows}</div>` : ""}${peekBody(p)}</div>`;
 }
@@ -459,9 +472,13 @@ function hint(id: KeyAction): string {
 let lastMiniHtml: string | null = null;
 export function renderMini() {
   const activeProj = activeId ? sessions.get(activeId)?.project : null;
+  const list = projectList();
+  // The collapsed rail is the only project surface on screen while it is up, so a
+  // dashboard has to mark its button here too — see projectHtml's `on`.
+  const dash = dashHeads(list, dashMirror()?.root ?? null);
   const html =
     `<button class="rm-btn" data-rail="1" title="Expand sidebar${hint("sidebar")}">»</button>` +
-    projectList().map((p) => {
+    list.map((p) => {
       const first = p.sessions[0];
       const firstExt = p.externals[0];
       const attn = p.sessions.some((s) => s.attention || s.phase === "error");
@@ -470,7 +487,8 @@ export function renderMini() {
         : `data-launch="${esc(p.path)}" data-proj="${esc(p.name)}"`;
       const ic = iconFor(p.path);
       const glyph = ic ? `<img class="rm-icon" src="${ic}" alt="" />` : `<span class="rm-dot"></span>`;
-      const onCls = p.name === activeProj || (extMirrorId() && p.externals.some((e) => e.session_id === extMirrorId())) ? "on" : "";
+      const onCls = p.name === activeProj || dash.has(p.path)
+        || (extMirrorId() && p.externals.some((e) => e.session_id === extMirrorId())) ? "on" : "";
       const extOnly = !first && firstExt ? "ext" : "";
       return `<button class="rm-proj ${onCls} ${extOnly}" style="--rc:${p.accent}" title="${esc(p.name)}${extOnly ? " (external)" : ""}" data-key="${esc(p.path)}" ${sel}>${glyph}${attn ? '<span class="rm-badge"></span>' : ""}</button>`;
     }).join("") +

--- a/src/styles.css
+++ b/src/styles.css
@@ -309,6 +309,14 @@ html.win .wctl { display: flex; }
 .premove { flex: none; margin-left: 7px; opacity: 0; color: var(--muted-2); font-size: 10px; cursor: pointer; transition: opacity .12s, color .12s; }
 .phead.empty-p:hover .premove { opacity: .75; }
 .premove:hover { color: var(--st-attention); opacity: 1; }
+/* The header whose dashboard holds the stage — the same treatment .srow.active gives a
+   selected session, since a dashboard owns the stage the same way. Deliberately AFTER
+   .phead:hover and the .empty-p overrides: all three are two classes, so source order
+   is what decides, and a selected header must not lose its state to the pointer or to
+   being a project with nothing running in it. --accent is the dashboard project's (set
+   on open), which is right precisely because only its own row can be active. */
+.phead.active { background: var(--surface-2); box-shadow: inset 0 0 0 1px var(--hair); }
+.phead.active .pname { color: var(--accent-ink); }
 
 .psessions { padding: 1px 0 4px 8px; margin-left: 10px; border-left: 1px solid var(--hair); display: flex; flex-direction: column; gap: 1px; }
 .srow { position: relative; display: grid; grid-template-columns: 14px minmax(0,1fr) auto; gap: 7px; align-items: center; padding: 5px 8px; border-radius: 7px; cursor: pointer; }

--- a/test/grouping.test.ts
+++ b/test/grouping.test.ts
@@ -7,7 +7,7 @@ import {
   worktreesByRepo,
 } from "../src/state";
 import {
-  allProjects, clusterByWorktree, clusterIsLive, dormantBusy, foldRunGroups,
+  allProjects, clusterByWorktree, clusterIsLive, dashHeads, dormantBusy, foldRunGroups,
   groupedProjects, groupPhase, groupSummary, needsYou, needsYouSessions,
   nextAfterClose, nextInGroup, orderedSessions, orphanAdoptions, projectList,
   reactorLabel, reactorState, splitByWorktree, urgencyRank,
@@ -352,6 +352,39 @@ describe("splitByWorktree — toplevel mode explodes a multi-checkout project", 
     const out = splitByWorktree([p]);
     expect(out[0].externals.map((e) => e.session_id)).toEqual(["e2"]);
     expect(out[1].externals.map((e) => e.session_id)).toEqual(["e1"]);
+  });
+});
+
+describe("dashHeads — which sidebar row the open dashboard is marked on", () => {
+  const wt = (path: string, repoRoot: string) => grp({ path, repoRoot, wtBranch: "feature" });
+  it("marks nothing when no dashboard holds the stage", () => {
+    expect(dashHeads([grp()], null).size).toBe(0);
+  });
+  it("marks the row whose project the dashboard is of", () => {
+    const list = [grp(), grp({ name: "other", path: "/w/other" })];
+    expect([...dashHeads(list, "/w/epi")]).toEqual(["/w/epi"]);
+  });
+  it("marks nothing when the dashboard's project is not in the list", () => {
+    // It can leave it: a project with nothing running drops off a filtered list while
+    // its dashboard is still on stage. No row is better than the wrong row.
+    expect(dashHeads([grp({ path: "/w/other" })], "/w/epi").size).toBe(0);
+  });
+  it("marks the root row alone when a repo is split across checkouts", () => {
+    // Every one of these rows opens the SAME dashboard (`repoRoot ?? path`), and
+    // lighting all three would say the project is on stage three times over.
+    const list = [grp(), wt("/w/wt-a", "/w/epi"), wt("/w/wt-b", "/w/epi")];
+    expect([...dashHeads(list, "/w/epi")]).toEqual(["/w/epi"]);
+  });
+  it("falls back to the checkouts when the repo has no root row", () => {
+    // splitByWorktree drops the phantom root of a worktree-only repo, and that row is
+    // what would otherwise carry the mark — leaving the click that opened the dashboard
+    // with nothing to show for it.
+    const list = [wt("/w/wt-a", "/w/epi"), wt("/w/wt-b", "/w/epi")];
+    expect([...dashHeads(list, "/w/epi")]).toEqual(["/w/wt-a", "/w/wt-b"]);
+  });
+  it("never marks another project's checkout", () => {
+    const list = [grp(), wt("/w/other-wt", "/w/other")];
+    expect([...dashHeads(list, "/w/other")]).toEqual(["/w/other-wt"]);
   });
 });
 


### PR DESCRIPTION
When a project dashboard held the stage, nothing in the sidebar said so. `projectHtml` never read the `dash` mirror, so the header you clicked looked exactly as it had before — and with the sidebar collapsed to the rail, nothing on screen named the project you were reading.

## What changed

- **`grouping.ts` — new pure `dashHeads(list, root)`.** Not a `p.path === root` test: every header opens the dashboard of `repoRoot ?? path`, so in toplevel worktree mode one repo is several rows all pointing at the same dashboard, and lighting all of them would claim the project is on stage several times over. The root row *is* the project (`splitByWorktree` is what leaves it without a `repoRoot`), so it wears the mark alone whenever it is in the list. The checkouts share it only for a worktree-only repo, whose phantom root row is dropped — the one case that would otherwise still have nothing to highlight.
- **`sidebar.ts`** — `renderSidebar` computes the set once from `dashMirror()` and threads it through `foldHtml` to all three header shapes (plain / `empty-p` / `ext-only`). `foldHtml` wraps the call rather than passing `projectHtml` to `map`, which would hand the index in as the second argument and make every row after the first think it was the dashboard's.
- **`renderMini`** marks the rail button the same way — the rail is the only project surface on screen while it is up, so it had the identical gap. It reuses the one `projectList()` call instead of making a second.
- **`styles.css`** — `.phead.active` mirrors `.srow.active` (surface-2 + inset hairline, accent-ink name). Deliberately after `.phead:hover` and the `.empty-p` overrides: all three are two classes, so source order decides, and a selected header must not lose its state to the pointer or to being a project with nothing running in it.

The markup change flows through `renderSidebar`'s `lastHtml` guard normally, so opening a dashboard still costs one repaint.

## Testing

- Six new cases in `test/grouping.test.ts` for `dashHeads`: no dashboard, the plain match, a project that has left the list, the split repo, the worktree-only fallback, and never marking another project's checkout.
- `pnpm exec tsc --noEmit` clean; `pnpm test` 1019 passing; `node scripts/changelog.mjs check` passes.
- The highlight itself is in the untested-by-design render layer and wants a look in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)