### PR TITLE
review: the fifteen findings from today's sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,41 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
+! **A tool call's output can no longer land on another call's row.** Pairing a call's
+  start and end by `tool_use_id` fell back to matching by tool name whenever the id
+  matched nothing — not only when the payload carried none — so a reply whose opening row
+  had already aged out of the twelve the session keeps would close the oldest *other* open
+  call of that tool and staple its output, its latency and its failure onto it. Under
+  parallel subagents running many `Bash` calls at once that is routine, and a row saying
+  it ran something it never ran is worse than a row with no output at all. Two smaller
+  things on the same card: a tool answering with a JSON list (an MCP tool's content
+  blocks, a search's matches) said *(nothing returned)* for a call that returned plenty,
+  and a patch with no lines in it drew a bare `@@ … @@` header instead of falling back to
+  the line count.
+
+! **The explorer stops showing a project as it was the first time you opened it.** The
+  index is cached for thirty seconds, but a cache *hit* restarted the clock, so anyone
+  who reopens ⌘P more often than that never got a second read — a file an agent created
+  ten minutes ago was simply missing from browse and find. It also now marks the files
+  inside a newly created folder: git collapses those into a single `new dir/` entry
+  unless asked otherwise, so every file in the newest folder in the project arrived with
+  no mark and the `Changed` chip filtered them all out.
+
+! **One file, one letter.** The explorer's row marks and the new-session dialog's file
+  list read git's two-character status by opposite rules, so a file staged and then
+  edited showed `M` in one and `A` in the other, and a staged rename `M` against `R`.
+  They now share the one parser, which keeps the index half — `A` and `R` say something
+  `M` doesn't, since every uncommitted file is modified.
+
+! **Smaller repairs.** A symlinked folder in a non-repo project was listed as though it
+  were a file (and the guard meant to stop the walk following it could never fire); the
+  explorer's "some files not shown" warning could appear for a project that fitted
+  exactly and, worse, stay silent for one that genuinely didn't; hiding *Session count*
+  in Settings › Footer left the status bar opening with a stray divider; the guided
+  tour's card was rebuilt on every repaint, which can swallow a click on **Next** while
+  an agent is running; and a second confirmation raised from the first one's answer now
+  asks in the order the caller meant.
+
 + **A first run now offers a guided tour, and a release can offer a short intro to what it
   added.** The welcome card leads into a picker: `Quick start` is required, five chapters are
   optional and remembered one at a time, so you can take one now and three next month —

--- a/src-tauri/src/files.rs
+++ b/src-tauri/src/files.rs
@@ -46,8 +46,7 @@ pub(crate) struct FileIndex {
 /// project contains, and there is no second round trip per folder you step into.
 #[tauri::command(async)]
 pub(crate) fn project_files(root: String) -> FileIndex {
-    if let Some(files) = git_index(&root) {
-        let truncated = files.len() >= MAX_FILES;
+    if let Some((files, truncated)) = git_index(&root) {
         return FileIndex { files, truncated, repo: true };
     }
     let (files, truncated) = walk_index(std::path::Path::new(&root));
@@ -56,7 +55,14 @@ pub(crate) fn project_files(root: String) -> FileIndex {
 
 /// `git ls-files`, or None when this is not a repo (or git is unavailable, which is the
 /// same thing from here: the walk is the answer either way).
-fn git_index(root: &str) -> Option<Vec<String>> {
+///
+/// Returns whether the list was cut, decided at the cut rather than measured afterwards:
+/// `.take(MAX_FILES)` happens before the sort/dedup, so a post-dedup `len() >= MAX_FILES`
+/// both claims truncation for a repo of exactly MAX_FILES files and — mid-merge, where
+/// `--cached` lists a conflicted path once per stage — misses a genuine cut that
+/// deduplicated back under the line. The second is the one that matters: it hands the
+/// explorer a partial project and lets it present it as the whole thing.
+fn git_index(root: &str) -> Option<(Vec<String>, bool)> {
     let out = sys_command("git")
         .env("LC_ALL", "C")
         .arg("-C").arg(root)
@@ -68,17 +74,16 @@ fn git_index(root: &str) -> Option<Vec<String>> {
     }
     // `-z` rather than lines: a path may contain anything but NUL, and this is the one
     // place a quoted or newline-bearing filename would silently split into two rows.
-    let mut files: Vec<String> = String::from_utf8_lossy(&out.stdout)
-        .split('\0')
-        .filter(|s| !s.is_empty())
-        .take(MAX_FILES)
-        .map(|s| s.to_string())
-        .collect();
+    let text = String::from_utf8_lossy(&out.stdout);
+    let mut it = text.split('\0').filter(|s| !s.is_empty());
+    let mut files: Vec<String> = it.by_ref().take(MAX_FILES).map(|s| s.to_string()).collect();
+    // Whether anything was left behind, asked of the iterator we stopped pulling from.
+    let truncated = it.next().is_some();
     // `--cached` lists a conflicted path once per stage, so the same name can arrive
     // three times mid-merge.
     files.sort();
     files.dedup();
-    Some(files)
+    Some((files, truncated))
 }
 
 /// The non-repo fallback: a bounded, breadth-limited walk that skips what no file
@@ -100,15 +105,23 @@ fn walk_index(root: &std::path::Path) -> (Vec<String>, bool) {
                 continue;
             }
             let Ok(ft) = e.file_type() else { continue };
+            // Tested BEFORE `is_dir`, and this is the whole of the fix: `file_type()`
+            // never follows a link, so a symlink to a directory answers `is_dir() ==
+            // false` and `is_symlink() == true`. The old guard sat inside the `is_dir`
+            // arm where it could never be false — dead code — and, because `is_dir` was
+            // false, the link fell through to the file arm below and `vendor ->
+            // ../shared` was listed as a file. Skipping it outright keeps the walk
+            // bounded (a link can point at an ancestor) and keeps the list to real files.
+            if ft.is_symlink() {
+                continue;
+            }
             if ft.is_dir() {
                 if SKIP_DIRS.contains(&name.as_str()) {
                     continue;
                 }
-                // A symlinked directory is not descended into: it is the one way a
-                // bounded walk still becomes an unbounded one.
-                if depth + 1 < MAX_DEPTH && !ft.is_symlink() {
+                if depth + 1 < MAX_DEPTH {
                     stack.push((e.path(), depth + 1));
-                } else if depth + 1 >= MAX_DEPTH {
+                } else {
                     truncated = true;
                 }
             } else if let Ok(rel) = e.path().strip_prefix(root) {

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -2164,9 +2164,9 @@ pub(crate) struct ChangedPath {
     /// Repo-relative, forward slashes — the same shape the explorer's index uses, so the
     /// two join on the string without either side normalising.
     path: String,
-    /// One letter: `M` modified, `A` added, `D` deleted, `R` renamed, `U` unmerged,
-    /// `?` untracked. The worktree half of git's XY wins over the index half, because a
-    /// file staged-then-edited is, to a reader looking at their tree, edited.
+    /// One letter, from the same `v2_code` the new-session dialog's file list uses, so
+    /// the two lists cannot call one file two things. See that function for which half
+    /// of git's XY wins and why.
     status: String,
 }
 
@@ -2174,8 +2174,9 @@ pub(crate) struct ChangedPath {
 ///
 /// A sibling of `git_diffstat` rather than a field on it: the stat is polled every 15s
 /// for every open folder and must stay a handful of integers, while this is asked for
-/// once, by one overlay, when it opens. Same single `status --porcelain=v2` walk either
-/// way, so the cost is one process and no diffing.
+/// once, by one overlay, when it opens. One `status --porcelain=v2` process either way
+/// and no diffing — but this one asks for `-uall` and the polled one must not, which is
+/// the second reason they are separate commands rather than one with a flag.
 ///
 /// Returns an empty list rather than an error when the folder is not a repo: the
 /// explorer works fine there (its index just comes from a walk instead), and a row with
@@ -2186,7 +2187,14 @@ pub(crate) fn git_changed(workdir: String) -> Vec<ChangedPath> {
         .env("LC_ALL", "C")
         .arg("-C").arg(&workdir)
         .args(["-c", "core.quotePath=false"])
-        .args(["--no-optional-locks", "status", "--porcelain=v2"])
+        // `-uall`, not git's default `-unormal`. The default collapses a new folder into
+        // the single entry `? sub/`, so every file inside it reaches the explorer with no
+        // mark at all and the `Changed` chip filters out the newest files in the project
+        // — while the index beside it (`ls-files --others`) lists each one. That walk is
+        // already being done for this same overlay, so naming the files here costs
+        // nothing new. `working_set` keeps `-unormal` on purpose: it is polled every 15s
+        // and it *counts* the collapsed entry as one `new_dirs`.
+        .args(["--no-optional-locks", "status", "--porcelain=v2", "-uall"])
         .output();
     let Ok(out) = out else { return Vec::new() };
     if !out.status.success() {
@@ -2195,50 +2203,24 @@ pub(crate) fn git_changed(workdir: String) -> Vec<ChangedPath> {
     let text = String::from_utf8_lossy(&out.stdout);
     let mut rows = Vec::new();
     for line in text.lines() {
-        // Every entry type puts its path LAST, after a fixed field count, so splitn on
-        // that count keeps a path with spaces in one piece. Rename entries then carry
-        // `<new>\t<old>`; the new name is the one a file list is about.
-        let (fields, xy) = match line.as_bytes().first() {
-            Some(b'1') => (9, line.get(2..4)),
-            Some(b'2') => (10, line.get(2..4)),
-            Some(b'u') => (11, Some("uu")),
-            Some(b'?') => (2, Some("??")),
-            _ => continue,
-        };
-        let Some(path) = line.splitn(fields, ' ').nth(fields - 1) else { continue };
-        let path = path.split('\t').next().unwrap_or(path);
+        // `v2_path`/`v2_code` rather than a second parse of the same format. This used to
+        // re-implement the per-kind field count inline (9/10/11/2 against their 8/9/10,
+        // both correct, both arrived at separately), which meant a fix to either had to
+        // be found twice — and the two disagreed about the status letter, so one file
+        // could be `M` here and `A` in the new-session dialog.
+        let Some(kind) = line.as_bytes().first().copied() else { continue };
+        if !matches!(kind, b'1' | b'2' | b'u' | b'?') {
+            continue;
+        }
+        let Some((path, _from)) = v2_path(line) else { continue };
         if path.is_empty() {
             continue;
         }
-        rows.push(ChangedPath { path: path.to_string(), status: status_letter(xy).to_string() });
+        let xy = line.split(' ').nth(1).unwrap_or("");
+        let code = if kind == b'?' { '?' } else { v2_code(kind, xy) };
+        rows.push(ChangedPath { path, status: code.to_string() });
     }
     rows
-}
-
-/// git's two-character XY (index, worktree) as the one letter a row shows.
-fn status_letter(xy: Option<&str>) -> &'static str {
-    let b = xy.unwrap_or("").as_bytes();
-    if b == b"??" {
-        return "?";
-    }
-    if b == b"uu" {
-        return "U";
-    }
-    // Worktree half first: a file staged as added and then edited still reads as `A`
-    // only if nothing has happened to it since, which is what taking `.` as "no news"
-    // gives us.
-    for c in [b.get(1).copied().unwrap_or(b'.'), b.first().copied().unwrap_or(b'.')] {
-        match c {
-            b'M' => return "M",
-            b'A' => return "A",
-            b'D' => return "D",
-            b'R' => return "R",
-            b'C' => return "C",
-            b'T' => return "T",
-            _ => {}
-        }
-    }
-    "M"
 }
 
 #[derive(serde::Serialize)]
@@ -3658,6 +3640,31 @@ canonicalizehostname false
         assert!(by("old name.txt").is_none(), "the old name is not a file any more: {:?}",
             rows.iter().map(|r| &r.path).collect::<Vec<_>>());
         assert_eq!(rows.len(), 4);
+
+        // A new *folder* is where `-unormal` used to give up: it reports `? sub/` as one
+        // entry, so both files below would reach the explorer unmarked while its index
+        // (`ls-files --others`) lists them individually — and the `Changed` chip would
+        // then filter out the newest files in the project.
+        std::fs::create_dir(dir.join("new dir")).unwrap();
+        std::fs::write(dir.join("new dir").join("a.txt"), "a\n").unwrap();
+        std::fs::write(dir.join("new dir").join("b.txt"), "b\n").unwrap();
+        let rows = git_changed(path.clone());
+        let by = |p: &str| rows.iter().find(|r| r.path == p).map(|r| r.status.clone());
+        assert_eq!(by("new dir/a.txt").as_deref(), Some("?"), "each file inside a new folder is named: {:?}",
+            rows.iter().map(|r| &r.path).collect::<Vec<_>>());
+        assert_eq!(by("new dir/b.txt").as_deref(), Some("?"));
+        assert!(by("new dir/").is_none(), "the collapsed folder entry is not a row");
+
+        // The index half of XY wins, and this is the case that says so: staged as added,
+        // then edited in the tree. `A` is the fact worth keeping — every dirty file is
+        // modified, only a new one is added — and the new-session dialog's list reads it
+        // the same way, which is the point of sharing `v2_code`.
+        std::fs::write(dir.join("staged then edited.txt"), "1\n").unwrap();
+        git(&dir, &["add", "staged then edited.txt"]);
+        std::fs::write(dir.join("staged then edited.txt"), "1\n2\n").unwrap();
+        let rows = git_changed(path.clone());
+        let by = |p: &str| rows.iter().find(|r| r.path == p).map(|r| r.status.clone());
+        assert_eq!(by("staged then edited.txt").as_deref(), Some("A"));
 
         // Not a repo: an empty list, not an error — the explorer still works there.
         let plain = scratch_dir();

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -10,6 +10,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { $, toast } from "./dom";
 import { ask } from "./confirm";
 import { basename } from "./format";
@@ -57,8 +58,15 @@ export function openTerminalIn(project: string, dir: string) {
   if (termEngine !== "embedded") { invoke("open_terminal_here", { workdir: dir, engine: termEngine }).catch((e) => toast("terminal: " + e)); return; }
   void launchShell(project, dir, { colorKey: dir });
 }
+/// The one copy-a-path in the app: the project menu's row, the Context card and the
+/// explorer's ⌥↵ all land here.
+///
+/// Through the Tauri plugin rather than `navigator.clipboard`, which is the same reason
+/// the terminal panes use it: the web API raises an OS permission prompt in a webview,
+/// and a prompt is a strange answer to "copy this path". Two back-ends for one verb is
+/// also how the wording and the failure path drift apart.
 export async function copyPath(dir: string) {
-  try { await navigator.clipboard.writeText(dir); toast("Path copied"); }
+  try { await writeText(dir); toast("Path copied"); }
   catch { toast(dir); } // clipboard denied — at least show what it was
 }
 

--- a/src/callsheet.ts
+++ b/src/callsheet.ts
@@ -56,7 +56,11 @@ export function openCallSheet(sessionId: string, key: string) {
 }
 
 export function closeCallSheet() {
-  if (!sid) return;
+  // `sid === null`, not `!sid`: `callSheetOpen()` asks the first question and these ask
+  // the second, so an empty-string id would answer "open" there and "closed" here — the
+  // dialog and its scrim would show, paint nothing, and refuse to close. No call site
+  // passes `""` today; the guards disagreeing is what makes one able to.
+  if (sid === null) return;
   sid = null;
   sel = null;
   $("callDlg").classList.remove("show");
@@ -64,7 +68,7 @@ export function closeCallSheet() {
 }
 
 export function selectCall(key: string) {
-  if (!sid || key === sel) return;
+  if (sid === null || key === sel) return;
   sel = key;
   renderCallSheet();
 }
@@ -123,7 +127,7 @@ let lastDetail = "";
  * match and skip.
  */
 export function renderCallSheet(force = false) {
-  if (!sid) return;
+  if (sid === null) return;
   const s = sessions.get(sid);
   // The pane went away under the sheet (closed, or the session ended and was swept).
   // Nothing left to show and no honest way to show it, so step out.

--- a/src/confirm.ts
+++ b/src/confirm.ts
@@ -107,9 +107,16 @@ function settle(v: boolean) {
   restoreFocus?.focus();
   restoreFocus = null;
   r(v);
-  // Only after the resolver has run, so a caller that asks a second question from its
-  // own `.then` is the one that gets in next rather than racing the queue.
-  waiting.shift()?.();
+  // `r(v)` only *schedules* the caller's continuation — it does not run it — so draining
+  // synchronously here painted the queued question first and pushed the caller's own
+  // follow-up behind it, which is the opposite of what this comment used to claim. One
+  // microtask hop puts the drain after that continuation.
+  //
+  // The `settleOpen` test is what makes the hop safe: if the continuation asked its own
+  // question, it is on screen now and the queue must not overwrite it. That question's
+  // own `settle` drains the queue next, so nothing is stranded — the order just ends up
+  // caller-first, which is the intent.
+  queueMicrotask(() => { if (!settleOpen) waiting.shift()?.(); });
 }
 
 $("cfmYes").addEventListener("click", () => settle(true));

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -23,11 +23,10 @@
 // ./explore instead.
 
 import { invoke } from "@tauri-apps/api/core";
-import { writeText } from "@tauri-apps/plugin-clipboard-manager";
-import { $, dropScrim, FILE_MANAGER, toast } from "./dom";
+import { $, dropScrim, FILE_MANAGER } from "./dom";
 import { basename, esc, escAttr } from "./format";
 import { sessions } from "./state";
-import { openTouchedFile, revealTouchedFile } from "./actions";
+import { copyPath, openTouchedFile, revealTouchedFile } from "./actions";
 import { openDiff } from "./diffview";
 import {
   browseRows, crumbs, findRows, parentDir, rowAction, scopeKeep, touchIndex,
@@ -100,7 +99,11 @@ export async function openExplorer(dir: string, label?: string) {
   if (!explorerOpen || root !== dir) return; // closed, or moved on, while reading
   loading = false;
   if (idx) {
-    indexCache.set(dir, { at: Date.now(), idx });
+    // Only a real read restarts the clock. Re-stamping on a cache *hit* would let every
+    // reopen inside the window extend it, so a project you glance at every half-minute
+    // would never be re-read at all and a file an agent made ten minutes ago would stay
+    // missing — the opposite of what CACHE_MS is for.
+    if (idx !== fresh) indexCache.set(dir, { at: Date.now(), idx });
     paths = idx.files;
     truncated = idx.truncated;
     isRepo = idx.repo;
@@ -241,7 +244,7 @@ $("expIn").addEventListener("keydown", (e) => {
     // ⌘↵ and ⌥↵ are the row's other two verbs, and both apply to a folder as well as a
     // file — revealing a directory is exactly what you want when you are looking at one.
     if (e.metaKey || e.ctrlKey) { closeExplorer(); void revealTouchedFile(abs(r.path)); }
-    else if (e.altKey) { void writeText(abs(r.path)).then(() => toast("Path copied")).catch((err) => toast(String(err))); }
+    else if (e.altKey) { void copyPath(abs(r.path)); }
     else activate(sel);
   } else if (e.key === "Backspace" && !($("expIn") as HTMLInputElement).value && cwd) {
     // Only when the field is empty: inside a query, ⌫ is editing text.

--- a/src/footer.ts
+++ b/src/footer.ts
@@ -76,16 +76,33 @@ function paintFootIo() {
 /// opens with one. The permanent three carry no divider and no entry in `FOOT_SEGS`,
 /// which is what keeps them permanent — see ./footprefs.
 ///
+/// The **first visible** segment drops its rule too, and that is not the same statement.
+/// `sessions` is the leftmost switchable segment and has no divider of its own in the
+/// markup, so hiding it used to promote `cost`'s rule up against the version block —
+/// a rule where the bar has never had one. Deciding it here rather than adding a
+/// `data-fdiv="sessions"` keeps the default appearance exactly as it is and survives
+/// whatever ends up leftmost next.
+///
 /// `hidden` rather than a class, because these are inline elements in a flex row and
 /// `hidden` is the one thing that removes them from the layout without a second rule to
 /// keep in sync.
+///
+/// Guarded on the switch state, because this runs from `renderFoot` on every `renderAll`
+/// pass and nothing but a Settings toggle can change the answer: without the guard it is
+/// fourteen DOM lookups a frame, forever, to rewrite a value that is already correct.
+let footPrefsKey = "";
 function applyFootPrefs() {
+  const key = FOOT_SEGS.map((s) => (footShown(footPrefs, s.id) ? "1" : "0")).join("");
+  if (key === footPrefsKey) return;
+  footPrefsKey = key;
+  let leading = true;
   for (const seg of FOOT_SEGS) {
     const on = footShown(footPrefs, seg.id);
     const el = document.getElementById(seg.el);
     if (el) (el as HTMLElement).hidden = !on;
     const div = document.querySelector<HTMLElement>(`[data-fdiv="${seg.id}"]`);
-    if (div) div.hidden = !on;
+    if (div) div.hidden = !on || leading;
+    if (on) leading = false;
   }
 }
 // Colour the footer % by its forecast (not its raw level), and show a muted

--- a/src/phase.ts
+++ b/src/phase.ts
@@ -74,8 +74,14 @@ function openActivity(s: Sess, tool: string, arg: string, id: string, inp: strin
   if (s.activity.length > ACT_CAP) s.activity.length = ACT_CAP;
 }
 function closeActivity(s: Sess, tool: string, id: string, inp: string, desc: string, out: string, failed: boolean) {
-  const a = (id && s.activity.find((x) => x.id === id))
-    || s.activity.find((x) => x.tool === tool && x.durMs == null);
+  // A ternary, never `||`: with an id that matches nothing — its Pre row aged out past
+  // ACT_CAP, or never opened — falling through to the name match closes the oldest
+  // *other* open call of the same tool and staples this output onto it. Under parallel
+  // subagents that is routine, and a row that says it ran something it didn't is worse
+  // than a row with no output. The name match exists for a payload carrying no id.
+  const a = id
+    ? s.activity.find((x) => x.id === id)
+    : s.activity.find((x) => x.tool === tool && x.durMs == null);
   if (!a) return;
   a.durMs = Date.now() - a.startMs;
   a.out = out;

--- a/src/toolio.ts
+++ b/src/toolio.ts
@@ -157,14 +157,20 @@ function patchText(o: Record<string, unknown>): string {
   // patch, which is the same claim `update` makes.
   const head = o.type === "create" ? "created"
     : o.type === "update" || hunks.length ? "updated" : "wrote";
+  // Drop an empty hunk on its `lines`, not on the joined string: every element built
+  // below carries a literal newline after the `@@` header whether or not anything
+  // follows it, so a `.includes("\n")` filter is always true and a hunk with no lines
+  // survives as a bare header — with `body` then truthy, the `N lines` fallback under
+  // it can never fire.
   const body = hunks
     .map((h) => {
       const g = isObj(h) ? h : {};
       const lines = Array.isArray(g.lines) ? g.lines.map((l) => String(l)) : [];
       const n = (v: unknown) => (typeof v === "number" ? v : 0);
-      return `@@ -${n(g.oldStart)},${n(g.oldLines)} +${n(g.newStart)},${n(g.newLines)} @@\n${lines.join("\n")}`;
+      return { head: `@@ -${n(g.oldStart)},${n(g.oldLines)} +${n(g.newStart)},${n(g.newLines)} @@`, lines };
     })
-    .filter((h) => h.includes("\n"))
+    .filter((h) => h.lines.length > 0)
+    .map((h) => `${h.head}\n${h.lines.join("\n")}`)
     .join("\n");
   if (body) return `${head}\n${body}`;
   // A fresh file has no hunks to show, and its content is already on the input side.
@@ -189,7 +195,12 @@ export function outputText(resp: unknown, error: unknown): string {
   if (resp == null) return "";
   if (!isObj(resp)) {
     const s = scalar(resp);
-    return s ? clip(s) : "";
+    if (s) return clip(s);
+    // An array is neither a scalar nor a record, so it reaches neither `scalar` nor
+    // `fieldsText` — and returning "" here made the sheet say "(nothing returned)" for a
+    // call that returned plenty (an MCP tool's content blocks, a search's matches). The
+    // generic dump is exactly what the header promises for a shape we don't model.
+    return Array.isArray(resp) ? clip(json(resp)) : "";
   }
   // Order matters: a Write response carries `type`, `content` AND `structuredPatch`, so
   // the patch has to win before the generic dump prints the whole file back at you.

--- a/src/tourui.ts
+++ b/src/tourui.ts
@@ -184,7 +184,8 @@ export function startChapter(id: string) {
   const at = read().at;
   if (at?.ch === c.id) {
     si = Math.min(Math.max(0, at.step), c.steps.length - 1);
-    if (!stepApplies(c.steps[si], world())) { const n = neighbour(si, 1); si = n >= 0 ? n : firstIndex(); }
+    const w0 = world();
+    if (!stepApplies(c.steps[si], w0)) { const n = neighbour(si, 1, w0); si = n >= 0 ? n : firstIndex(); }
   }
   seed();
   enter();
@@ -243,11 +244,10 @@ function allSteps(): TourStep[] { return chapter()?.steps ?? []; }
  */
 let seenCh = "";
 const seenIdx = new Set<number>();
-function counted(): TourStep[] {
+function counted(w: TourWorld = world()): TourStep[] {
   const c = chapter();
   if (!c) return [];
   if (seenCh !== c.id) { seenCh = c.id; seenIdx.clear(); }
-  const w = world();
   const out: TourStep[] = [];
   c.steps.forEach((s, i) => { if (stepApplies(s, w)) seenIdx.add(i); if (seenIdx.has(i)) out.push(s); });
   return out;
@@ -260,8 +260,8 @@ function step(): TourStep | null { return allSteps()[si] ?? null; }
  * points into the full list, so a predicate flipping while a step is on screen changes
  * what comes next and never what you are looking at.
  */
-function neighbour(from: number, dir: 1 | -1): number {
-  const list = allSteps(); const w = world();
+function neighbour(from: number, dir: 1 | -1, w: TourWorld = world()): number {
+  const list = allSteps();
   for (let i = from + dir; i >= 0 && i < list.length; i += dir) if (stepApplies(list[i], w)) return i;
   return -1;
 }
@@ -416,7 +416,7 @@ export function tourTick() {
   // footer are all rebuilt from scratch under us (so the node the hole was measured
   // against is routinely gone), and the card's own content is live too — a satisfied
   // wait drops its chip, and the stuck affordance appears on a clock.
-  renderStep();
+  renderStep(w);
 }
 
 // ---------- painting ----------
@@ -489,12 +489,23 @@ const KEYS: [RegExp, string][] = [
   ...(IS_MAC ? [] : ([[/⌘/g, "Ctrl"], [/⇧/g, "Shift"]] as [RegExp, string][])),
 ];
 const keys = (t: string) => KEYS.reduce((a, [re, to]) => a.replace(re, to), t);
+/// Guarded, like every other `innerHTML` surface on `renderAll`'s path.
+///
+/// `tourTick` is the last thing `renderAllNow` does, so while a chapter is open this
+/// runs on every paint — and during `quickstart` an agent is live, which means a paint
+/// per telemetry event. An assignment destroys the node under the pointer, so a click
+/// landing between mousedown and mouseup is silently dropped: exactly how a permission
+/// *Allow* was lost once, and here the buttons are Next and the chapter rows.
+let cardHtml = "";
 const shell = (cls: string, eyebrow: string, count: string, inner: string) => {
   const card = $("tourCard");
   card.className = `tour-card show ${cls}`;
-  card.innerHTML = `<div class="tc-top"><span class="tc-ch">${eyebrow}</span>`
+  const html = `<div class="tc-top"><span class="tc-ch">${eyebrow}</span>`
     + (count ? `<span class="tc-count">${count}</span>` : "")
     + `<button class="tc-x" data-tour="end" title="End the tour" aria-label="End the tour">✕</button></div>${inner}`;
+  if (html === cardHtml) return;
+  cardHtml = html;
+  card.innerHTML = html;
 };
 
 function renderWelcome() {
@@ -547,19 +558,25 @@ function renderDone() {
   centreHole($("tourHole"));
 }
 
-function renderStep() {
+/// Takes the pass's world rather than building its own.
+///
+/// Four builds per paint is the obvious cost — each one spreads the session map and
+/// sorts the needs-you set — but the correctness half matters more: `tourTick` folds the
+/// `permAnswered` latch into its snapshot, and a `world()` built here would not carry it.
+/// The chip saying a step is still waiting could then disagree with the tick that had
+/// already decided the step was satisfied.
+function renderStep(w: TourWorld = world()) {
   const c = chapter(); const s = step();
   if (!c || !s) return;
-  const w = world();
   const blocked = stepBlocked(s, w);
   const stuck = blocked && waitingSince > 0 && Date.now() - waitingSince > STUCK_MS;
   // The dots count the steps that apply, and `si` indexes all of them — so the position
   // is a lookup, not the index. A step standing on a `when` that has just gone false is
   // not in the list at all; it keeps the first dot rather than losing the row.
-  const list = counted();
+  const list = counted(w);
   const pos = Math.max(0, list.indexOf(s));
   const dots = list.map((_, i) => `<i class="${i === pos ? "on" : i < pos ? "past" : ""}"></i>`).join("");
-  const lastStep = neighbour(si, 1) < 0;
+  const lastStep = neighbour(si, 1, w) < 0;
   const lastCh = ci === plan.length - 1;
   const nextLabel = !lastStep ? "Next" : lastCh ? "Finish" : "Next chapter ▸";
 

--- a/test/phase.test.ts
+++ b/test/phase.test.ts
@@ -262,6 +262,22 @@ describe("applyHook — the lifecycle state machine", () => {
       hook(s, "PostToolUse", { tool_name: "Grep" });
       expect(s.activity).toHaveLength(0);
     });
+    it("drops a Post whose id matches nothing rather than closing another call's row", () => {
+      // The id is present and unknown — its Pre row aged out past ACT_CAP, or never
+      // opened. Falling back to the tool name here would close the oldest still-open
+      // Bash and staple this output onto it, which under parallel subagents is routine
+      // and is a row claiming it ran something it did not. The name match is for a
+      // payload with NO id; it is not a second chance for one that missed.
+      const s = sess();
+      hook(s, "PreToolUse", { tool_name: "Bash", tool_use_id: "t1", tool_input: { command: "ls" } });
+      vi.setSystemTime(NOW_MS + 400);
+      hook(s, "PostToolUse", { tool_name: "Bash", tool_use_id: "gone", tool_response: { stdout: "not mine" } });
+      expect(s.activity.map((a) => [a.arg, a.durMs])).toEqual([["ls", null]]);
+      expect(s.activity[0].out).toBe("");
+      // The right id still closes it.
+      hook(s, "PostToolUse", { tool_name: "Bash", tool_use_id: "t1", tool_response: { stdout: "mine" } });
+      expect(s.activity[0].durMs).toBe(400);
+    });
   });
 
   // What was executed and what came back, kept on the row so the inspector can expand it.

--- a/test/toolio.test.ts
+++ b/test/toolio.test.ts
@@ -163,6 +163,30 @@ describe("outputText — what came back", () => {
   });
 });
 
+describe("outputText — the shapes that used to read as nothing", () => {
+  it("dumps an array response instead of claiming nothing came back", () => {
+    // Neither a scalar nor a record, so it reached neither `scalar` nor `fieldsText` and
+    // fell out as "" — which the sheet renders as "(nothing returned)" for a call that
+    // returned plenty. An MCP tool's content blocks are exactly this shape.
+    const out = outputText([{ type: "text", text: "first" }, { type: "text", text: "second" }], null);
+    expect(out).toContain("first");
+    expect(out).toContain("second");
+    expect(out).not.toBe("");
+  });
+  it("keeps an empty array distinguishable from nothing at all", () => {
+    expect(outputText([], null)).toBe("[]");
+    expect(outputText(null, null)).toBe("");
+  });
+  it("falls back to the line count when a patch has no hunk lines", () => {
+    // Every hunk string carries a newline after its `@@` header whether or not anything
+    // follows, so the old `.includes("\n")` filter passed an empty hunk through and the
+    // truthy `body` blocked the `N lines` fallback underneath it.
+    const out = outputText({ type: "create", content: "a\nb\nc\n", structuredPatch: [{ oldStart: 0, oldLines: 0, newStart: 1, newLines: 3, lines: [] }] }, null);
+    expect(out).not.toContain("@@");
+    expect(out).toContain("4 lines");
+  });
+});
+
 describe("actClipText — what Copy hands over", () => {
   const act = (o: Partial<Act> = {}): Act => ({
     tool: "Bash", arg: "pnpm test", time: "14:22", startMs: 0, durMs: 120,


### PR DESCRIPTION
Fourteen fixes and one judgement call, from a review of the 31 commits that landed on `dev` today (PRs #97, #98, #100, #102, #104, #105, #106).

## The two that were actively lying

**A tool call's output could land on another call's row.** `closeActivity` paired Post to Pre with `(id && byId) || byName`, so an id matching nothing — its row aged out past `ACT_CAP`, or never opened — fell through and closed the oldest *other* open call of that tool, stamping its output, latency and failure onto it. Under parallel subagents running many `Bash` calls that is routine. It is a ternary now: the name match is for a payload with **no** id, not a second chance for one that missed. CLAUDE.md and `types.ts` both already said so.

**The explorer showed a project as it was the first time you opened it.** The index cache re-stamped `at` on a cache *hit*, so the 30s TTL never expired for anyone reopening ⌘P more often than that — a file an agent made ten minutes ago was simply absent from browse and find.

## The judgement call — worth disagreeing with

`git_changed` (explorer marks) and `v2_code` (new-session dialog) read git's XY pair by **opposite** rules, each documented as deliberate where it sat. A file staged then edited (`AM`) read `A` in one list and `M` in the other; a staged rename `R` against `M`. CLAUDE.md requires the app's file lists to describe a path the same way, so they now share `v2_code`.

I kept the **index half**: `A` and `R` carry information `M` does not, since every uncommitted file is modified. **This changes two letters on a shipped surface** — if you'd rather the explorer keep reading worktree-half-first, the fix is to make `v2_code` the one that changes, and the new test pins whichever you pick.

## The rest

- `git_changed` asks for **`-uall`**: git's default collapses a new folder into one `? sub/` entry, so every file in the newest folder arrived unmarked and the `Changed` chip filtered them out — while `ls-files --others` beside it listed each one. `working_set` deliberately keeps `-unormal`: it is polled every 15s and counts that entry as one `new_dirs`.
- `files.rs`: the symlink guard sat inside the `is_dir()` arm where it could never fire (`file_type()` never follows a link), and because `is_dir()` was false a symlinked folder fell through and listed as a *file*. Tested before `is_dir()` now.
- `files.rs`: `truncated` is decided at the `.take()` rather than measured after the sort/dedup — it was a false positive at exactly `MAX_FILES` and, worse, a false negative for a genuinely cut list that deduplicated back under the line.
- `toolio`: an array `tool_response` (MCP content blocks, a list of matches) read as `""` and rendered *(nothing returned)*; and a hunk filter that was always true let an empty hunk survive as a bare `@@ … @@`, blocking the `N lines` fallback beneath it.
- `callsheet`: `callSheetOpen()` tested `sid !== null` while `close`/`render` tested `!sid`. Latent — `data-tlsid` always rides along today — but the guards disagreeing is what would make one call site able to wedge the dialog open.
- `footer`: the first **visible** segment now drops its leading rule. `sessions` is leftmost and has no divider of its own, so hiding it promoted `cost`'s rule against the version block. Decided in code rather than by adding a `data-fdiv="sessions"`, which would have added a rule the bar has never had.
- `confirm`: the queue drained synchronously after `r(v)`, which only *schedules* the caller's continuation — so a queued question always beat the caller's own follow-up, the opposite of what the comment claimed.
- Two on `renderAll`'s path: the tour card is guarded like every other `innerHTML` surface (it repaints per telemetry event during `quickstart`, and an assignment between mousedown and mouseup drops the click on **Next**), and `renderStep` takes the pass's `TourWorld` instead of building three more — which also stops it disagreeing with the tick about whether a permission was answered, since only the tick folds in the latch.
- `copyPath` moves to `tauri-plugin-clipboard-manager` and the explorer's ⌥↵ calls it instead of carrying a second copy. `docs/explorer.md` already required the plugin over `navigator.clipboard`; this makes the app-wide verb agree.

## Tests

+4 vitest and +3 cargo assertions, each pinning a fix that would otherwise be invisible: the id-miss must drop rather than mispair, an array response must survive, an empty patch must fall back, every file in a new folder must be named, and `AM` must read `A`.

## Gates

`tsc` clean · 1234 vitest across 31 files · 195 cargo · clippy `-D warnings` clean · `vite build` clean · no import cycles across 65 modules.

**Not covered by any suite:** the footer divider, the tour card guard and the callsheet guards are DOM surfaces the suites don't touch by design — worth a click-through before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)