### PR TITLE
servers: what is still running, in the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,34 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
++ **The dev servers your agents leave running, in the header.** When an agent backgrounds a
+  shell — which is how `pnpm dev`, `uvicorn` and every watcher gets started — Episko now sees
+  it, reads the log that shell is writing, and shows a count beside the reactor. The pill goes
+  green once something has actually announced a URL. Open it and each row names the project and
+  the command, offers the URL as a button that opens your browser, jumps to the session that
+  started it, and expands to the last lines of its output. **Stop** asks that session's agent to
+  run `TaskStop` rather than killing the process behind its back, so the agent stops believing
+  it still has a server. A server that **crashes** — the port was already taken, which is the
+  commonest way this goes wrong — turns the pill red and keeps its row until you dismiss it,
+  rather than dropping the count back to zero and saying nothing. Nothing new is instrumented:
+  it all rides the `PostToolUse` hook Episko already receives, and an idle server's log costs
+  one length check rather than a read.
+
++ **And it asks the kernel, not just the output.** Episko now walks every listening TCP port
+  back up the process tree to the pane it came from, so a server shows up whether or not
+  anything announced it — including one you started by hand in a shell pane, and one whose
+  banner Episko cannot parse. Where a port and a pane's own words agree, the words win (they
+  carry the scheme and any base path); where a pane started something and went quiet, the one
+  unexplained port under it fills in the address; anything left over gets a row of its own.
+  Debugger and kernel-assigned sockets are filtered out, so one `wrangler dev` is one row
+  rather than five.
+
++ **Tasks you ran yourself are in there too.** A `just dev`, a VS Code task or an npm script
+  launched from **▶ Run** joins the same list the moment it prints a URL, marked `▶` so you can
+  tell it apart — and because Episko owns that terminal, its **Stop** really does stop it. A
+  task only appears once it is serving: it already has a pane and a sidebar row, and the one
+  thing those cannot give you is an address to click.
+
 ## 0.21.0 — 2026-08-21
 
 A first run that explains itself, ⌘P to find any file in a project, and a tool call you

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,10 @@ Three hard constraints shape this code:
 | `git.rs` | worktrees, branches (local **and** remote-only, each with its standing and author), the working-set diff, the paged commit graph, the toolbar's fetch/pull/push, commit info, the branch sweeps (`sweep_branches`, `delete_remote_branches`) |
 | `tasks.rs` | runnable discovery; see docs/tasks.md |
 | `usage.rs` | transcripts (incl. History's whole-machine scan) + the token ledger; everything read out of `~/.claude` |
-| `pty.rs` | the four launch engines, the permission-mode whitelist, app-wide disk I/O, `stream_pty_session`, the PTY lifecycle |
+| `pty.rs` | the four launch engines, the permission-mode whitelist, app-wide disk I/O (incl. `read_bg_log`, the tail of a background shell's output), `stream_pty_session`, the PTY lifecycle |
 | `telemetry.rs` | `write_instrument_settings`, `run_telemetry_server`, `resolve_permission` |
 | `platform.rs` | OS leaves (top half, incl. `norm_path`/`physical_cwd` and the `path_holders`/`remove_tree` group) + OS integrations (bottom half) |
-| `external.rs` | the `~/.claude/sessions` registry, `ProcTable`, terminal focus |
+| `external.rs` | the `~/.claude/sessions` registry, `ProcTable`, terminal focus, `session_ports` (which TCP ports a pane's process tree is listening on) |
 | `github.rs` | `gh`: issues/PRs, the claim writes, closing, the committed keep list, the merged-PR evidence behind the broom's force |
 | `notes.rs` | shared notes (`.episko/notes.toml`) |
 | `summarize.rs` | `summarize_day` (Haiku via `claude -p`) over both `Scope`s + the committed `.episko/digest.md` |
@@ -93,7 +93,7 @@ The disk-I/O accounting behind `io_samples`/`io_retired` (run vs. day vs. all-ti
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (the seam map, which belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, the window controls (see docs/native-ui.md), and the `setInterval`s.
 
-**Tested logic modules** (twenty-nine, with no DOM, no Tauri and no render imports; these are what the vitest suites cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it, plus `dispatch.test.ts` and `ipc.test.ts` which read source instead of importing it):
+**Tested logic modules** (thirty, with no DOM, no Tauri and no render imports; these are what the vitest suites cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it, plus `dispatch.test.ts` and `ipc.test.ts` which read source instead of importing it):
 
 | Module | What |
 | --- | --- |
@@ -109,6 +109,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 | `grouping.ts` | what the sidebar shows and in what order; `urgencyRank`, `needsYou`/`attnPending`/`syncAttn`, `nextAfterClose`, `dormantBusy`, and the run-group fold (`foldRunGroups`, `groupPhase`, `nextInGroup`) |
 | `tasks.ts` | the frontend half of Runnables: `stopRuleBlocked`, `launchWithDeps` (dep memoisation), `findDepCycle`, `applyRunner`, `${input:…}` glue |
 | `history.ts` | History's rules: `histProject` (regrafting a row onto a project), `histBusy`, the scope/search predicates, day buckets |
+| `servers.ts` | the dev servers running behind the header pill, from all three sources: recognising an agent's backgrounded shell off its PostToolUse payload and reading its log file (the URL, the peek, the sentinel that says it died), latching the URL an Episko task announces as its output streams, and reconciling both against the ports the kernel actually reports (`usefulPort`, `reconcilePorts`) |
 | `gitwatch.ts` | `gitMutates`: whether a shell command an agent ran is worth re-reading git for; `driftTarget`/`driftUpdate`: which checkout its work has moved to, from writes, `cwd`, and the `cd` of a shell-only agent that calls no write tool |
 | `graph.ts` | the commit graph: `layoutGraph`'s lanes, what names a lane (`lineRef`, `lineTip`), `parseRefs`, the geometry and `rowSvg` |
 | `peek.ts` | the sidebar's hover-to-reveal: what arms, what cancels, what the next deadline is |
@@ -131,11 +132,11 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 
 **Markup-only views**, untested by design: `usageview`, `inspectorview`, `sidebarview`, `footerview` (the engine picker and the shortcut sheet — extracted from `footer.ts` because `footer` imports `settings`, so Settings' previews of those popovers could not have reached them otherwise).
 
-**DOM-owning / render**, untested by design: `sidebar`, `footer`, `tray`, `inspector`, `confirm` (every yes/no question in the app), `callsheet` (the tool-call window: the dialog, its list/detail split and the two independent `innerHTML` guards that let you select text in it), `debug`, `worktree` (the new-session dialog and the worktree removal flows, the biggest single module), `settings`, `taskui`, `palui`, `projmenu`, `caffeinate`, `diffview`, `graphview` (the paged commit-graph panel), `mirror`, `historyui`, `update`, `explorer` (⌘P, the project explorer), `tourui` (the veil, the card and the chapter picker), `chime` (the only file that touches Web Audio, a live browser resource, so a test would only assert against its own mock).
+**DOM-owning / render**, untested by design: `sidebar`, `footer`, `tray`, `inspector`, `confirm` (every yes/no question in the app), `callsheet` (the tool-call window: the dialog, its list/detail split and the two independent `innerHTML` guards that let you select text in it), `debug`, `worktree` (the new-session dialog and the worktree removal flows, the biggest single module), `settings`, `taskui`, `palui`, `projmenu`, `caffeinate`, `diffview`, `graphview` (the paged commit-graph panel), `mirror`, `historyui`, `update`, `serversui` (the header's running-server pill, its popover and the poll behind it), `explorer` (⌘P, the project explorer), `tourui` (the veil, the card and the chapter picker), `chime` (the only file that touches Web Audio, a live browser resource, so a test would only assert against its own mock).
 
 **Behaviour**, IPC and DOM all the way down, so untested too, and therefore the thinnest ice in the app: `panes` (the three spawners + a pane's lifecycle), `terminal` (the xterm plumbing), `taskrun` (run on stop), `actions` (the app-level verbs), `icons` (the per-project glyph store).
 
-Four rules keep that graph honest. **There are no import cycles across the 65 modules; re-run a cycle check after any change that adds an import.**
+Four rules keep that graph honest. **There are no import cycles across the 67 modules; re-run a cycle check after any change that adds an import.**
 
 - **Dependency direction is state ← render ← wiring.** A logic module must not import render code or `main.ts`.
 - **When an extracted function needs something that lives further up**, resolve it in this order: (1) **move the callee down too** if it is itself leaf-shaped, which is why `icons.ts` sits below `sidebar.ts` and `usage.ts` below `phase.ts`; (2) **a settable hook defaulting to a no-op** (`setRlLogger`, `setPanesRenderAll`) when the callee genuinely belongs to the render layer; (3) **an extra parameter** only as a last resort, since it changes a signature the move was supposed to leave alone. A control panel touching many things it doesn't own may take **one host object** instead of N setters (`settings`, `palui`, `projmenu`); prefer per-callee setters below ~4.
@@ -206,6 +207,66 @@ And the things that hold however the files are arranged:
   not beside it (docs/explorer.md).
 - **The stage has one owner**: `activeId` and the `mirror` pointer (`{kind:"ext"|"past"|"dash"}`) are mutually exclusive, and `takeStage(show)` in `dom.ts` is the only code that may touch `#extPane`/`#dashPane`/`#empty`/`insp-mini`. Add a stage kind by extending `Stage`, never by poking `hidden` at a call site.
 - **`termEngine` picks where a terminal lives** (embedded xterm pane / ghostty / Terminal / iTerm); the per-launch instrumentation and telemetry are identical for all four. `permMode` is orthogonal and sets the *starting* permission mode only (`docs/sessions.md`).
+- **A background shell's log is addressed by the transcript path it had AT START.**
+  An agent's `Bash{run_in_background:true}` is how every dev server in this app gets
+  started, and Episko sees it for free: `tool_response.backgroundTaskId` on a
+  PostToolUse it already receives, with the output at
+  `<tmp>/claude/<slug>/<uuid>/tasks/<id>.output` — the last two components of
+  `transcript_path`. But Claude mints a **new** session dir on `/clear`, `/compact` and
+  `/resume`, so re-deriving that path later points at a directory that has never held
+  the log. `BgServer.transcript` is captured when the shell is recorded and never
+  recomputed (./servers, ./types); `read_bg_log` resolves it. Same trap as the
+  `X-CC-Session` rule above, one level down.
+- **Stopping a server is asked of the agent, never done behind its back.** The process
+  is a descendant of Episko's own tree and could be killed — but the agent holds
+  `TaskStop`, believes the server is up, and goes on saying so after a kill it never
+  saw. So ./serversui prefills `TaskStop <id>` into the session and the human presses
+  Enter: the `handToTerminal`/`sendOutputToSession` contract. A server whose session is
+  gone is an **orphan**: `session_ports` cannot see it either, because attribution is by
+  ancestry and its chain is broken, so it belongs to no pane and there is nobody to ask.
+  Listing orphans would need a *project*-level answer (match the process's cwd or command
+  line against known roots), which is a separate feature and not this one.
+- **The kernel is the authority; a parsed log line is a guess.** `session_ports`
+  (external.rs) walks every listening TCP socket back up the ppid chain to a pane's PTY
+  child — measured **eight** hops from a `vite` leaf to `episko.exe`, well inside
+  `is_descendant_of`'s cap — and that is the only signal that can see a server nobody
+  announced: one typed by hand into a shell pane, or one whose banner nothing parses.
+  `reconcilePorts` joins the two in a three-step ladder (a port a record already names
+  is that record's → **one** silent record and **one** loose port are each other → the
+  rest get rows of their own), failing closed the moment either side is ambiguous.
+  **`usefulPort` runs first and matters**: one real `wrangler dev` holds five listening
+  sockets, of which four are Node's inspector and kernel-assigned control channels, so
+  an unfiltered scan puts four pieces of noise in front of one useful row. And
+  **`reconcilePorts` mutates**, so it belongs to the poll and never to a render pass.
+- **The header lists three sources on different rules, because it is for what is
+  otherwise invisible.** An agent's background shell has no pane, no row, nothing on screen, so
+  **every** one is listed — URL or not. An Episko **task** (`just dev`, a VS Code task,
+  an npm script) already has a pane, a sidebar row, a glyph and a phase, so it appears
+  **only once it has announced a URL** — the one thing its pane cannot give you. Same
+  reason a failed *task* never appears here and a failed *shell* does: the sidebar has
+  already gone red about the first. A bare **port** is listed when nothing else explains
+  it, which is the only way a server started by hand in a shell pane has ever been
+  visible. Stopping differs with the source and honestly so: Episko owns a task's PTY, so
+  ✕ there is a real `closeSession` (what the pane's own ✕ does), an agent's shell is only
+  ever asked, and a port row has **no ✕ at all** — we know which pid holds the socket, but
+  it sits several hops below a pane that has its own ✕, and the row exists to tell you the
+  port is open rather than to take responsibility for it. Its empty cell is kept so ◨
+  stays in line down the list.
+- **A task's server URL is latched as its output streams, never rescanned from `tail`.**
+  `run.tail` is a rolling 40 lines, so a dev server's banner is gone from it seconds
+  after the first HMR line — a URL read back off the tail would appear and then silently
+  vanish. `taskServerUrl` folds it per line in main.ts's `pty-output` handler, and is
+  **stricter than `serverUrl`**: it latches only on an announcement line, because its
+  answer sticks and a stray `curl http://localhost:9999` in the output would otherwise
+  put a wrong address on the row permanently.
+- **A server that died on its own keeps its row; one that was asked to stop does not.**
+  A dev server exiting on `EADDRINUSE` two seconds in is the commonest way this goes
+  wrong, and dropping the count 1 → 0 would be the exact silence the feature exists to
+  end — so a **non-zero** exit persists (red pill) until dismissed, the rule task panes
+  already follow. `exit === 0` (a background one-shot finishing) and `exit === null` (a
+  kill somebody requested) are not news and leave. `liveServers` is what the poll
+  re-reads, `shownServers` what the popover draws; keep those two questions apart, or a
+  dead log is re-read every four seconds forever.
 - **`needsYou` is the raw fact; `attnPending` is what you count at the user.** A session
   you have been to since it finished leaves the badge, the tray title, the palette's
   "Needs you" group and a collapsed group's glyph (`Sess.seenAt >= Sess.attnAt`, ./attn);

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -197,6 +197,81 @@ a broken alert is indistinguishable from a switched-off one.
       reads this preference. Worth one pass in an *external* engine too, since that is
       the only path where the flag goes through a generated shell script.
 
+### Running servers
+
+The whole feature reads a payload field and a file layout that are **not ours** —
+`tool_response.backgroundTaskId`, and the log Claude Code writes beside the transcript.
+The rules are unit-tested against captured fixtures, but a release of Claude Code that
+renames either would leave every test green and the pill permanently dark, so this is
+the one section here that is checking somebody else's contract.
+
+- [ ] **A dev server appears.** In a session, prompt: *"start the dev server in the
+      background"* (any project with one). Within a few seconds the header grows a
+      `◉ 1` pill, left of the reactor, and it turns **green** once the server prints its
+      URL. Grey-and-never-green is the failure that matters: it means the shell was seen
+      but its log was not, so check `bg_log_path` against the real
+      `<tmp>/claude/<slug>/<uuid>/tasks/` layout before shipping.
+- [ ] **The URL opens.** Click the pill, click the URL chip — your browser opens the
+      running site. The row names the project and the command with the `cd …&&` prefix
+      stripped.
+- [ ] **The peek is live.** Click the row to expand it, then hit the site in the
+      browser. New lines appear in the log peek within ~4s (a request log, an HMR line).
+- [ ] **`◨` jumps** to the session that started it, and closes the popover.
+- [ ] **Stop asks rather than kills.** Click `✕` on a live row: the session takes the
+      stage with `Stop the background task <id>…` **prefilled and not sent**. Press
+      Enter; the agent runs `TaskStop` and the pill drops. It must never kill the
+      process directly — the point is that the agent knows its server is gone.
+- [ ] **A crash stays on screen.** Start a dev server on a port that is already taken
+      (start two). The second exits within seconds: its row must **stay**, dimmed, with
+      `exited 1` where the URL was, and the pill must go **red** rather than dropping
+      the count. `✕` on that row dismisses it and asks nobody.
+- [ ] **`/clear` does not lose a running server.** With a server up, `/clear` the
+      session. Claude mints a new session directory; the row must keep its URL and its
+      peek, because the log path was captured at start. A row that goes grey here is
+      the transcript path being re-derived — the one trap this feature has.
+- [ ] **The poll is not re-reading the world.** With a server up and idle, the 🐞
+      console's paint counter must stay flat. Every four seconds Episko asks for the
+      log's length; an unchanged log must cost no paint.
+
+The other half comes from Episko's own runnables, and shares none of the plumbing above
+— no hook, no log file, no poll. Its evidence is the pane's own output as it streams.
+
+- [ ] **A task you ran shows up too.** `▶ Run` a dev-server task (`just dev`, a VS Code
+      task, an npm script). Once it prints its URL the row appears, marked `▶`, and the
+      pill counts it. A task that is *not* a server — `tsc --watch`, a test run — must
+      **not** appear at all: its pane already says everything there is to say.
+- [ ] **Its URL survives a busy log.** Leave the task running and edit a file until the
+      pane has scrolled well past 40 lines of HMR output. The URL must still be there.
+      Losing it is the tail being rescanned instead of latched — the trap this half has.
+- [ ] **Its Stop really stops.** `✕` on a `▶` row kills the task and closes its pane,
+      exactly as the pane's own `✕` does — no prefilled message, no agent involved.
+- [ ] **A restart follows the port.** Change the dev server's port in its config and let
+      it restart itself; the row must follow to the new URL rather than keep the old one.
+
+The third source asks the kernel rather than reading anything, and it is the one that
+needs checking on **both** OSes: `session_ports` leans on `listeners`, whose Windows,
+macOS and Linux halves are three separate implementations of the same question.
+
+- [ ] **A server nobody announced still shows.** Open a plain `❯ Terminal` pane and run
+      a dev server in it by hand. Within ~4s a row appears marked `◎`, named after the
+      process (`node`, `python`), with a `localhost:<port>` button that opens. This is
+      the only way that server has ever been visible, and it is the check that proves
+      the ancestry walk reaches — the process sits many hops below the pane.
+- [ ] **One server is one row.** Run something that opens several sockets (`wrangler
+      dev` is the reference case: it holds five, four of them a debugger and
+      kernel-assigned control channels). Exactly one row must appear, on the port you
+      would actually open. Extra rows in the 49152+ range mean `usefulPort` is not being
+      applied before the join.
+- [ ] **A pane that went quiet gets its address filled in.** Have an agent background a
+      server whose banner Episko cannot parse. The row should start at `starting…` and,
+      on the next poll, gain `localhost:<port>` from the scan rather than staying blank.
+- [ ] **A second server in the same pane does NOT get guessed at.** With two servers
+      under one pane and neither announced, both must appear as their own `◎` rows —
+      nothing should adopt an address it cannot be sure of.
+- [ ] **It costs nothing when idle.** With no panes open the scan must not run at all
+      (the roster is checked first). With panes open and no servers, the pill stays
+      hidden and the paint counter stays flat.
+
 ### Identity across rotations
 
 - [ ] **`/clear` (or `/compact`) does not orphan the pane.** Claude mints a new

--- a/index.html
+++ b/index.html
@@ -20,6 +20,12 @@
         <div class="brand"><div class="logo"></div><b>Episko</b></div>
         <div class="kbar" id="kbar" data-tauri-drag-region="false"><span>⌕</span><span>Jump to a session, launch a project…</span><span class="kbd"><kbd>⌘</kbd><kbd>K</kbd></span></div>
         <div class="top-right">
+          <!--
+            Running servers. Left of the reactor because it is the calmer of the two:
+            the reactor is "something wants you now", this is "something is still up".
+            Hidden entirely when the count is zero (see renderServers).
+          -->
+          <button class="svr-badge" id="svrBadge" aria-label="Running servers"><span class="svr-ic">◉</span><span id="svrBadgeTxt"></span></button>
           <button class="attn-badge" id="attnBadge"><span class="bdot"></span><span id="attnBadgeTxt"></span></button>
           <div class="caf" id="caf">
             <button class="caf-main" id="cafMain" aria-label="Keep this computer awake">
@@ -425,6 +431,7 @@
     <div class="menupop" id="enginePop"></div>
     <div class="menupop cafpop" id="cafPop"></div>
     <div class="menupop attnpop" id="attnPop"></div>
+    <div class="menupop svrpop" id="svrPop"></div>
     <div class="menupop usagepop" id="usagePop"></div>
     <div class="menupop costpop" id="costPop"></div>
     <div class="menupop iopop" id="ioPop"></div>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1012,6 +1012,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "jsonc-parser",
+ "listeners",
  "log",
  "portable-pty",
  "rusqlite",
@@ -1161,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fixedbitset"
@@ -2259,6 +2260,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "listeners"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504c4ecfa20498c07ae4ff19b632d212e1fdcef83195b8e9eb2552306c42205f"
+dependencies = [
+ "byteorder",
+ "cc",
+ "libc",
+ "rustix",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2365,7 +2379,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,6 +53,19 @@ tauri-plugin-log = "2"
 # spawning `ps`/`tasklist` — one in-process snapshot, same code on every OS.
 # 0.38 (not latest) because newer sysinfo raises MSRV past our rustc.
 sysinfo = { version = "0.38", default-features = false, features = ["system"] }
+# "Which ports are our sessions listening on" — the ground truth behind the header's
+# running-server list, where a parsed log line is only ever a guess about somebody
+# else's output format. Native APIs on every platform (GetExtendedTcpTable, libproc,
+# /proc), so this stays spawn-free like `ProcTable` beside it, and it needs no bindgen
+# (netstat2, the obvious alternative, drags in bindgen + clang-sys and so a system
+# LLVM on both CI runners).
+#
+# The cost, and it is a real one: on Windows this resolves `windows` 0.62 alongside
+# the 0.61 tauri already uses — a second copy of a large binding crate, which is
+# exactly what the windows-sys note below avoids. Taken deliberately: the alternative
+# is hand-written libproc FFI for macOS, unverifiable from a Windows machine, in the
+# one place where a wrong answer means the app reports a port that does not exist.
+listeners = "0.6"
 
 # `SetThreadExecutionState` for the keep-awake control — Windows' answer to
 # macOS `caffeinate` — the window APIs behind `focus_external_session`

--- a/src-tauri/src/external.rs
+++ b/src-tauri/src/external.rs
@@ -109,6 +109,91 @@ impl ProcTable {
     }
 }
 
+// ---------- which ports our sessions are actually listening on ----------
+
+/// One TCP port a session's process tree has open, as the frontend reads it.
+#[derive(serde::Serialize, Debug, PartialEq, Eq)]
+pub(crate) struct SessionPort {
+    /// The Episko pane whose PTY child this socket descends from.
+    session_id: String,
+    port: u16,
+    /// The process actually holding the socket — `node.exe`, `python.exe`. It is
+    /// several hops below the pane (a real chain measured here was
+    /// `node <- cmd <- node <- cmd <- node <- cmd <- pwsh <- claude <- episko`), so
+    /// this is a leaf's name, not the command the user or the agent ran.
+    pid: u32,
+    name: String,
+}
+
+/// Collapse the several sockets one server really has down to one row per
+/// (session, port).
+///
+/// A dev server binding "everywhere" is three or four listeners: `0.0.0.0`, `[::]`,
+/// and often `127.0.0.1` and a LAN address besides — a real one measured here showed
+/// up five times. They are one server and one row. The lowest pid wins so the answer
+/// is stable across polls rather than reordering with the OS's enumeration.
+fn dedupe_ports(mut found: Vec<SessionPort>) -> Vec<SessionPort> {
+    found.sort_by(|a, b| {
+        (a.session_id.as_str(), a.port, a.pid).cmp(&(b.session_id.as_str(), b.port, b.pid))
+    });
+    found.dedup_by(|a, b| a.session_id == b.session_id && a.port == b.port);
+    found
+}
+
+/// Every TCP port listened on by a process descended from one of our panes.
+///
+/// **This is the ground truth the rest of the running-server feature only approximates.**
+/// A parsed log line is a guess about somebody else's output format; a listening socket
+/// either exists or it does not. It is also the only thing that can see a server nobody
+/// announced — one started by hand in a shell pane, or one whose banner we cannot parse
+/// — because it asks the kernel rather than the process.
+///
+/// Attribution is by ancestry, and it reaches: the chain from a `vite` leaf back to
+/// `episko.exe` measured **eight** hops on Windows (node → cmd → node → cmd → node →
+/// cmd → pwsh → claude), well inside `is_descendant_of`'s cap. What it cannot do is
+/// name a server whose chain is *broken* — an orphan whose session has exited — and
+/// that is deliberate: those have no pane to belong to, and inventing one would be
+/// worse than leaving them out.
+///
+/// Spawn-free on every platform (`GetExtendedTcpTable`, libproc, `/proc`), like
+/// `ProcTable` above, because this is polled.
+#[tauri::command]
+pub(crate) fn session_ports(state: State<AppState>) -> Vec<SessionPort> {
+    // The roster first: with no panes open there is nothing any socket could belong
+    // to, and the whole scan is skipped.
+    let roster: Vec<(String, u32)> = state
+        .sessions
+        .lock()
+        .unwrap()
+        .iter()
+        .filter_map(|(id, s)| s.pid.map(|p| (id.clone(), p)))
+        .collect();
+    if roster.is_empty() {
+        return Vec::new();
+    }
+    let Ok(all) = listeners::get_all() else { return Vec::new() };
+    let table = ProcTable::snapshot();
+    let mut found = Vec::new();
+    for l in all {
+        // TCP only, and only actually-listening sockets: SSDP, NetBIOS and mDNS are
+        // UDP and would otherwise read as somebody's dev server.
+        if l.protocol != listeners::Protocol::TCP || l.state != listeners::SocketState::Listen {
+            continue;
+        }
+        let Some((id, _)) = roster.iter().find(|(_, root)| table.is_descendant_of(l.process.pid, *root))
+        else {
+            continue;
+        };
+        found.push(SessionPort {
+            session_id: id.clone(),
+            port: l.socket.port(),
+            pid: l.process.pid,
+            name: l.process.name.clone(),
+        });
+    }
+    dedupe_ports(found)
+}
+
 /// Parse one `~/.claude/sessions/<pid>.json` registry file into an
 /// `ExternalSession` (repo_root/branch enriched later). None for malformed
 /// files and non-interactive entries (`claude -p`, SDK runs).
@@ -451,6 +536,93 @@ mod tests {
         }
     }
 
+    fn sp(session: &str, port: u16, pid: u32) -> SessionPort {
+        SessionPort { session_id: session.into(), port, pid, name: "node.exe".into() }
+    }
+
+    /// One dev server is several sockets. Vite binding "everywhere" shows up as
+    /// `0.0.0.0`, `[::]`, `127.0.0.1` and a LAN address — a real process measured on
+    /// this machine appeared five times — and every one of them is the same server and
+    /// must be one row. Without this the header would count a single `pnpm dev` as four.
+    #[test]
+    fn dedupe_ports_collapses_one_server_to_one_row() {
+        let got = dedupe_ports(vec![
+            sp("a", 5555, 64828), sp("a", 5555, 64828), sp("a", 5555, 64828),
+            sp("a", 8787, 81320),
+        ]);
+        assert_eq!(got.len(), 2, "one row per (session, port): {got:?}");
+        assert_eq!(got.iter().map(|p| p.port).collect::<Vec<_>>(), vec![5555, 8787]);
+    }
+
+    /// The same port in two panes is two servers, not one. Two worktrees of the same
+    /// repo each running their own dev server is the normal way this happens — they
+    /// cannot both hold 5555, but a `--strictPort`-less vite will land one on 5556, and
+    /// collapsing across sessions would still be wrong the moment the ports differ.
+    #[test]
+    fn dedupe_ports_keeps_the_same_port_in_two_panes_apart() {
+        let got = dedupe_ports(vec![sp("a", 5555, 1), sp("b", 5555, 2)]);
+        assert_eq!(got.len(), 2, "sessions must not collapse into each other: {got:?}");
+    }
+
+    /// The lowest pid wins, so a row does not reshuffle between polls just because the
+    /// OS enumerated its sockets in a different order.
+    #[test]
+    fn dedupe_ports_is_stable_across_enumeration_order() {
+        let a = dedupe_ports(vec![sp("s", 3000, 900), sp("s", 3000, 100)]);
+        let b = dedupe_ports(vec![sp("s", 3000, 100), sp("s", 3000, 900)]);
+        assert_eq!(a, b);
+        assert_eq!(a[0].pid, 100);
+    }
+
+    /// A contract test for somebody else's crate, on whatever OS is running the suite.
+    ///
+    /// `listeners` is the one dependency here whose whole job is a platform API we do not
+    /// own — three separate implementations (`GetExtendedTcpTable`, libproc, `/proc`) of
+    /// the same question — and it is the half of this feature that cannot be checked from
+    /// a developer's machine, because only one OS is in front of you at a time. A release
+    /// that broke its macOS arm would leave every other test in this file green while the
+    /// header's server list silently emptied.
+    ///
+    /// **So the test opens a socket and demands the crate find it.** Merely asserting that
+    /// the returned rows are well-formed would pass *vacuously* on an implementation that
+    /// returned nothing at all, which is precisely the failure being guarded against —
+    /// and "assert it found at least one" would lean on the machine happening to have a
+    /// server up. Binding our own removes both problems: the answer is known, it is ours,
+    /// and the assertion covers the whole chain this feature needs — the socket, its port,
+    /// and the owning pid that `session_ports` walks ancestry from.
+    #[test]
+    fn listeners_sees_a_socket_we_just_opened() {
+        // Port 0 → the kernel picks a free one, so this cannot collide with anything.
+        let sock = std::net::TcpListener::bind("127.0.0.1:0").expect("bind a local listener");
+        let port = sock.local_addr().unwrap().port();
+        let us = std::process::id();
+
+        let all = listeners::get_all().expect("listeners::get_all failed on this OS");
+        let mine = all.iter().find(|l| {
+            l.protocol == listeners::Protocol::TCP
+                && l.state == listeners::SocketState::Listen
+                && l.socket.port() == port
+        });
+        let mine = mine.unwrap_or_else(|| {
+            panic!(
+                "listeners did not report a socket this process is holding open on port \
+                 {port}. It saw {} listening TCP sockets. Attribution in `session_ports` \
+                 is built on this, so the header's server list is empty on this OS.",
+                all.iter()
+                    .filter(|l| l.protocol == listeners::Protocol::TCP
+                        && l.state == listeners::SocketState::Listen)
+                    .count()
+            )
+        });
+        assert_eq!(
+            mine.process.pid, us,
+            "the socket was found but attributed to pid {} rather than ours ({us}); \
+             ancestry would then place every server under the wrong pane",
+            mine.process.pid
+        );
+        drop(sock);
+    }
+
     #[test]
     fn proc_table_identity_and_ancestry() {
         // episko(100) → ghostty(200) → claude(300); unrelated claude(400) under init.
@@ -586,3 +758,4 @@ mod tests {
     }
 
 }
+

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -517,6 +517,8 @@ pub fn run() {
             pty::kill_session,
             pty::live_sessions,
             pty::read_scrollback,
+            pty::read_bg_log,
+            external::session_ports,
             git::git_branch,
             git::git_head,
             git::git_diffstat,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1290,6 +1290,120 @@ fn fold_io(
     f
 }
 
+// ---------- the log of a background shell an agent started ----------
+
+/// How much of a background log to hand the frontend. A dev server left running all
+/// afternoon writes megabytes (a real one measured 300 KiB in three hours of HMR), and
+/// every consumer — the URL, the sentinel, a twelve-line peek — reads the *end*. So the
+/// tail is all that crosses the IPC boundary, and it is read without loading the front
+/// of the file at all.
+const BG_LOG_TAIL: u64 = 32 * 1024;
+
+/// Where Claude Code writes a backgrounded shell's output.
+///
+/// It mirrors the transcript: a transcript at
+/// `~/.claude/projects/<slug>/<uuid>.jsonl` puts its background logs under
+/// `<tmp>/claude/<slug>/<uuid>/tasks/<task_id>.output`. The layout is undocumented and
+/// not ours, so this is written to fail by returning `None` rather than by guessing —
+/// a row with no log still shows its command, which is a better failure than a row
+/// pointing confidently at a file that was never there.
+///
+/// `tmp` is a parameter rather than `env::temp_dir()` so the test can pin a root
+/// instead of building one by hand (CLAUDE.md's fixture-path rule).
+fn bg_log_path(tmp: &std::path::Path, transcript: &str, task_id: &str) -> Option<std::path::PathBuf> {
+    // The id reaches us from a hook payload and lands in a path, so it is checked
+    // rather than trusted: anything but Claude's own alphabet is refused outright.
+    if task_id.is_empty() || !task_id.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_') {
+        return None;
+    }
+    let t = std::path::Path::new(transcript);
+    let uuid = t.file_stem()?.to_str()?;
+    let slug = t.parent()?.file_name()?.to_str()?;
+    if uuid.is_empty() || slug.is_empty() {
+        return None;
+    }
+    Some(tmp.join("claude").join(slug).join(uuid).join("tasks").join(format!("{task_id}.output")))
+}
+
+#[derive(serde::Serialize)]
+pub(crate) struct BgLog {
+    /// The resolved path, so a row can name (and reveal) the file it is reading.
+    path: String,
+    /// The last `BG_LOG_TAIL` bytes, lossily decoded — a dev server's output is
+    /// whatever the process emitted, and a truncated multi-byte character at the cut
+    /// must not cost the whole read.
+    text: String,
+    /// The file isn't there. Normal and temporary right after a shell starts, and
+    /// permanent when Claude Code's layout is not what `bg_log_path` expects — the
+    /// caller shows the row either way rather than dropping it.
+    missing: bool,
+    /// The file's full length, which the caller keeps and passes back as `known_len`.
+    len: u64,
+    /// The length matched `known_len`, so nothing was read and `text` is empty. A
+    /// background log is append-only, which is what makes a length comparison an exact
+    /// "has anything happened" test rather than a heuristic.
+    unchanged: bool,
+}
+
+/// Read the tail of one background shell's log. `transcript` is the session's
+/// `transcript_path` **as it stood when the shell was spawned** — see the note on
+/// `BgServer` in types.ts for why it must not be re-derived from the session's current
+/// one. Errors are states, not failures: an unresolvable path or an unreadable file
+/// comes back as `missing`, because every one of them is a row that should still draw.
+///
+/// **`known_len` is what keeps this poll cheap.** It runs every few seconds against
+/// every running server, and the overwhelmingly common case is a dev server nobody is
+/// hitting, whose log has not moved since the last look. The file is append-only, so
+/// its length is an exact test for that — one `metadata()` call instead of a 32 KiB
+/// read. Same trick, and the same reasoning, as the discovery stamp in `tasks.rs`:
+/// this is not a watcher, it is a cheap question asked often. Pass 0 to force a read.
+#[tauri::command]
+pub(crate) fn read_bg_log(transcript: String, task_id: String, known_len: u64) -> BgLog {
+    match bg_log_path(&std::env::temp_dir(), &transcript, &task_id) {
+        Some(path) => bg_log_at(&path, known_len),
+        // Nothing resolved, so there is no path to name either — an unresolvable
+        // address and an absent file are the same answer to the caller.
+        None => BgLog { path: String::new(), text: String::new(), missing: true, len: 0, unchanged: false },
+    }
+}
+
+/// The half of `read_bg_log` that has a path already. Split out so the test can drive
+/// it against a real file: the command resolves through `env::temp_dir()`, which a test
+/// must not go anywhere near (CLAUDE.md's fixture-path rule), and a test that asserts
+/// about a `BgLog` it built itself would prove nothing about either.
+fn bg_log_at(path: &std::path::Path, known_len: u64) -> BgLog {
+    let miss = |path: String, len: u64| BgLog {
+        path, text: String::new(), missing: true, len, unchanged: false,
+    };
+    let disp = path.to_string_lossy().to_string();
+    let Ok(mut f) = std::fs::File::open(path) else { return miss(disp, 0) };
+    let len = f.metadata().map(|m| m.len()).unwrap_or(0);
+    // Nothing has been appended since the caller last looked. Note this is checked
+    // BEFORE the zero-length shortcut would matter: a log that is still empty is also
+    // a log that has not moved, and both answers are "there is nothing to fold in".
+    if len == known_len {
+        return BgLog { path: disp, text: String::new(), missing: false, len, unchanged: true };
+    }
+    if len > BG_LOG_TAIL {
+        use std::io::Seek;
+        if f.seek(std::io::SeekFrom::Start(len - BG_LOG_TAIL)).is_err() {
+            return miss(disp, len);
+        }
+    }
+    let mut buf = Vec::new();
+    use std::io::Read as _;
+    if f.read_to_end(&mut buf).is_err() {
+        return miss(disp, len);
+    }
+    BgLog {
+        path: disp,
+        text: String::from_utf8_lossy(&buf).to_string(),
+        missing: false,
+        len,
+        unchanged: false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1911,4 +2025,137 @@ mod tests {
             "claude accepted a nonsense --permission-mode, so the assertions above prove nothing"
         );
     }
+
+    // ---------- where a background shell's log lives ----------
+
+    /// The layout `bg_log_path` mirrors, spelled out once. Both halves come off the
+    /// transcript path — the project slug from its directory, the session uuid from its
+    /// file stem — because those are the two components Claude Code repeats under the
+    /// temp root. Verified against a real backgrounded shell before it was written down.
+    #[test]
+    fn bg_log_path_mirrors_the_transcript() {
+        let tmp = std::path::Path::new("/tmproot");
+        let got = bg_log_path(
+            tmp,
+            "/home/u/.claude/projects/E--tmp-episko-probe/819131de-4c0e-4a7e-a5c5-2d4a5550a104.jsonl",
+            "bczk8s47b",
+        )
+        .expect("a well-formed transcript path resolves");
+        let want: std::path::PathBuf = ["/tmproot", "claude", "E--tmp-episko-probe",
+            "819131de-4c0e-4a7e-a5c5-2d4a5550a104", "tasks", "bczk8s47b.output"]
+            .iter().collect::<std::path::PathBuf>();
+        // Compare component-wise: the separator differs by OS and the point here is the
+        // shape, not the spelling.
+        assert_eq!(
+            got.components().skip(1).collect::<Vec<_>>(),
+            want.components().skip(1).collect::<Vec<_>>(),
+            "resolved {got:?}"
+        );
+    }
+
+    /// The id lands in a path, so it is validated rather than trusted. It arrives in a
+    /// hook payload — the one part of this whole feature that is neither ours nor
+    /// checked by anything upstream of us.
+    #[test]
+    fn bg_log_path_refuses_a_task_id_that_is_not_one() {
+        let tmp = std::path::Path::new("/tmproot");
+        let tr = "/home/u/.claude/projects/slug/uuid.jsonl";
+        for bad in ["", "..", "../../etc/passwd", "a/b", r"a\b", "a.output", "a b"] {
+            assert!(
+                bg_log_path(tmp, tr, bad).is_none(),
+                "{bad:?} was accepted as a task id and would have escaped the tasks dir"
+            );
+        }
+        assert!(bg_log_path(tmp, tr, "bs0hhu7b4").is_some(), "a real id must still resolve");
+    }
+
+    /// A transcript path that isn't one resolves to nothing rather than to a plausible
+    /// wrong file. The frontend draws the row either way; what it must not do is offer
+    /// to reveal a path we invented.
+    #[test]
+    fn bg_log_path_refuses_a_transcript_without_both_halves() {
+        let tmp = std::path::Path::new("/tmproot");
+        for bad in ["", "uuid.jsonl", "/"] {
+            assert!(bg_log_path(tmp, bad, "bs0hhu7b4").is_none(), "{bad:?} resolved");
+        }
+    }
+
+    /// The tail is the point: only the end of the file crosses the IPC boundary, and a
+    /// log longer than the window must come back cut at the front, not at the back. A
+    /// real dev server left running an afternoon measured 300 KiB, so this is the
+    /// normal case rather than the extreme one.
+    #[test]
+    fn read_bg_log_returns_the_end_of_a_long_log() {
+        let dir = crate::testutil::scratch_dir();
+        let f = dir.join("long.output");
+        let mut body = "x".repeat(BG_LOG_TAIL as usize + 4096);
+        body.push_str("
+Local:   http://localhost:5555/
+[exited with code 0]
+");
+        std::fs::write(&f, &body).unwrap();
+
+        let got = bg_log_at(&f, 0);
+        assert!(!got.missing && !got.unchanged);
+        assert!(got.text.len() as u64 <= BG_LOG_TAIL, "the whole file came back, not its tail");
+        assert_eq!(got.len, body.len() as u64, "the caller needs the FULL length to gate on");
+        assert!(got.text.contains("[exited with code 0]"), "the sentinel must survive the cut");
+        assert!(got.text.contains("http://localhost:5555/"), "the URL must survive the cut");
+    }
+
+    /// The poll's cheap path, and the two halves of it that must both hold. Without the
+    /// gate, every running server costs a 32 KiB read every few seconds forever, and a
+    /// dev server nobody is hitting is exactly the case whose log never moves. Without
+    /// the gate *breaking* on an append, a server's death would never be noticed — the
+    /// sentinel arrives the same way everything else does.
+    #[test]
+    fn read_bg_log_skips_the_read_only_until_something_is_appended() {
+        let dir = crate::testutil::scratch_dir();
+        let f = dir.join("dev.output");
+        std::fs::write(&f, "  Local:   http://localhost:5555/
+").unwrap();
+
+        let first = bg_log_at(&f, 0);
+        assert!(!first.unchanged, "a first look must read");
+        assert!(first.text.contains("5555"));
+
+        // The poll's steady state: the log has not moved, so nothing is read.
+        let again = bg_log_at(&f, first.len);
+        assert!(again.unchanged, "an unmoved log must not be re-read");
+        assert!(again.text.is_empty(), "unchanged must carry no text for the caller to fold");
+        assert_eq!(again.len, first.len);
+
+        // ...and the moment it does move, the gate opens.
+        std::fs::write(&f, "  Local:   http://localhost:5555/
+[exited with code 1]
+").unwrap();
+        let after = bg_log_at(&f, first.len);
+        assert!(!after.unchanged, "an appended log must be read again");
+        assert!(after.text.contains("[exited with code 1]"), "the sentinel must reach the caller");
+    }
+
+    /// An empty log - a shell that has started but printed nothing yet - is *unchanged*
+    /// rather than missing. The distinction matters: missing means the row has no file
+    /// to name, and a shell that simply has not spoken yet does.
+    #[test]
+    fn read_bg_log_treats_an_empty_log_as_unchanged_not_missing() {
+        let dir = crate::testutil::scratch_dir();
+        let f = dir.join("silent.output");
+        std::fs::write(&f, "").unwrap();
+        let got = bg_log_at(&f, 0);
+        assert!(!got.missing, "the file is there");
+        assert!(got.unchanged && got.len == 0);
+    }
+
+    /// A log that is not there is a *state*, not an error: a shell that started a
+    /// moment ago has not written one yet, and the row still has to draw.
+    #[test]
+    fn read_bg_log_reports_a_missing_file_rather_than_failing() {
+        let got = read_bg_log("/w/.claude/projects/slug/uuid.jsonl".into(), "nosuchtask".into(), 0);
+        assert!(got.missing, "a missing log must come back as `missing`");
+        assert!(got.text.is_empty());
+        // The path is still reported, because it is what the row would reveal.
+        assert!(got.path.contains("nosuchtask.output"), "path was {:?}", got.path);
+    }
+
 }

--- a/src/footer.ts
+++ b/src/footer.ts
@@ -11,6 +11,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { $, FILE_MANAGER, IS_MAC, toast } from "./dom";
+import { closeServersPop } from "./serversui";
 import { dlog } from "./debug";
 import { esc, fmtMb, fmtUntil } from "./format";
 import { abbr } from "./phase";
@@ -215,7 +216,7 @@ export function closeFootMenus(keep?: string) {
   const menus: [string, () => void][] = [
     ["colorPop", closeColorPop], ["enginePop", closeEnginePop], ["cafPop", closeCafPop],
     ["usagePop", closeUsagePop], ["attnPop", closeAttnPop], ["shortPop", closeShortPop],
-    ["costPop", closeCostPop], ["ioPop", closeIoPop],
+    ["costPop", closeCostPop], ["ioPop", closeIoPop], ["svrPop", closeServersPop],
   ];
   for (const [id, close] of menus) if (id !== keep) close();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,11 @@ import {
   toggleRail, toggleTheme,
 } from "./actions";
 import { playSound, setSoundLogger } from "./chime";
+import { taskServerUrl } from "./servers";
+import {
+  closeServersPop, pollServers, renderServers, setServersCloseMenus, setServersCloseSession,
+  setServersRepaint, setServersSetActive,
+} from "./serversui";
 import { exitSound, hookSound, limitCrossed, soundSnap } from "./sound";
 import {
   activeCwd, activeProjectCtx, closeRunGroup, closeSession, focusInGroup, handToTerminal,
@@ -205,6 +210,13 @@ setSidebarRenderAll(renderAll);
 // rows here, and the reactor badge puts a pane on the stage.
 setFooterCloseColorPop(closeColorPop);
 setFooterSetActive(setActive);
+// The running-server pill lives in the header but joins the footer's popover family
+// (only one menu open at a time), puts a pane on the stage, and repaints itself off a
+// poll rather than off telemetry — three things it cannot reach from where it sits.
+setServersCloseMenus(closeFootMenus);
+setServersSetActive(setActive);
+setServersRepaint(renderAll);
+setServersCloseSession(closeSession);
 // A palette row can do almost anything the app can do, so the ⌘K UI takes one host
 // rather than a dozen setters — the settings.ts deviation, for the same reason.
 /// ⌘P — the explorer, on whatever owns the stage. Keyed by folder like the peek, and
@@ -463,7 +475,7 @@ function renderAllNow() {
   // at all — so the stamp every attention surface below reads is refreshed here, once,
   // rather than at each of them. See syncAttn in ./grouping.
   syncAttn();
-  renderSidebar(); renderMini(); renderFoot(); renderAttn(); syncStageButtons();
+  renderSidebar(); renderMini(); renderFoot(); renderAttn(); renderServers(); syncStageButtons();
   // A tiled pane's caption carries live state (elapsed, exit code, the ✕ a finished run
   // keeps), and panes are outside the render-everything sweep — so it has to be asked
   // for. No-ops unless a group is actually tiled.
@@ -538,7 +550,13 @@ listen<{ sessionId: string; data: string; seq: number }>("pty-output", (e) => {
   if (s.run) {
     const text = new TextDecoder().decode(bytes).replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, "");
     for (const line of text.split(/\r?\n/)) {
-      if (line.trim()) s.run.tail.push(line.trimEnd());
+      if (!line.trim()) continue;
+      s.run.tail.push(line.trimEnd());
+      // …and if this run is a server — `just dev`, a VS Code task, an npm script — the
+      // URL it announces is latched HERE, as it streams, rather than read back off the
+      // tail: the tail is the rolling 40 lines below, and a dev server's banner is gone
+      // from it within seconds of the first HMR line. See taskServerUrl in ./servers.
+      s.run.url = taskServerUrl(s.run.url, line);
     }
     if (s.run.tail.length > 40) s.run.tail.splice(0, s.run.tail.length - 40);
   }
@@ -658,6 +676,7 @@ document.addEventListener("click", (e) => {
   if (!t.closest("#costPop, #fCostSeg")) closeCostPop();
   if (!t.closest("#ioPop, #fIoSeg")) closeIoPop();
   if (!t.closest("#attnPop, #attnBadge")) closeAttnPop();
+  if (!t.closest("#svrPop, #svrBadge")) closeServersPop();
   if (!t.closest("#shortPop, #fShortSeg")) closeShortPop();
   // Every anchor that OPENS this popover must be spared here, or the same click that
   // opened it closes it again and the control reads as dead. `[data-dashbrtrunk]` is the
@@ -1009,6 +1028,13 @@ setInterval(() => {
 // anything when the disk was idle, and flushes at most once per floor when it wasn't.
 // It carries no `git_diffstat` — see `pollIo`.
 setInterval(() => { void pollIo(); }, 60_000);
+
+// Re-read the background logs of every server still running. 4s rather than the
+// telemetry cadence: this is a file read per server, and the two things it is watching
+// for — a URL appearing a second after a dev server boots, and the sentinel that says
+// one has died — are both fine to learn about a beat late. It returns before touching
+// the disk when nothing is running, which is the overwhelming majority of the time.
+setInterval(() => { void pollServers(); }, 4000);
 
 // discover Claude Code sessions running outside Episko and keep them fresh.
 refreshExternals();

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -109,7 +109,7 @@ export async function launch(project: string, workdir: string, opts: { colorKey?
     model: "", ctxPct: null, ctxTokens: null, cost: null, durMs: null,
     curTool: "", curArg: "", todos: [], ctxHist: [], costHist: [], git: null,
     lastEvent: "", activity: [],
-    files: [], tally: {}, kind: "claude", external, term, fit, pane,
+    files: [], tally: {}, servers: [], kind: "claude", external, term, fit, pane,
   };
   sessions.set(id, s);
   term?.onTitleChange((t) => {
@@ -247,7 +247,7 @@ async function adoptSession(o: { id: string; workdir: string; meta: Restorable |
     model: "", ctxPct: null, ctxTokens: null, cost: null, durMs: null,
     curTool: "", curArg: "", todos: [], ctxHist: [], costHist: [], git: null,
     lastEvent: "", activity: [],
-    files: [], tally: {}, kind: "claude", external: false, term, fit, pane,
+    files: [], tally: {}, servers: [], kind: "claude", external: false, term, fit, pane,
     adopt: { pending: [] },
   };
   // From this line the pty-output listener queues this session's chunks into
@@ -311,7 +311,7 @@ export async function launchShell(project: string, workdir: string, opts: { colo
     model: "", ctxPct: null, ctxTokens: null, cost: null, durMs: null,
     curTool: "", curArg: "", todos: [], ctxHist: [], costHist: [], git: null,
     lastEvent: "", activity: [],
-    files: [], tally: {},
+    files: [], tally: {}, servers: [],
     kind: "shell", external: false, term, fit, pane,
   };
   sessions.set(id, s);
@@ -376,7 +376,7 @@ export async function launchTask(r: Runnable, project: string, opts: TaskLaunchO
     model: "", ctxPct: null, ctxTokens: null, cost: null, durMs: null,
     curTool: "", curArg: "", todos: [], ctxHist: [], costHist: [], git: null,
     lastEvent: "", activity: [],
-    files: [], tally: {},
+    files: [], tally: {}, servers: [],
     resumeId: id, kind: "task", external: false, term, fit, pane,
     run: { id: r.id, label: r.label, source: r.source, sourceFile: r.sourceFile, cmd, background: r.background, startedAt: Date.now(), exitCode: null, tail: [], root: opts.discoveredIn ?? colorKey, forSession: opts.forSession, groupId: opts.groupId, groupLabel: opts.groupLabel },
   };

--- a/src/phase.ts
+++ b/src/phase.ts
@@ -14,6 +14,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { liveFanout, type Fanout, type Phase, type Risk, type Sess } from "./types";
 import { applyTouch, bumpTally } from "./files";
+import { applyBg } from "./servers";
 import { addUsage, costDelta } from "./usage";
 import { descText, inputText, outputText } from "./toolio";
 import { mergeRl, onRlUpdate, rl } from "./rl";
@@ -292,6 +293,15 @@ export function applyHook(s: Sess, data: any) {
       // appear on the strength of a Read that errored.
       bumpTally(s.tally, tool);
       if (ev === "PostToolUse") applyTouch(s.files, tool, data.tool_input, data.tool_response, Date.now());
+      // The dev servers an agent starts and leaves running. Recorded on Post for the
+      // same reason the file set is: the *response* is what carries `backgroundTaskId`,
+      // and there is no shell to point at until the tool has actually spawned one. A
+      // failed call is skipped — a background shell that errored started nothing.
+      //
+      // `transcript_path` travels with the record rather than being read back later:
+      // the log lives under the session directory Claude owned at *this* moment, and
+      // /clear, /compact and /resume each mint a new one (see `BgServer` in ./types).
+      if (ev === "PostToolUse") applyBg(s.servers, tool, data.tool_input, data.tool_response, data.transcript_path, Date.now());
       onSessionTouched(s, tool, data);
       if (!bg()) setPhase(s, ev === "PostToolUse" ? "working" : "error");
       break;

--- a/src/servers.ts
+++ b/src/servers.ts
@@ -1,0 +1,384 @@
+// The dev servers an agent starts and walks away from.
+//
+// Claude Code's answer to "start the dev server" is `Bash{run_in_background:true}`: it
+// spawns the process, hands the model a `backgroundTaskId`, and pipes the output to a
+// file only the model ever reads. Nothing about that reaches the human. You find out
+// there is a server when you go looking for the port, or when the next one refuses to
+// bind — a machine picked at random for this feature had **eleven** of them listening,
+// most of them orphans of sessions that had long since ended.
+//
+// Episko needs no new instrumentation to see them, because the hook that carries them
+// is one it already registers. A backgrounded shell's PostToolUse payload reads:
+//
+//   tool_input:    { command: "pnpm dev", run_in_background: true }
+//   tool_response: { stdout: "", …, backgroundTaskId: "bczk8s47b" }
+//
+// and the log the process is writing lives beside the session's transcript, at
+// `<tmp>/claude/<slug>/<uuid>/tasks/<backgroundTaskId>.output` — which is what
+// `read_bg_log` resolves. That file is the whole feature: it carries the URL the
+// server printed, its last lines, and a closing sentinel when the process dies.
+//
+// This module is the pure half — payload in, records out, log text in, facts out. It
+// owns no DOM, no IPC and no timers; ./serversui owns those. Same split, and the same
+// reason for it, as ./gitwatch beside it.
+//
+// **Two directions of error, and they cost differently.** A false positive is a row for
+// something that was never a server (`sleep 45` backgrounded by an agent is a perfectly
+// ordinary thing to do): it appears in the popover with no URL, and it leaves when the
+// sentinel lands. That is noise. A false negative is the state this feature exists to
+// end — a port held by nothing you can name. So this leans inclusive: **every**
+// backgrounded shell becomes a record, and the URL is what promotes one to a server.
+
+import type { BgServer } from "./types";
+
+/// The tools that *operate* on a background shell rather than creating one. Their
+/// responses can carry the same id, and reading one as a start would resurrect a
+/// record the sentinel had already retired.
+const NOT_A_START = new Set(["TaskStop", "TaskOutput"]);
+
+/// The id Claude Code gave a shell it just backgrounded, or "".
+///
+/// Keyed on the **response field**, not on `tool_input.run_in_background`, and not on
+/// the tool being named `Bash`. The id is the thing we actually need (it is the handle
+/// `TaskStop` takes), so a payload that carries it is usable whatever produced it, and
+/// a payload that doesn't is not — whatever the input said it intended.
+export function bgTaskId(tool: string, response: unknown): string {
+  if (NOT_A_START.has(tool)) return "";
+  const r = response as Record<string, unknown> | null | undefined;
+  const id = r?.backgroundTaskId;
+  return typeof id === "string" && id.trim() ? id.trim() : "";
+}
+
+/// The id an agent just asked Claude Code to kill, or "". The one event that ends a
+/// record *before* the log's sentinel does — and it usually beats it, since the
+/// sentinel only appears once the process has actually gone.
+export function bgStopId(tool: string, input: unknown): string {
+  if (tool !== "TaskStop") return "";
+  const i = input as Record<string, unknown> | null | undefined;
+  const id = i?.task_id;
+  return typeof id === "string" && id.trim() ? id.trim() : "";
+}
+
+/// The command a backgrounded shell ran, tidied to one line for a row label.
+function bgCmd(input: unknown): string {
+  const i = input as Record<string, unknown> | null | undefined;
+  const c = i?.command;
+  return typeof c === "string" ? c.replace(/\s+/g, " ").trim() : "";
+}
+
+/// Fold one completed tool call into a session's server list. Mutates in place and
+/// returns whether anything changed, exactly like `applyTouch` in ./files next door —
+/// the caller owns the array, and the boolean is what lets the render pass stay quiet
+/// for the overwhelming majority of tool calls, which are neither of these two events.
+export function applyBg(
+  list: BgServer[], tool: string, input: unknown, response: unknown,
+  transcript: unknown, now: number,
+): boolean {
+  const stopped = bgStopId(tool, input);
+  if (stopped) {
+    const rec = list.find((b) => b.taskId === stopped);
+    // `exit: null` is what `[killed]` means, and an agent's TaskStop is a kill. Setting
+    // it here rather than waiting for the sentinel is what makes the count drop on the
+    // click that caused it instead of on the next poll.
+    if (!rec || rec.ended) return false;
+    rec.ended = now; rec.exit = null;
+    return true;
+  }
+  const taskId = bgTaskId(tool, response);
+  if (!taskId) return false;
+  // A repeat of an id we already hold is not a new shell — it is `TaskOutput`'s
+  // response echoing, or a hook we saw twice. Leave the record alone.
+  if (list.some((b) => b.taskId === taskId)) return false;
+  list.push({
+    taskId,
+    cmd: bgCmd(input),
+    // Captured now, deliberately: see the `transcript` note on `BgServer`.
+    transcript: typeof transcript === "string" ? transcript : "",
+    startedAt: now,
+  });
+  return true;
+}
+
+// ---------- reading the log ----------
+
+/// Lines as a terminal would have shown them. A background log is raw process output:
+/// no ANSI (Claude Code strips it on the way to the file) but plenty of `\r`, because
+/// every progress bar in the ecosystem redraws its line that way. Keeping only what
+/// follows the last `\r` is what a terminal does, and it is the difference between a
+/// four-line peek and four hundred lines of the same install spinner.
+export function logLines(text: string): string[] {
+  return text.split("\n").map((l) => {
+    const i = l.lastIndexOf("\r");
+    return (i >= 0 ? l.slice(i + 1) : l).trimEnd();
+  });
+}
+
+/// The sentinel Claude Code appends when a background shell finishes: `[exited with
+/// code N]`, or `[killed]` when it was stopped rather than allowed to end. Returns the
+/// exit code (null for a kill), or `undefined` while the process is still running.
+///
+/// This is the liveness answer, and it is better than the two obvious alternatives. An
+/// mtime says only when the file was last written, and a dev server that nobody is
+/// hitting writes nothing for hours; a process-table lookup would need the pid, which
+/// no payload carries. The sentinel is the process's own last word.
+export function bgSentinel(text: string): number | null | undefined {
+  const m = /^\[exited with code (-?\d+)\]\s*$/m.exec(text);
+  if (m) return Number(m[1]);
+  if (/^\[killed\]\s*$/m.test(text)) return null;
+  return undefined;
+}
+
+/// Lines that read as a server announcing itself, rather than merely mentioning a URL.
+/// `Local:` (vite, next, astro), `running on` (uvicorn, gunicorn), `listening`,
+/// `started server`, `ready`… — and NOT `Vue DevTools: Open http://…`, which is the
+/// line that makes "take the last URL in the file" the wrong rule.
+const ANNOUNCE = /\b(local|listening|running|serving|server|ready|started|available)\b/i;
+
+/// Every localhost origin in one line, normalised. Paths are dropped on purpose: the
+/// origin is the whole of what a row needs, and dropping the path is also what makes
+/// vite's two announcements (`/` and `/__devtools__/`) collapse into one answer instead
+/// of competing. `0.0.0.0` and `[::]` are rewritten, since neither is a thing a browser
+/// will open.
+function origins(line: string): string[] {
+  const out: string[] = [];
+  const re = /\bhttps?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1?\]|\[::\])(?::(\d{1,5}))?/gi;
+  for (const m of line.matchAll(re)) {
+    const scheme = m[0].slice(0, m[0].indexOf(":"));
+    const host = /0\.0\.0\.0|\[::\]/.test(m[1]) ? "localhost" : m[1];
+    out.push(m[2] ? `${scheme}://${host}:${m[2]}` : `${scheme}://${host}`);
+  }
+  return out;
+}
+
+/// The URL a background process is serving on, or "".
+///
+/// Announcement lines are preferred over any other line carrying a localhost URL (an
+/// agent's own `curl http://localhost:9999` should not name the server), and within the
+/// chosen set the **last** wins — a dev server that restarts itself on a config change
+/// prints a fresh line, and the stale one above it would send you to a dead port.
+export function serverUrl(text: string): string {
+  const lines = logLines(text);
+  const announced: string[] = [], any: string[] = [];
+  for (const l of lines) {
+    const o = origins(l);
+    if (!o.length) continue;
+    (ANNOUNCE.test(l) ? announced : any).push(...o);
+  }
+  const pick = announced.length ? announced : any;
+  return pick.length ? pick[pick.length - 1] : "";
+}
+
+/// The origin one line announces, or "". Stricter than `serverUrl`: the line must read
+/// as an announcement, with no any-URL fallback.
+///
+/// The two rules differ because what they are asked about differs. `serverUrl` sees a
+/// whole log and can prefer an announcement *over* a stray URL, so falling back to any
+/// localhost origin when there is no announcement at all is a safety net for a server
+/// that prints a bare `http://localhost:3000`. This one sees a single line with no
+/// context and its answer **latches**, so a stray URL — an agent's own `curl`, a health
+/// check the process logged — would put a wrong address on a row permanently. When it
+/// cannot tell, it says nothing and waits for a line that can.
+function announcedOn(line: string): string {
+  return ANNOUNCE.test(line) ? (origins(line).pop() ?? "") : "";
+}
+
+/// The URL an Episko task pane is serving on, folded one output line at a time.
+///
+/// `just dev`, a VS Code task, an npm script — Episko runs these itself, in a PTY it
+/// owns, so there is no log file and no `backgroundTaskId`; the evidence is the pane's
+/// own output as it arrives. It has to be captured *as it streams* because `run.tail`
+/// is a rolling 40 lines and a dev server's banner scrolls out of it within seconds of
+/// the first HMR update — a URL rescanned from the tail would show for a moment and
+/// then disappear, which is worse than never showing it.
+///
+/// A later announcement still wins: vite reprints its banner when the config changes,
+/// sometimes on a different port, and the line above it names a port nothing is on.
+export function taskServerUrl(prev: string | undefined, line: string): string | undefined {
+  return announcedOn(line) || prev;
+}
+
+/// The last `n` non-empty lines, for the row's peek.
+export function logTail(text: string, n = 12): string[] {
+  const lines = logLines(text).filter((l) => l.trim());
+  return lines.slice(Math.max(0, lines.length - n));
+}
+
+/// One `read_bg_log` answer, as the command returns it.
+export interface BgRead { path: string; text: string; len: number; unchanged: boolean }
+
+/// Fold one log read into a record. Mutates in place, returns whether anything the UI
+/// draws actually moved — the poll runs on every live server every few seconds, and a
+/// dev server that nobody is hitting produces an identical read every time.
+///
+/// An `unchanged` read is the steady state and folds nothing: the backend did not even
+/// open the file, so `text` is empty and treating it as content would blank the peek
+/// and the URL on every poll.
+export function applyBgLog(rec: BgServer, read: BgRead, now: number): boolean {
+  let changed = false;
+  const { path, text } = read;
+  if (path && rec.log !== path) { rec.log = path; changed = true; }
+  if (read.unchanged) { rec.len = read.len; return changed; }
+  rec.len = read.len;
+  const url = serverUrl(text);
+  if (url && rec.url !== url) { rec.url = url; changed = true; }
+  const tail = logTail(text);
+  if (tail.join("\n") !== (rec.tail ?? []).join("\n")) { rec.tail = tail; changed = true; }
+  const sent = bgSentinel(text);
+  // `undefined` means "still running", which must never *clear* an end: a record ended
+  // by the agent's own TaskStop is ended before the process has written its last line,
+  // and re-reading the file in that window would otherwise un-end it every poll.
+  if (sent !== undefined && !rec.ended) { rec.ended = now; rec.exit = sent; changed = true; }
+  return changed;
+}
+
+// ---------- the ports the kernel says are open ----------
+
+/// One TCP port a session's process tree is listening on, from `session_ports`.
+export interface SessionPort { sessionId: string; port: number; pid: number; name: string }
+
+/// The port a URL names, or 0. Absent ports are the scheme's default, which is what
+/// makes `http://localhost` and `http://localhost:80` the same server.
+export function portOf(url: string): number {
+  const m = /^(https?):\/\/[^/:]+(?::(\d{1,5}))?/i.exec(url);
+  if (!m) return 0;
+  return m[2] ? Number(m[2]) : m[1].toLowerCase() === "https" ? 443 : 80;
+}
+
+/// Node's inspector, and the worker variant beside it. Both are debugger control
+/// channels that speak a WebSocket protocol to a devtools client — never a page, and
+/// `node --inspect` is a thing agents reach for constantly.
+const DEBUG_PORTS = new Set([9229, 9230]);
+
+/// IANA's dynamic/private range, and the floor of the ephemeral range Windows and macOS
+/// hand out. A port in it was chosen by the *kernel*, not by a person or a config file.
+const EPHEMERAL_FROM = 49152;
+
+/// Is this port worth putting in front of somebody?
+///
+/// The scan finds every listening socket under a pane, and a dev server is rarely just
+/// one: a single `wrangler dev` measured on this machine held **five** — the server you
+/// want on 8788, Node's inspector on 9229, and three kernel-assigned control channels in
+/// the 63xxx range. Listing all five would put four pieces of noise in front of one
+/// useful row, on the surface whose whole value is that you can trust the count.
+///
+/// So the rule is: a server you would open is on a port somebody *chose*. An ephemeral
+/// port is by definition one nobody chose, which is what makes this a principle rather
+/// than a denylist — the two named ports are the only hardcoded exceptions, and both are
+/// debugger endpoints rather than servers.
+///
+/// The cost is a real server on an ephemeral port (`vite --port 0`) going unlisted here.
+/// That is the right way round: this scan is the *fallback* for servers nobody
+/// announced, and a server on a random port has to announce itself to be reachable at
+/// all — so the log path already has it.
+export function usefulPort(port: number): boolean {
+  return port > 0 && port < EPHEMERAL_FROM && !DEBUG_PORTS.has(port);
+}
+
+/// Reconcile what a session *said* against what it is actually listening on, and
+/// return the ports nothing here accounts for.
+///
+/// This is the join that makes the whole feature trustworthy. A parsed log line is a
+/// guess about somebody else's output format; a listening socket is the kernel's
+/// answer. Three steps, in order, each narrower than the last:
+///
+/// 1. **A port some record already names is that record's.** Nothing to do — the
+///    record's own URL is better than a bare port, since it carries the scheme and any
+///    base path the server announced.
+/// 2. **One silent record, one loose port → they are each other.** A shell that
+///    started something we never got a URL for, and exactly one unexplained port under
+///    the same pane, is that pane's server essentially always. **Exactly one on both
+///    sides**: with two of either there is no way to tell which belongs to which, and a
+///    row pointing at the wrong port is worse than a row still saying "starting…". Same
+///    fail-closed rule as `checkoutDrift` in ./gitwatch.
+/// 3. **Whatever is left is a server nobody modelled** — one started by hand in a shell
+///    pane, or one whose banner we cannot parse. It gets a row of its own, which is the
+///    only way those have ever been visible at all.
+export function reconcilePorts(
+  records: BgServer[], taskUrl: string | undefined, ports: readonly number[],
+): { loose: number[]; changed: boolean } {
+  const live = liveServers(records);
+  const claimed = new Set<number>();
+  if (taskUrl) claimed.add(portOf(taskUrl));
+  for (const b of live) if (b.url) claimed.add(portOf(b.url));
+  // `usefulPort` first, and it applies to adoption too: a record with no URL must never
+  // adopt a kernel-assigned control socket, which would put an address on the row that
+  // serves nothing.
+  const loose = [...new Set(ports)]
+    .filter((p) => usefulPort(p) && !claimed.has(p))
+    .sort((a, b) => a - b);
+
+  const silent = live.filter((b) => !b.url);
+  if (loose.length === 1 && silent.length === 1) {
+    silent[0].url = `http://localhost:${loose[0]}`;
+    return { loose: [], changed: true };
+  }
+  return { loose, changed: false };
+}
+
+// ---------- what the header asks ----------
+
+/// The records still running. Everything the indicator counts, and everything the poll
+/// re-reads; a finished one keeps its row but costs nothing further.
+export function liveServers(list: readonly BgServer[]): BgServer[] {
+  return list.filter((b) => !b.ended);
+}
+
+/// The ones worth a badge: a background shell that has announced a URL. A `sleep 45` an
+/// agent backgrounded is live, and listed, but it is not something you can go and look
+/// at — counting it would make the indicator mean "the agent is doing something", which
+/// the phase glyphs already say better.
+export function servingUrls(list: readonly BgServer[]): BgServer[] {
+  return liveServers(list).filter((b) => b.url);
+}
+
+/// The ones that died on their own, with something to say about it.
+///
+/// Without this the feature has a hole exactly where it hurts: a dev server that exits
+/// on `EADDRINUSE` two seconds after starting would take the count from 1 back to 0 and
+/// say nothing, which is the *same* silence the whole feature exists to end. So a
+/// non-zero exit stays on the list until it is dismissed — the rule task panes already
+/// follow, where "successful runs auto-dismiss, failures persist" (docs/tasks.md).
+///
+/// Two endings are deliberately excluded. `exit === 0` is a background shell that
+/// simply finished, which is what a one-shot `pnpm build` in the background looks like
+/// and is not news. `exit === null` is a kill — the agent's `TaskStop`, or the session
+/// ending — which is somebody having *asked* for this, and a row reporting back an
+/// outcome you requested is noise.
+export function failedServers(list: readonly BgServer[]): BgServer[] {
+  return list.filter((b) => b.ended && b.exit != null && b.exit !== 0);
+}
+
+/// Everything the popover draws: still running, plus the failures nobody has read yet.
+/// Distinct from `liveServers`, which is what the poll re-reads — a dead log has
+/// nothing left to say and must not be read forever.
+export function shownServers(list: readonly BgServer[]): BgServer[] {
+  return [...liveServers(list), ...failedServers(list)];
+}
+
+/// Drop one record. Only ever a *failed* one, from its dismiss button: a live server is
+/// removed by stopping it, and forgetting one while its port is still held would put
+/// the app back to lying about what is running.
+export function forgetServer(list: BgServer[], taskId: string): boolean {
+  const i = list.findIndex((b) => b.taskId === taskId && b.ended);
+  if (i < 0) return false;
+  list.splice(i, 1);
+  return true;
+}
+
+/// What a finished record says about how it went, for the row.
+export function bgOutcome(b: BgServer): string {
+  if (!b.ended) return "";
+  return b.exit == null ? "stopped" : b.exit === 0 ? "finished" : `exited ${b.exit}`;
+}
+
+/// The short label a row shows for the command. A backgrounded dev server is nearly
+/// always `cd <somewhere> && <the interesting part>`, and the `cd` is both the longest
+/// and the least informative half — the row already says which project it belongs to.
+export function cmdLabel(cmd: string, max = 52): string {
+  let c = cmd.trim();
+  const m = /^cd\s+(?:"[^"]*"|'[^']*'|\S+)\s*&&\s*(.+)$/s.exec(c);
+  if (m) c = m[1].trim();
+  // A shell redirect to a log file is plumbing the agent added, never the command.
+  c = c.replace(/\s*(?:\d?>>?|2>&1)\s*(?:"[^"]*"|'[^']*'|\S+)?\s*/g, " ").trim();
+  return c.length > max ? c.slice(0, max - 1) + "…" : c;
+}

--- a/src/serversui.ts
+++ b/src/serversui.ts
@@ -1,0 +1,465 @@
+// The header's running-server indicator, and the popover behind it.
+//
+// The IDE convention, and the reason it belongs in the header rather than the
+// inspector: a dev server is not a fact about the session you happen to be looking at.
+// It is a fact about the machine — a held port, a process that outlives the turn that
+// started it, and something you may want to open in a browser while reading a
+// completely different pane. So the count is fleet-wide and always on screen, and the
+// popover is where the per-session detail lives.
+//
+// What this module owns: the pill, the popover, the poll that re-reads the logs, and
+// the three things a row can do. The rules — what counts as a server, what the log
+// says — are ./servers, which is pure and tested. This half is DOM and IPC all the way
+// down, like ./footer next door, and untested for the same reason.
+//
+// **Stopping is handed to the agent, not done behind its back.** Episko could find the
+// process (it is a descendant of Episko's own tree) and kill it — but the agent that
+// started it holds `TaskStop`, believes the server is up, and will go on telling you so
+// after a kill it never saw. So Stop prefills `TaskStop <id>` into the session and lets
+// you press Enter, the same contract as `handToTerminal` and `sendOutputToSession`:
+// Episko prefills, the human commits, and the agent's model of the world stays true.
+// (An *orphan* — a server whose session is gone — has no agent to ask, and killing one
+// needs a port→pid lookup this app does not have yet. Its row says so.)
+//
+// **Two sources, and they are listed by opposite rules.** An agent's background shell is
+// invisible — no pane, no row, nothing on screen — so every one of them is listed, URL or
+// not. An Episko **task** (`just dev`, a VS Code task, an npm script) already has a pane,
+// a sidebar row, a glyph and a phase, so listing it here would only repeat what the
+// sidebar says; it appears **only once it has announced a URL**, which is the one thing
+// its pane cannot give you — an address you can click. Same reason a failed task never
+// appears: the sidebar has already gone red about it. The header is for what is
+// otherwise invisible.
+//
+// Stopping differs with the source too, and honestly so: Episko owns a task's PTY, so ✕
+// there really does stop it (`closeSession`, exactly what the pane's own ✕ does). There
+// is no agent holding a stale belief to keep true.
+
+import { invoke } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { $, toast } from "./dom";
+import { esc, escAttr } from "./format";
+import { sessions, activeId } from "./state";
+import {
+  applyBgLog, bgOutcome, cmdLabel, failedServers, forgetServer, liveServers,
+  reconcilePorts, servingUrls, shownServers, type BgRead, type SessionPort,
+} from "./servers";
+import type { BgServer, Sess } from "./types";
+
+/// A row, resolved. `"bg"` is a shell an agent backgrounded — the record carries
+/// everything and the pane knows nothing about it. `"task"` is a runnable Episko itself
+/// launched, where the *pane* is the server and there is no record at all.
+type Row =
+  | { kind: "bg"; s: Sess; at: number; b: BgServer }
+  | { kind: "task"; s: Sess; at: number }
+  | { kind: "port"; s: Sess; at: number; port: number; name: string };
+
+interface LoosePort { port: number; name: string; at: number }
+
+/// The ports under each pane that no record explains — a server started by hand in a
+/// shell pane, or one whose banner nothing could parse. Keyed by session id.
+///
+/// Computed by the poll, not by the renderer, and that split is load-bearing:
+/// `reconcilePorts` **mutates** (step 2 of its ladder adopts a loose port onto a silent
+/// record), so calling it from a render pass would have the paint quietly rewriting the
+/// state it was asked to draw — at whatever rate telemetry happens to arrive.
+let loosePorts = new Map<string, LoosePort[]>();
+
+/// When each port was first seen, keyed `<session>:<port>`.
+///
+/// A socket has no age of its own — the kernel will tell you it is open, not since
+/// when — and `Sess` records no start time either. Without a stamp the rows would have
+/// nothing to sort by but the port number, so a server started this morning would sit
+/// below one started a minute ago purely because 8080 > 3000. Pruned against each
+/// poll's answer, so a port that closes and reopens is honestly new.
+const portSeen = new Map<string, number>();
+
+function looseOf(s: Sess): LoosePort[] {
+  return loosePorts.get(s.id) ?? [];
+}
+
+/// Task panes that are serving. Live only, and only with a URL — see the module header
+/// for why a task is listed on a stricter rule than an agent's shell.
+function taskRows(): Row[] {
+  const out: Row[] = [];
+  for (const s of sessions.values()) {
+    const r = s.run;
+    if (s.kind !== "task" || !r || r.exitCode != null || !r.url) continue;
+    out.push({ kind: "task", s, at: r.startedAt });
+  }
+  return out;
+}
+
+/// Everything the popover draws, from both sources: agent-backgrounded shells (running,
+/// plus the failures nobody has read yet) and Episko's own serving task panes.
+function rows(): Row[] {
+  const out: Row[] = [];
+  for (const s of sessions.values()) {
+    for (const b of shownServers(s.servers)) out.push({ kind: "bg", s, at: b.startedAt, b });
+    // A port nothing else here explains. Sorted by port so the rows of one pane keep a
+    // stable order; `at` borrows the pane's own start, since a socket carries no age of
+    // its own and the pane is the closest true answer.
+    for (const p of looseOf(s)) out.push({ kind: "port", s, at: p.at, port: p.port, name: p.name });
+  }
+  out.push(...taskRows());
+  // Oldest first: a dev server you started this morning is the one you have forgotten
+  // about, and the one a new arrival should not push off the bottom of the list.
+  return out.sort((a, b) => a.at - b.at);
+}
+
+/// What the poll re-reads — a separate question from what the popover draws, and
+/// deliberately a separate function rather than a mode of `rows`.
+///
+/// Only agent-backgrounded shells appear here, for two independent reasons: a task's
+/// output arrives on the PTY stream so there is no file to poll at all, and a *dead*
+/// log has nothing left to say, so re-reading one every four seconds forever is exactly
+/// the cost this feature must not have. Returning the records rather than rows is what
+/// makes both of those true by construction instead of by a filter somebody can drop.
+function livePolled(): BgServer[] {
+  const out: BgServer[] = [];
+  for (const s of sessions.values()) out.push(...liveServers(s.servers));
+  return out;
+}
+
+// ---------- the pill ----------
+
+let lastPop = "";
+
+/// The header indicator. Hidden entirely when nothing is running — an always-visible
+/// zero would be one more thing to read past, and the whole point is that a server you
+/// forgot about should be the thing that catches your eye.
+export function renderServers() {
+  const shown = rows();
+  const el = $("svrBadge");
+  if (!shown.length) { el.className = "svr-badge"; closeServersPop(); return; }
+  // Through the tested helpers rather than a second `.url`/`.exit` test here: "a server
+  // worth pointing at is one that has announced a URL", and "a failure is a non-zero
+  // exit nobody asked for", are both rules, and rules live in ./servers.
+  let serving = 0, failed = 0;
+  for (const s2 of sessions.values()) {
+    serving += servingUrls(s2.servers).length;
+    failed += failedServers(s2.servers).length;
+  }
+  // A task row is only ever here because it announced a URL, and a port row because the
+  // kernel says the socket is open — so every one of both counts toward green. For the
+  // task that is the whole condition for being listed at all; for the port it is the
+  // strongest evidence in the feature.
+  serving += shown.filter((r) => r.kind !== "bg").length;
+  el.className = "svr-badge show";
+  $("svrBadgeTxt").textContent = String(shown.length);
+  // The title carries what the pill cannot: one line per server, so hovering answers
+  // "which ones?" without a click.
+  el.title = shown.map((r) => `${r.s.project} · ${rowTitle(r)}`).join("\n");
+  // Failure wins the colour. A fleet with two servers up and one crashed is, right then,
+  // a thing that needs looking at — and green over the top of that reads as "all fine".
+  el.classList.toggle("serving", serving > 0 && !failed);
+  el.classList.toggle("failed", failed > 0);
+  if ($("svrPop").classList.contains("show")) renderServersPop();
+}
+
+// ---------- the popover ----------
+
+/// Which row is expanded. One at a time, and by task id rather than by index, so a
+/// server finishing while the popover is open cannot slide the peek onto its neighbour.
+let openRow = "";
+
+/// The one line a row is *about*, for the pill's hover list.
+function rowTitle(r: Row): string {
+  if (r.kind === "task") return `${r.s.run?.url} (${r.s.run?.label ?? "task"})`;
+  if (r.kind === "port") return `localhost:${r.port} (${r.name || "listening"})`;
+  return r.b.ended ? bgOutcome(r.b) : (r.b.url || cmdLabel(r.b.cmd));
+}
+
+/// A row's identity for the expander. Namespaced by source rather than shared, because
+/// the two are different things that happen to both be strings.
+function rowKey(r: Row): string {
+  if (r.kind === "task") return `t:${r.s.id}`;
+  if (r.kind === "port") return `p:${r.s.id}:${r.port}`;
+  return `b:${r.b.taskId}`;
+}
+
+/// The four things a row draws that differ by source, resolved once with the union
+/// narrowed. Everything below this point is the same markup for both.
+///
+/// `label` is deliberately different in kind, not just in value: an agent's row shows
+/// the **command**, because that is all there is to know about it, while a task's shows
+/// the **name you picked** with the command on its tooltip. The ▶ reuses the app's own
+/// Run glyph rather than inventing a marker, since "Episko ran this" is exactly what ▶
+/// already means everywhere else — without it a `just dev` row and an agent's `pnpm dev`
+/// row read identically.
+function rowFacts(r: Row) {
+  if (r.kind === "port") {
+    // Nothing announced this — it is a socket the kernel says is open under this pane.
+    // So the label is the only thing we actually know: the process holding it.
+    return {
+      url: `http://localhost:${r.port}`, dead: false, outcome: "", tail: undefined,
+      label: `<span class="sv-src sv-obs" title="Seen listening under this pane — nothing announced it">◎</span>${esc(r.name || "port " + r.port)}`,
+      // No ✕, but the cell stays: the row is a four-column grid, and dropping one
+      // column would pull this row's ◨ out of line with every other row's. We know
+      // which pid holds the socket; what we do not know is that killing it is what you
+      // meant — it sits several hops below a pane that has its own ✕, and this row
+      // exists to *tell* you the port is open, not to take responsibility for it.
+      x: `<span class="sv-stop sv-none"></span>`,
+      go: "Go to the pane this is running under",
+    };
+  }
+  if (r.kind === "task") {
+    const t = r.s.run!;
+    return {
+      url: t.url ?? "", dead: false, outcome: "", tail: t.tail,
+      label: `<span class="sv-src" title="Started by Episko · ${escAttr(t.cmd)}">▶</span>${esc(t.label)}`,
+      // Ours to stop, so it really is stopped.
+      x: `<button class="sv-stop" data-svkill="${r.s.id}" title="Stop this task">✕</button>`,
+      go: "Go to this task's pane",
+    };
+  }
+  const b = r.b;
+  const dead = !!b.ended;
+  return {
+    url: b.url ?? "", dead, outcome: bgOutcome(b), tail: b.tail,
+    label: esc(cmdLabel(b.cmd)),
+    // A dead row has no process left and is merely cleared; a live one is only ever
+    // *asked* to stop. Separate attributes rather than one branch in the handler, so the
+    // two can never be confused for each other.
+    x: dead
+      ? `<button class="sv-stop" data-svforget="${b.taskId}" data-svsid="${r.s.id}" title="Dismiss">✕</button>`
+      : `<button class="sv-stop" data-svstop="${b.taskId}" data-svsid="${r.s.id}" title="Ask this session's agent to stop it (TaskStop)">✕</button>`,
+    go: "Go to the session that started this",
+  };
+}
+
+function rowHtml(r: Row, open: boolean): string {
+  const s = r.s;
+  const { url, dead, outcome, tail, label, x, go } = rowFacts(r);
+  const peek = open && tail?.length
+    ? `<pre class="sv-log">${esc(tail.join("\n"))}</pre>`
+    : open ? `<pre class="sv-log sv-log-empty">no output yet</pre>` : "";
+  // A dead row keeps its outcome where the URL was, as plain text: the port is gone, and
+  // a chip that opens a dead tab is worse than one that does not invite the click.
+  const mid = dead
+    ? `<span class="sv-url sv-dead">${esc(outcome)}</span>`
+    : url
+      ? `<button class="sv-url" data-svopen="${escAttr(url)}" title="Open ${escAttr(url)}">${esc(url.replace(/^https?:\/\//, ""))}</button>`
+      : `<span class="sv-url sv-pending">starting…</span>`;
+  return `<div class="sv-row${open ? " open" : ""}${dead ? " dead" : ""}">
+    <button class="sv-head" data-svtoggle="${escAttr(rowKey(r))}" title="Show the last lines of this output">
+      <span class="sv-dot${dead ? " down" : url ? " up" : ""}"></span>
+      <span class="sv-main">
+        <span class="sv-proj">${esc(s.project)}</span>
+        <span class="sv-cmd">${label}</span>
+      </span>
+    </button>
+    ${mid}
+    <button class="sv-go" data-svgo="${s.id}" title="${go}">◨</button>
+    ${x}
+    ${peek}
+  </div>`;
+}
+
+function renderServersPop() {
+  const shown = rows();
+  const pop = $("svrPop");
+  const html = shown.length
+    ? `<div class="sv-h">Running servers<span class="sv-hn">${shown.length}</span></div>`
+      + shown.map((r) => rowHtml(r, rowKey(r) === openRow)).join("")
+      + `<div class="sv-foot">▶ is a task Episko ran and can stop. The rest were backgrounded by an agent, and Stop asks that session to run <code>TaskStop</code>.</div>`
+    : "";
+  // Same guard, and the same reason, as the attention popover: this repaints on every
+  // telemetry event, and an innerHTML assignment between mousedown and mouseup drops
+  // the click on the button underneath (docs/architecture.md).
+  if (html === lastPop) return;
+  lastPop = html;
+  pop.innerHTML = html;
+}
+
+export function openServersPop() {
+  const r = $("svrBadge").getBoundingClientRect();
+  const pop = $("svrPop");
+  closeOtherMenus();
+  lastPop = ""; // a fresh open always paints, even onto identical markup
+  renderServersPop();
+  pop.style.right = Math.max(8, window.innerWidth - r.right) + "px";
+  pop.style.left = "auto";
+  pop.style.top = (r.bottom + 6) + "px";
+  pop.classList.add("show");
+}
+export function closeServersPop() { $("svrPop").classList.remove("show"); openRow = ""; }
+
+/// The one thing this module needs from the popover family it joins. A settable hook
+/// rather than an import of ./footer, because footer imports settings, which imports
+/// enough of the app that a direct import here would close a cycle (CLAUDE.md's seam
+/// rule 2). main.ts wires it.
+let closeOtherMenus: () => void = () => {};
+export function setServersCloseMenus(f: () => void) { closeOtherMenus = f; }
+
+let repaint: () => void = () => {};
+export function setServersRepaint(f: () => void) { repaint = f; }
+
+/// ./panes owns a pane's lifecycle and sits above this module, so closing one arrives
+/// as a hook like the rest (CLAUDE.md's seam rule 2).
+let closePane: (id: string) => void = () => {};
+export function setServersCloseSession(f: (id: string) => void) { closePane = f; }
+
+// ---------- the poll ----------
+
+/// Re-read every live server's log. This is the only thing that ever fills in a URL, a
+/// peek or an ended state, so the cadence is the feature's latency — but it is also a
+/// disk read per server, so it is deliberately slower than anything on the telemetry
+/// path and skips finished records entirely.
+///
+/// A dev server that nobody is hitting writes nothing for hours, which is exactly why
+/// `applyBgLog` returns whether anything moved: the common case is N reads that change
+/// nothing and must cost no paint.
+/// Ask the kernel which ports our panes are listening on, and reconcile that against
+/// what the panes have said about themselves.
+///
+/// This is the half that needs no cooperation from anything: no hook, no log, no output
+/// format. It is what lets a shell pane where somebody typed `pnpm dev` by hand show up
+/// at all, and what puts a port on a row whose banner nothing could parse.
+async function refreshPorts(): Promise<boolean> {
+  let seen: SessionPort[];
+  try {
+    seen = await invoke<SessionPort[]>("session_ports");
+  } catch {
+    return false; // keep the last answer rather than blanking the list on one bad poll
+  }
+  const now = Date.now();
+  const bySession = new Map<string, SessionPort[]>();
+  for (const p of seen) {
+    const list = bySession.get(p.sessionId) ?? [];
+    list.push(p);
+    bySession.set(p.sessionId, list);
+    const k = `${p.sessionId}:${p.port}`;
+    if (!portSeen.has(k)) portSeen.set(k, now);
+  }
+  // Prune stamps for ports that have closed, so one that comes back is honestly new
+  // rather than claiming the age of the server that held it before.
+  const alive = new Set(seen.map((p) => `${p.sessionId}:${p.port}`));
+  for (const k of [...portSeen.keys()]) if (!alive.has(k)) portSeen.delete(k);
+
+  let changed = false;
+  const next = new Map<string, LoosePort[]>();
+  for (const s of sessions.values()) {
+    const mine = bySession.get(s.id) ?? [];
+    // Runs even with no ports: a record that adopted one earlier keeps its URL, and
+    // there is nothing here that needs clearing — a closed port does not un-say what
+    // the server announced.
+    const { loose, changed: adopted } = reconcilePorts(s.servers, s.run?.url, mine.map((p) => p.port));
+    if (adopted) changed = true;
+    if (loose.length) {
+      next.set(s.id, loose.map((p) => ({
+        port: p,
+        name: mine.find((x) => x.port === p)?.name ?? "",
+        at: portSeen.get(`${s.id}:${p}`) ?? now,
+      })));
+    }
+  }
+  // A repaint is owed whenever the *set* of loose rows moved, which is the only part of
+  // this the popover draws directly.
+  const key = (m: Map<string, LoosePort[]>) =>
+    [...m].map(([k, v]) => k + ":" + v.map((p) => p.port).join(",")).sort().join("|");
+  if (key(next) !== key(loosePorts)) changed = true;
+  loosePorts = next;
+  return changed;
+}
+
+export async function pollServers() {
+  let changed = await refreshPorts();
+  const live = livePolled();
+  if (!live.length) { if (changed) repaint(); return; }
+  for (const b of live) {
+    if (!b.transcript) continue; // no address to read; the row still draws
+    try {
+      // `knownLen` is the whole cost control: the backend compares it against the file's
+      // length and, for an append-only log that has not moved, answers without opening
+      // it at all. See `read_bg_log`.
+      const got = await invoke<BgRead & { missing: boolean }>(
+        "read_bg_log", { transcript: b.transcript, taskId: b.taskId, knownLen: b.len ?? 0 },
+      );
+      // A missing file is normal for a second or two after a shell starts, and
+      // permanent if Claude Code's layout ever changes. Either way there is nothing to
+      // fold in, and the record keeps whatever it already knew.
+      if (got.missing) { if (!b.log && got.path) { b.log = got.path; changed = true; } continue; }
+      if (applyBgLog(b, got, Date.now())) changed = true;
+    } catch { /* the row survives a failed read; the next poll tries again */ }
+  }
+  if (changed) repaint();
+}
+
+// ---------- what a row can do ----------
+
+$("svrBadge").addEventListener("click", (e) => {
+  e.stopPropagation();
+  $("svrPop").classList.contains("show") ? closeServersPop() : openServersPop();
+});
+
+$("svrPop").addEventListener("click", (e) => {
+  const t = e.target as HTMLElement;
+  // Buttons first, expander last — the expander is the row's whole background, so
+  // `closest()` would hand it back for a click that landed on any of the three.
+  const url = t.closest<HTMLElement>("[data-svopen]");
+  if (url) { e.stopPropagation(); void openUrl(url.dataset.svopen!).catch((err) => toast("open failed: " + err)); return; }
+  const go = t.closest<HTMLElement>("[data-svgo]");
+  if (go) { e.stopPropagation(); goToSession(go.dataset.svgo!); return; }
+  const stop = t.closest<HTMLElement>("[data-svstop]");
+  if (stop) { e.stopPropagation(); askStop(stop.dataset.svsid!, stop.dataset.svstop!); return; }
+  const forget = t.closest<HTMLElement>("[data-svforget]");
+  if (forget) { e.stopPropagation(); dismiss(forget.dataset.svsid!, forget.dataset.svforget!); return; }
+  const kill = t.closest<HTMLElement>("[data-svkill]");
+  if (kill) { e.stopPropagation(); stopTask(kill.dataset.svkill!); return; }
+  const tog = t.closest<HTMLElement>("[data-svtoggle]");
+  if (tog) {
+    e.stopPropagation();
+    openRow = openRow === tog.dataset.svtoggle ? "" : tog.dataset.svtoggle!;
+    lastPop = ""; renderServersPop();
+  }
+});
+
+/// A hook rather than an import: ./panes owns `setActive`, and it sits above this
+/// module in the graph.
+let setActiveSession: (id: string) => void = () => {};
+export function setServersSetActive(f: (id: string) => void) { setActiveSession = f; }
+
+function goToSession(id: string) {
+  if (!sessions.has(id)) { toast("That session is gone"); return; }
+  setActiveSession(id);
+  closeServersPop();
+}
+
+/// Prefill the stop into the session's stdin — deliberately **without** a trailing
+/// newline, so you read what is about to be sent and press Enter yourself. Same
+/// contract as `sendOutputToSession` in ./taskrun.
+function askStop(sessionId: string, taskId: string) {
+  const s = sessions.get(sessionId);
+  if (!s) { toast("That session is gone — nothing here can stop it"); return; }
+  if (s.kind !== "claude") { toast("Only a Claude session can be asked to stop a task"); return; }
+  if (s.phase === "ended") { toast("That session has ended — its agent can no longer be asked"); return; }
+  const msg = `Stop the background task ${taskId} (use the TaskStop tool). Don't start it again.`;
+  if (activeId !== sessionId) setActiveSession(sessionId);
+  invoke("write_pty", { sessionId, data: msg })
+    .then(() => { closeServersPop(); toast("Prefilled in the session. Press Enter to send"); })
+    .catch((e) => toast("send failed: " + e));
+}
+
+/// Stop a task Episko itself launched. Unlike the agent's shells this is a real stop:
+/// the PTY is ours, `closeSession` kills it and reaps the pane, and it is exactly what
+/// the pane's own ✕ does — so the two routes cannot end up meaning different things.
+/// No confirm, for the same reason that ✕ has none: a task is a thing you re-run.
+function stopTask(sessionId: string) {
+  const s = sessions.get(sessionId);
+  if (!s) { toast("That task is gone"); return; }
+  const label = s.run?.label ?? "task";
+  closePane(sessionId);
+  lastPop = "";
+  toast(`Stopped ${label}`);
+}
+
+/// Clear a finished row. Only ever reachable on one that has actually ended, and
+/// `forgetServer` re-checks that rather than trusting the markup: a live server is
+/// removed by stopping it, and forgetting one whose port is still held would put the app
+/// straight back to lying about what is running.
+function dismiss(sessionId: string, taskId: string) {
+  const s = sessions.get(sessionId);
+  if (!s || !forgetServer(s.servers, taskId)) return;
+  lastPop = "";
+  repaint();
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -2160,6 +2160,61 @@ select.in-ctl { cursor: pointer; }
 .attnpop .ap-ttl { font-size: 10px; color: var(--muted-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .attnpop .ap-reason { flex: none; max-width: 40%; font-size: 9px; font-weight: 600; color: var(--st-attention); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
+/* Running servers: the header pill and its popover.
+
+   Two states, and the difference matters: a *live* background shell is grey (the agent
+   backgrounded something and it has not finished), while one that has announced a URL
+   goes green and pulses (there is a port up you can go and look at). Counting only the
+   second would hide a dev server that crashed on boot; colouring them the same would
+   make `sleep 45` look like a running site. */
+.svr-badge { display: none; align-items: center; gap: 5px; height: 24px; padding: 0 9px; border-radius: 999px; cursor: pointer; font: 650 11px var(--font-ui); color: var(--muted); background: color-mix(in srgb, var(--muted) 10%, transparent); border: 1px solid color-mix(in srgb, var(--muted) 26%, transparent); }
+.svr-badge.show { display: flex; }
+.svr-badge:hover { background: color-mix(in srgb, var(--muted) 16%, transparent); }
+.svr-badge .svr-ic { font-size: 8px; line-height: 1; }
+.svr-badge.serving { color: var(--st-done); background: color-mix(in srgb, var(--st-done) 13%, transparent); border-color: color-mix(in srgb, var(--st-done) 32%, transparent); }
+/* A crashed server outranks a healthy one for the pill's colour: green over the top of a
+   failure reads as "all fine", which is the one thing it must never say. */
+.svr-badge.failed { color: var(--st-error); background: color-mix(in srgb, var(--st-error) 13%, transparent); border-color: color-mix(in srgb, var(--st-error) 32%, transparent); }
+@media (prefers-reduced-motion: no-preference) { .svr-badge.serving .svr-ic { animation: pulse 2.4s ease-in-out infinite; } }
+
+.svrpop { min-width: 330px; max-width: 460px; padding: 7px; }
+.svrpop .sv-h { display: flex; align-items: center; gap: 6px; font: 700 10px var(--font-mono); letter-spacing: .06em; text-transform: uppercase; color: var(--muted-2); padding: 2px 4px 5px; }
+.svrpop .sv-hn { margin-left: auto; font-family: var(--font-mono); color: var(--muted); }
+/* The row is a grid so the three buttons keep their columns however long the command
+   is — a flex row lets a long `pnpm --filter web dev` shove the URL off the edge. */
+.svrpop .sv-row { display: grid; grid-template-columns: minmax(0, 1fr) auto auto auto; align-items: center; gap: 4px; padding: 2px; border-radius: 9px; }
+.svrpop .sv-row:hover { background: var(--surface); }
+.svrpop .sv-row.open { background: var(--surface); }
+.svrpop .sv-head { display: flex; align-items: center; gap: 8px; min-width: 0; padding: 6px 6px; border: 0; border-radius: 8px; background: transparent; color: var(--text); cursor: pointer; text-align: left; }
+.svrpop .sv-dot { flex: none; width: 6px; height: 6px; border-radius: 50%; background: var(--muted-2); }
+.svrpop .sv-dot.up { background: var(--st-done); }
+.svrpop .sv-dot.down { background: var(--st-error); }
+/* A finished row is dimmed but still readable — it is kept precisely so it can be read. */
+.svrpop .sv-row.dead .sv-proj, .svrpop .sv-row.dead .sv-cmd { color: var(--muted-2); }
+.svrpop .sv-dead { border-color: color-mix(in srgb, var(--st-error) 34%, transparent); background: color-mix(in srgb, var(--st-error) 12%, transparent); color: var(--st-error); cursor: default; }
+.svrpop .sv-main { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.svrpop .sv-proj { font: 700 11.5px var(--font-ui); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.svrpop .sv-cmd { font: 500 10px var(--font-mono); color: var(--muted-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+/* ▶ — this one is a task Episko ran, so it is Episko's to stop. Same glyph as the Run
+   button, because that is already what it means everywhere else in the app. */
+.svrpop .sv-src { margin-right: 5px; font-size: 8px; color: var(--accent-ink); }
+/* ◎ — nobody announced this one; the kernel says the socket is open under this pane.
+   Muted, because the row carries a process name rather than anything a human named. */
+.svrpop .sv-obs { color: var(--muted-2); }
+/* The ✕ column, kept empty on a row that has no stop, so ◨ stays in line down the list. */
+.svrpop .sv-none { display: inline-block; }
+.svrpop .sv-url { flex: none; max-width: 170px; padding: 4px 7px; border-radius: 7px; border: 1px solid var(--accent-line); background: var(--accent-wash); color: var(--accent-ink); font: 600 10px var(--font-mono); cursor: pointer; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.svrpop .sv-url:hover { border-color: var(--accent-ink); }
+.svrpop .sv-pending { border-style: dashed; border-color: var(--hair-strong); background: transparent; color: var(--muted-2); cursor: default; }
+.svrpop .sv-go, .svrpop .sv-stop { flex: none; width: 24px; height: 24px; border-radius: 7px; border: 0; background: transparent; color: var(--muted); font-size: 11px; cursor: pointer; }
+.svrpop .sv-go:hover { background: var(--bg-2); color: var(--text); }
+.svrpop .sv-stop:hover { background: color-mix(in srgb, var(--st-error) 18%, transparent); color: var(--st-error); }
+/* The peek spans the whole row, below the four columns above it. */
+.svrpop .sv-log { grid-column: 1 / -1; margin: 2px 4px 5px; padding: 7px 8px; max-height: 148px; overflow: auto; border-radius: 7px; background: var(--bg-2); border: 1px solid var(--hair); color: var(--muted); font: 500 10px/1.5 var(--font-mono); white-space: pre-wrap; word-break: break-word; }
+.svrpop .sv-log-empty { color: var(--muted-2); font-style: italic; }
+.svrpop .sv-foot { padding: 6px 5px 2px; margin-top: 3px; border-top: 1px solid var(--hair); font-size: 9.5px; color: var(--muted-2); }
+.svrpop .sv-foot code { font-family: var(--font-mono); color: var(--muted); }
+
 /* account usage-limits popover (5-hour session + 7-day weekly windows) */
 .usagepop { min-width: 244px; gap: 4px; padding: 10px; }
 .usagepop .up-h { font: 700 10px var(--font-mono); letter-spacing: .06em; text-transform: uppercase; color: var(--muted-2); padding: 0 2px 3px; }

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,48 @@ export const actKey = (a: Act): string => a.id || `t${a.startMs}`;
 // `at` the most recent one — together they order the list and size the "×3" badge.
 export type TouchKind = "created" | "edited" | "read";
 export interface FileTouch { path: string; kind: TouchKind; n: number; at: number }
+
+/// One background shell an agent started and left running — Claude Code's own
+/// `Bash{run_in_background:true}`, which is how every "let me start the dev server"
+/// ends up. See ./servers for how one is recognised and what the log file answers.
+///
+/// **`transcript` is captured at start and never recomputed.** The log lives beside the
+/// transcript, under the session directory Claude Code owned *at the moment the shell
+/// was spawned* — and Claude mints a new one on `/clear`, `/compact` and `/resume`. So
+/// the path is a fact about the launch, not about the session now; re-deriving it later
+/// from a rotated session would point at a directory that has never held this log.
+/// (Same trap as the `X-CC-Session` rule in CLAUDE.md, one level down.)
+export interface BgServer {
+  /// Claude Code's own `backgroundTaskId` — the id `TaskStop`/`TaskOutput` name, and
+  /// therefore the only handle that lets the *agent* be asked to stop this.
+  taskId: string;
+  /// The command the agent ran, verbatim, for the row's label.
+  cmd: string;
+  /// `transcript_path` as it stood when the shell was spawned. Half of the log's
+  /// address; the other half is `taskId`. Resolved to a real path by `read_bg_log`.
+  transcript: string;
+  startedAt: number;
+  /// Everything below is read back out of the log file by the poll, so all of it is
+  /// absent until the first read lands — and stays absent if the file never appears.
+  /// The resolved log path, echoed back by `read_bg_log` so a row can name its file.
+  log?: string;
+  /// The last localhost URL the process printed. The *last*, not the first: a dev
+  /// server that restarts itself (a vite config change) prints a fresh one, and the
+  /// stale line above it would send you to a port nothing is on.
+  url?: string;
+  /// Set once the log's closing sentinel appears — `[exited with code N]` or `[killed]`,
+  /// the latter carrying no code. A record with `ended` set is history: it stays on the
+  /// session so the popover can say "this one is finished", and is what keeps a crashed
+  /// dev server from silently disappearing off the count.
+  ended?: number; exit?: number | null;
+  /// Last few lines of the log, for the row's expanded peek.
+  tail?: string[];
+  /// The log's length at the last read. A background log is append-only, so handing
+  /// this back to `read_bg_log` turns the steady-state poll — a dev server nobody is
+  /// hitting, whose log has not moved in an hour — into one `metadata()` call instead
+  /// of a 32 KiB read.
+  len?: number;
+}
 // A single item from a TodoWrite payload (the plan Claude keeps for itself).
 export interface Todo { content: string; status: string }
 // Uncommitted "working set" summary from the git_diffstat backend command, plus
@@ -414,6 +456,11 @@ export interface Sess {
   /// — nothing here is written to disk or read back, so a restart starts them empty.
   /// See ./files for the rules and the inspector's Context card for what draws them.
   files: FileTouch[]; tally: Record<string, number>;
+  /// Background shells this session started and has not stopped — the dev servers,
+  /// watchers and long-running processes an agent leaves behind. Fed from PostToolUse
+  /// like `files` above, and display-only in the same way: nothing here survives a
+  /// restart, because the process it describes is a child of the session's own tree.
+  servers: BgServer[];
   // `gl` is the pane's WebGL renderer addon while it holds a pooled context —
   // attached on activation, released when the pool evicts it or the pane exits (see
   // attachWebgl in ./terminal). Held here rather than inside terminal.ts because it
@@ -429,6 +476,12 @@ export interface Sess {
   run?: {
     id: string; label: string; source: string; sourceFile: string; cmd: string; background: boolean;
     startedAt: number; exitCode: number | null; tail: string[];
+    /// The localhost URL this run announced, if it is a server — `just dev`, a VS Code
+    /// task, an npm script. **Latched as the output streams, never rescanned from
+    /// `tail`**, which is a rolling 40 lines: a dev server's banner scrolls out of it
+    /// within seconds of the first HMR line, so a URL read off the tail would appear
+    /// and then silently vanish. See `taskServerUrl` in ./servers.
+    url?: string;
     /// When the process exited. Without it the elapsed readout is `Date.now() -
     /// startedAt` forever, so a run that took 400ms reads "1m 23s" a minute later —
     /// the duration has to be frozen at the exit, not recomputed on every repaint.

--- a/test/servers.test.ts
+++ b/test/servers.test.ts
@@ -1,0 +1,458 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyBg, applyBgLog, bgOutcome, bgSentinel, bgStopId, bgTaskId, cmdLabel,
+  failedServers, forgetServer, liveServers, logLines, logTail, serverUrl,
+  portOf, reconcilePorts, servingUrls, shownServers, taskServerUrl, usefulPort,
+} from "../src/servers";
+import type { BgServer } from "../src/types";
+
+// The payload shapes below are not invented. They were captured off the real CLI by
+// running a session with a stdin-dumping PostToolUse hook and backgrounding a shell,
+// and the log excerpts are real vite / uvicorn / pnpm output taken off disk. That
+// matters more here than in most suites: every field this module reads belongs to a
+// format nobody in this repo controls, so a fixture written from memory would only
+// prove that the code agrees with the guess it was written from.
+
+/** A PostToolUse payload for a shell the agent backgrounded, as the hook delivers it. */
+const started = (id: string, cmd = "pnpm dev") => ({
+  tool: "Bash",
+  input: { command: cmd, description: "Start the dev server", run_in_background: true },
+  response: { stdout: "", stderr: "", interrupted: false, isImage: false, noOutputExpected: false, backgroundTaskId: id },
+});
+
+describe("recognising a backgrounded shell", () => {
+  it("reads the id off the RESPONSE, which is the only place it exists", () => {
+    const p = started("bczk8s47b");
+    expect(bgTaskId(p.tool, p.response)).toBe("bczk8s47b");
+  });
+
+  it("does not invent one from `run_in_background` alone", () => {
+    // The input says the agent asked for a background shell; the response says whether
+    // it got one. Only the second is a fact, and only the second carries the handle
+    // TaskStop needs — so an input-only payload must produce no record at all.
+    expect(bgTaskId("Bash", { stdout: "", stderr: "" })).toBe("");
+  });
+
+  it("ignores the tools that OPERATE on a shell rather than create one", () => {
+    // TaskOutput's response can echo the same id. Reading that as a start is how a
+    // record the sentinel had already retired would come back from the dead.
+    expect(bgTaskId("TaskOutput", { backgroundTaskId: "bczk8s47b" })).toBe("");
+    expect(bgTaskId("TaskStop", { backgroundTaskId: "bczk8s47b" })).toBe("");
+  });
+
+  it("reads TaskStop's id from its input", () => {
+    expect(bgStopId("TaskStop", { task_id: "bc1sxie6v" })).toBe("bc1sxie6v");
+    expect(bgStopId("Bash", { task_id: "bc1sxie6v" })).toBe("");
+    expect(bgStopId("TaskStop", {})).toBe("");
+  });
+});
+
+describe("applyBg", () => {
+  const now = 1_000;
+
+  it("records a started shell, with the transcript path captured AT START", () => {
+    const list: BgServer[] = [];
+    const p = started("bs0hhu7b4");
+    const tr = "/h/.claude/projects/E--proj/819131de-4c0e-4a7e-a5c5-2d4a5550a104.jsonl";
+    expect(applyBg(list, p.tool, p.input, p.response, tr, now)).toBe(true);
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({ taskId: "bs0hhu7b4", cmd: "pnpm dev", transcript: tr, startedAt: now });
+  });
+
+  it("does not duplicate a shell it already holds", () => {
+    const list: BgServer[] = [];
+    const p = started("bs0hhu7b4");
+    applyBg(list, p.tool, p.input, p.response, "t.jsonl", now);
+    expect(applyBg(list, p.tool, p.input, p.response, "t.jsonl", now + 5)).toBe(false);
+    expect(list).toHaveLength(1);
+    expect(list[0].startedAt).toBe(now); // the first sighting is the start
+  });
+
+  it("ends the record TaskStop names, and reports it as a kill", () => {
+    const list: BgServer[] = [];
+    const p = started("bs0hhu7b4");
+    applyBg(list, p.tool, p.input, p.response, "t.jsonl", now);
+    expect(applyBg(list, "TaskStop", { task_id: "bs0hhu7b4" }, {}, "t.jsonl", now + 90)).toBe(true);
+    expect(list[0].ended).toBe(now + 90);
+    // A stop is a kill, not an exit: there is no code, and `null` is what the log's own
+    // `[killed]` sentinel means too.
+    expect(list[0].exit).toBeNull();
+  });
+
+  it("ignores a TaskStop for a shell it never saw, and a second stop", () => {
+    const list: BgServer[] = [];
+    expect(applyBg(list, "TaskStop", { task_id: "ghost" }, {}, "t.jsonl", now)).toBe(false);
+    const p = started("bs0hhu7b4");
+    applyBg(list, p.tool, p.input, p.response, "t.jsonl", now);
+    applyBg(list, "TaskStop", { task_id: "bs0hhu7b4" }, {}, "t.jsonl", now + 5);
+    expect(applyBg(list, "TaskStop", { task_id: "bs0hhu7b4" }, {}, "t.jsonl", now + 9)).toBe(false);
+    expect(list[0].ended).toBe(now + 5); // the FIRST stop is when it ended
+  });
+
+  it("says nothing changed for the tool calls that are neither event", () => {
+    const list: BgServer[] = [];
+    expect(applyBg(list, "Read", { file_path: "/a" }, { type: "text" }, "t.jsonl", now)).toBe(false);
+    expect(applyBg(list, "Bash", { command: "ls" }, { stdout: "a\nb" }, "t.jsonl", now)).toBe(false);
+    expect(list).toHaveLength(0);
+  });
+});
+
+describe("reading the log", () => {
+  // Real vite output, byte for byte off a running session's log file.
+  const VITE = `
+> frontend@0.0.0 dev E:\\proj\\frontend
+> vite
+
+  VITE v8.1.5  ready in 1114 ms
+
+  ➜  Local:   http://localhost:5555/
+  ➜  Network: use --host to expose
+  ➜  Vue DevTools: Open http://localhost:5555/__devtools__/ as a separate window
+18:03:56 [vite] (client) hmr update /src/App.vue
+`;
+
+  it("finds the URL a dev server printed", () => {
+    expect(serverUrl(VITE)).toBe("http://localhost:5555");
+  });
+
+  it("finds uvicorn's, which announces itself in a different shape entirely", () => {
+    expect(serverUrl("INFO:     Uvicorn running on http://127.0.0.1:8787 (Press CTRL+C to quit)"))
+      .toBe("http://127.0.0.1:8787");
+  });
+
+  it("rewrites the bind addresses no browser will open", () => {
+    expect(serverUrl("Listening on http://0.0.0.0:3000")).toBe("http://localhost:3000");
+    expect(serverUrl("server started at http://[::]:8080")).toBe("http://localhost:8080");
+  });
+
+  it("prefers the announcement over a URL the agent merely mentioned", () => {
+    // A health check the process logged is not the address of the process.
+    const log = "Uvicorn running on http://127.0.0.1:8787\nGET http://localhost:9999/ping 200\n";
+    expect(serverUrl(log)).toBe("http://127.0.0.1:8787");
+  });
+
+  it("takes the LAST announcement, so a self-restart wins over the stale line", () => {
+    // vite reprints its banner when the config changes, sometimes on a new port. The
+    // line above it points at a port nothing is on any more.
+    const log = VITE + "\n[vite] config changed, restarting\n\n  ➜  Local:   http://localhost:5556/\n";
+    expect(serverUrl(log)).toBe("http://localhost:5556");
+  });
+
+  it("returns nothing for output that names no server", () => {
+    expect(serverUrl("306 passed (10.0m)\n")).toBe("");
+    // A remote URL is not a local server, however loudly the line announces it.
+    expect(serverUrl("Local build ready, deployed to https://example.com/")).toBe("");
+  });
+
+  it("reads the closing sentinel, and distinguishes an exit from a kill", () => {
+    expect(bgSentinel("done\n[exited with code 0]\n")).toBe(0);
+    expect(bgSentinel("boom\n[exited with code 1]\n")).toBe(1);
+    expect(bgSentinel("\n[killed]")).toBeNull();
+    // Still running is `undefined` — distinct from a kill's null, because one of them
+    // must never end a record and the other must.
+    expect(bgSentinel(VITE)).toBeUndefined();
+  });
+
+  it("collapses a redrawn line to what a terminal would have shown", () => {
+    // Every progress bar in the ecosystem redraws with \r. Splitting on \n alone turns
+    // one install spinner into hundreds of lines and pushes the real output out of the
+    // peek entirely.
+    expect(logLines("Progress: 1%\rProgress: 50%\rProgress: 100%\ndone")).toEqual(["Progress: 100%", "done"]);
+  });
+
+  it("takes the tail, not the head", () => {
+    const text = Array.from({ length: 40 }, (_, i) => `line ${i}`).join("\n");
+    const tail = logTail(text, 3);
+    expect(tail).toEqual(["line 37", "line 38", "line 39"]);
+  });
+});
+
+describe("applyBgLog", () => {
+  const rec = (): BgServer => ({ taskId: "b1", cmd: "pnpm dev", transcript: "t.jsonl", startedAt: 0 });
+  /** A `read_bg_log` answer, as the command shapes it. */
+  const read = (text: string, unchanged = false) =>
+    ({ path: "/tmp/x.output", text, len: text.length, unchanged });
+
+  it("folds in the path, the URL and the peek, and says something changed", () => {
+    const b = rec();
+    expect(applyBgLog(b, read("  ➜  Local:   http://localhost:5555/\n"), 10)).toBe(true);
+    expect(b.log).toBe("/tmp/x.output");
+    expect(b.url).toBe("http://localhost:5555");
+    // Leading indentation is kept: a peek that reflows its own output reads as a
+    // different program's. Only the trailing edge (and \r redraws) are tidied.
+    expect(b.tail).toEqual(["  ➜  Local:   http://localhost:5555/"]);
+  });
+
+  it("reports NO change on an identical re-read", () => {
+    // The poll re-reads every live server every few seconds, and a dev server nobody is
+    // hitting writes nothing for hours. If this returned true the app would repaint
+    // itself forever over a file that never moved.
+    const b = rec();
+    const text = "  ➜  Local:   http://localhost:5555/\n";
+    applyBgLog(b, read(text), 10);
+    expect(applyBgLog(b, read(text), 20)).toBe(false);
+  });
+
+  it("ends a record when the sentinel appears, and keeps the exit code", () => {
+    const b = rec();
+    applyBgLog(b, read("starting\n"), 10);
+    expect(b.ended).toBeUndefined();
+    expect(applyBgLog(b, read("starting\nboom\n[exited with code 1]\n"), 20)).toBe(true);
+    expect(b.ended).toBe(20);
+    expect(b.exit).toBe(1);
+  });
+
+  it("never un-ends a record the agent's TaskStop already ended", () => {
+    // TaskStop ends the record at the click; the process writes its `[killed]` line a
+    // moment later, and until it does the file still reads as running. A poll landing in
+    // that window must not resurrect the row — it would flicker back into the count.
+    const b = rec();
+    b.ended = 50; b.exit = null; b.log = "/tmp/x.output"; b.tail = ["still going"];
+    expect(applyBgLog(b, read("still going\n"), 60)).toBe(false);
+    expect(b.ended).toBe(50);
+    expect(b.exit).toBeNull();
+  });
+});
+
+describe("a server Episko itself ran (just / VS Code task / npm script)", () => {
+  // Real output from `just dev`, `npm run dev` and uvicorn, one line at a time — which
+  // is how it actually arrives, on the PTY stream.
+  const feed = (lines: string[], start?: string) =>
+    lines.reduce<string | undefined>((u, l) => taskServerUrl(u, l), start);
+
+  it("latches the URL as the output streams", () => {
+    expect(feed([
+      "> frontend@0.0.0 dev",
+      "> vite",
+      "",
+      "  VITE v8.1.5  ready in 1114 ms",
+      "  ➜  Local:   http://localhost:5555/",
+    ])).toBe("http://localhost:5555");
+  });
+
+  it("KEEPS it once the banner has scrolled out of the tail", () => {
+    // This is the whole reason it latches. `run.tail` is a rolling 40 lines, so within
+    // seconds of the first HMR update the banner is gone from it — a URL rescanned from
+    // the tail would appear and then silently vanish, which is worse than never showing.
+    const hmr = Array.from({ length: 60 }, (_, i) => `18:0${i % 6}:0${i % 9} [vite] hmr update /src/App.vue`);
+    expect(feed(hmr, "http://localhost:5555")).toBe("http://localhost:5555");
+  });
+
+  it("follows a restart onto a new port", () => {
+    // vite reprints its banner when the config changes, sometimes elsewhere. The old
+    // line names a port nothing is on any more.
+    expect(feed(["  ➜  Local:   http://localhost:5556/"], "http://localhost:5555"))
+      .toBe("http://localhost:5556");
+  });
+
+  it("refuses to latch onto a URL that is not an announcement", () => {
+    // Stricter than `serverUrl`, and deliberately: that one sees a whole log and can
+    // prefer an announcement *over* a stray URL, so its any-URL fallback is a safety
+    // net. This one sees one line with no context and its answer sticks, so a health
+    // check the task logged would put a wrong address on the row permanently.
+    expect(feed(['  "GET /api/health" -> http://localhost:9999/ 200'])).toBeUndefined();
+    expect(feed(["curl http://localhost:9999/ping"])).toBeUndefined();
+    // …and a real announcement afterwards still wins.
+    expect(feed(["curl http://localhost:9999/ping", "Listening on http://localhost:4000"]))
+      .toBe("http://localhost:4000");
+  });
+
+  it("says nothing for a task that is not a server at all", () => {
+    expect(feed(["> tsc --watch", "Found 0 errors. Watching for file changes."])).toBeUndefined();
+    expect(feed(["306 passed (10.0m)"])).toBeUndefined();
+  });
+});
+
+describe("reconciling what a pane SAID against what it is listening on", () => {
+  const mk = (id: string, over: Partial<BgServer> = {}): BgServer =>
+    ({ taskId: id, cmd: "pnpm dev", transcript: "t", startedAt: 0, ...over });
+
+  it("reads a port off a URL, defaults included", () => {
+    expect(portOf("http://localhost:5555")).toBe(5555);
+    expect(portOf("http://localhost")).toBe(80);
+    expect(portOf("https://localhost")).toBe(443);
+    expect(portOf("")).toBe(0);
+  });
+
+  it("leaves alone a port a record already names", () => {
+    // The record's own URL is better than a bare port: it carries the scheme, and any
+    // base path the server announced.
+    const list = [mk("a", { url: "http://localhost:5555" })];
+    const got = reconcilePorts(list, undefined, [5555]);
+    expect(got.loose).toEqual([]);
+    expect(got.changed).toBe(false);
+  });
+
+  it("matches a task's URL too, not just an agent's", () => {
+    expect(reconcilePorts([], "http://localhost:1420", [1420]).loose).toEqual([]);
+  });
+
+  it("adopts one loose port onto the one record that never said anything", () => {
+    // The payoff: a background shell we watched start, and exactly one unexplained
+    // socket under the same pane. That is its server, and now the row has an address
+    // instead of "starting…" forever.
+    const silent = mk("a");
+    const got = reconcilePorts([silent], undefined, [5555]);
+    expect(got.changed).toBe(true);
+    expect(silent.url).toBe("http://localhost:5555");
+    expect(got.loose).toEqual([]);
+  });
+
+  it("refuses to guess when either side is ambiguous", () => {
+    // Two silent records and one port, or one record and two ports: there is no way to
+    // tell which belongs to which, and a row pointing at the wrong port is worse than
+    // one still saying "starting…". Fail closed, like checkoutDrift in ./gitwatch.
+    const two = [mk("a"), mk("b")];
+    expect(reconcilePorts(two, undefined, [5555]).changed).toBe(false);
+    expect(two.every((b) => !b.url)).toBe(true);
+
+    const one = [mk("a")];
+    expect(reconcilePorts(one, undefined, [5555, 8787]).changed).toBe(false);
+    expect(one[0].url).toBeUndefined();
+    // …and both ports are then reported as unexplained, so neither is lost.
+    expect(reconcilePorts(one, undefined, [5555, 8787]).loose).toEqual([5555, 8787]);
+  });
+
+  it("ignores a record that has already ended", () => {
+    // A crashed shell must not adopt the port of whatever replaced it — which is the
+    // exact shape of "restart the dev server after it failed to bind".
+    const dead = mk("a", { ended: 5, exit: 1 });
+    const got = reconcilePorts([dead], undefined, [5555]);
+    expect(dead.url).toBeUndefined();
+    expect(got.loose).toEqual([5555]);
+  });
+
+  it("drops the sockets that are not servers", () => {
+    // Measured on a real machine: one `wrangler dev` held five listening sockets — the
+    // server on 8788, Node's inspector on 9229, and three kernel-assigned control
+    // channels in the 63xxx range. Listing all five puts four pieces of noise in front
+    // of the one useful row.
+    expect(usefulPort(8788)).toBe(true);
+    expect(usefulPort(3000)).toBe(true);
+    expect(usefulPort(9229)).toBe(false); // node --inspect
+    expect(usefulPort(9230)).toBe(false); // …and its worker
+    expect(usefulPort(63720)).toBe(false); // kernel-assigned
+    expect(usefulPort(0)).toBe(false);
+    expect(reconcilePorts([], undefined, [8788, 9229, 63720, 63721, 63199]).loose).toEqual([8788]);
+  });
+
+  it("never adopts a control socket onto a silent record", () => {
+    // The dangerous half: a record with no URL and one loose ephemeral port would
+    // otherwise be handed an address that serves nothing at all.
+    const silent = mk("a");
+    expect(reconcilePorts([silent], undefined, [63720]).changed).toBe(false);
+    expect(silent.url).toBeUndefined();
+  });
+
+  it("reports a port nothing here can explain", () => {
+    // The whole reason this exists: somebody typed `pnpm dev` in a shell pane, or a
+    // server printed a banner in a format nothing parses. No hook, no log, no record —
+    // and the kernel still knows.
+    expect(reconcilePorts([], undefined, [8100]).loose).toEqual([8100]);
+  });
+
+  it("counts one server once however many addresses it bound", () => {
+    // The backend dedupes by (session, port), but a caller handing the same port twice
+    // must not produce two rows either.
+    expect(reconcilePorts([], undefined, [3000, 3000, 3000]).loose).toEqual([3000]);
+  });
+});
+
+describe("the poll's cheap path", () => {
+  const rec = (): BgServer => ({ taskId: "b1", cmd: "pnpm dev", transcript: "t.jsonl", startedAt: 0 });
+
+  it("keeps the length the backend reports, so the next read can be skipped", () => {
+    const b = rec();
+    applyBgLog(b, { path: "/tmp/x.output", text: "hello\n", len: 6, unchanged: false }, 10);
+    expect(b.len).toBe(6);
+  });
+
+  it("folds NOTHING from an unchanged read, whose text is empty by construction", () => {
+    // The backend never opened the file, so `text: ""` means "I didn't look", not "the
+    // log is empty". Treating it as content would blank the URL and the peek on every
+    // poll — the row would flicker between knowing its port and not.
+    const b = rec();
+    applyBgLog(b, { path: "/tmp/x.output", text: "  Local: http://localhost:5555/\n", len: 33, unchanged: false }, 10);
+    expect(b.url).toBe("http://localhost:5555");
+
+    expect(applyBgLog(b, { path: "/tmp/x.output", text: "", len: 33, unchanged: true }, 20)).toBe(false);
+    expect(b.url).toBe("http://localhost:5555");
+    expect(b.tail).toEqual(["  Local: http://localhost:5555/"]);
+    expect(b.ended).toBeUndefined(); // and an unchanged read must not read as a death
+  });
+});
+
+describe("a server that died on its own", () => {
+  const mk = (id: string, over: Partial<BgServer> = {}): BgServer =>
+    ({ taskId: id, cmd: "pnpm dev", transcript: "t", startedAt: 0, ...over });
+
+  it("stays on the list, because vanishing is the silence the feature exists to end", () => {
+    // The commonest real failure: a dev server exits on EADDRINUSE two seconds after
+    // starting. If it dropped off the list the count would go 1 → 0 and say nothing.
+    const list = [mk("crashed", { ended: 5, exit: 1 })];
+    expect(failedServers(list).map((b) => b.taskId)).toEqual(["crashed"]);
+    expect(shownServers(list).map((b) => b.taskId)).toEqual(["crashed"]);
+    // But the poll must not keep re-reading a dead log for the rest of the session.
+    expect(liveServers(list)).toEqual([]);
+  });
+
+  it("does not keep an ending somebody asked for", () => {
+    // `exit: 0` is a background one-shot that simply finished; `exit: null` is a kill —
+    // the agent's TaskStop, or the session ending. Reporting either back is noise.
+    const list = [mk("clean", { ended: 5, exit: 0 }), mk("killed", { ended: 5, exit: null })];
+    expect(failedServers(list)).toEqual([]);
+    expect(shownServers(list)).toEqual([]);
+  });
+
+  it("names what happened", () => {
+    expect(bgOutcome(mk("a", { ended: 5, exit: 1 }))).toBe("exited 1");
+    expect(bgOutcome(mk("a", { ended: 5, exit: 0 }))).toBe("finished");
+    expect(bgOutcome(mk("a", { ended: 5, exit: null }))).toBe("stopped");
+    expect(bgOutcome(mk("a"))).toBe(""); // still running says nothing
+  });
+
+  it("is dismissable, and a LIVE one is not", () => {
+    // The guard is the point: forgetting a running server would put the app straight
+    // back to saying nothing about a port that is still held.
+    const list = [mk("live"), mk("crashed", { ended: 5, exit: 1 })];
+    expect(forgetServer(list, "live")).toBe(false);
+    expect(list).toHaveLength(2);
+    expect(forgetServer(list, "crashed")).toBe(true);
+    expect(list.map((b) => b.taskId)).toEqual(["live"]);
+    expect(forgetServer(list, "crashed")).toBe(false); // and again is a no-op
+  });
+});
+
+describe("what the header counts", () => {
+  const mk = (id: string, over: Partial<BgServer> = {}): BgServer =>
+    ({ taskId: id, cmd: "pnpm dev", transcript: "t", startedAt: 0, ...over });
+
+  it("counts the running ones and drops the finished", () => {
+    const list = [mk("a"), mk("b", { ended: 5, exit: 0 }), mk("c", { url: "http://localhost:3000" })];
+    expect(liveServers(list).map((b) => b.taskId)).toEqual(["a", "c"]);
+  });
+
+  it("badges only the ones that have announced a URL", () => {
+    // A `sleep 45` an agent backgrounded is live and listed, but it is not something you
+    // can go and look at — counting it green would make the pill mean "the agent is
+    // busy", which the phase glyphs already say better.
+    const list = [mk("a"), mk("c", { url: "http://localhost:3000" }), mk("d", { url: "http://localhost:4000", ended: 9 })];
+    expect(servingUrls(list).map((b) => b.taskId)).toEqual(["c"]);
+  });
+});
+
+describe("cmdLabel", () => {
+  it("drops the cd an agent nearly always prefixes", () => {
+    expect(cmdLabel("cd E:/Programming/projects/wirksam/frontend && pnpm dev")).toBe("pnpm dev");
+    expect(cmdLabel('cd "E:/a b/c" && npm run dev')).toBe("npm run dev");
+  });
+
+  it("drops the redirect the agent added, not the command", () => {
+    expect(cmdLabel('cd "E:/p" && npx vite --port 3000 > "E:/tmp/vite.log" 2>&1')).toBe("npx vite --port 3000");
+    expect(cmdLabel("pnpm preview --port 4173 2>&1")).toBe("pnpm preview --port 4173");
+  });
+
+  it("truncates rather than wrapping a row", () => {
+    expect(cmdLabel("pnpm --filter @acme/web dev --host --port 5173 --strictPort", 20)).toHaveLength(20);
+  });
+});


### PR DESCRIPTION
Episko can see the dev servers your agents leave running, and shows them in the header.

An agent's `Bash{run_in_background:true}` is how every "let me start the dev server" ends, and none of it reaches you: the process spawns, the model gets a task id, the output goes to a file only the model reads. You find out when you go looking for the port, or when the next one refuses to bind. A scan of one developer machine while writing this found **eleven** listening dev servers, most of them orphans of sessions that had ended hours earlier.

## What it looks like

A pill left of the reactor, hidden at zero, green once something is actually serving and red when something crashed. The popover lists project, command, the URL as a button that opens your browser, `◨` to jump to the pane, and an expandable peek at the last lines of output.

## Three sources, on different rules

The rules differ because the header's job is to surface what is **otherwise invisible**.

| Source | Listed when | Marker |
|---|---|---|
| An agent's backgrounded shell | Always — it has no pane, no row, nothing on screen | — |
| A task Episko ran (`just dev`, VS Code task, npm script) | Once it announces a URL; its pane says the rest | `▶` |
| A listening TCP port under a pane's process tree | When nothing else explains it | `◎` |

That third one is the only way a server typed by hand into a shell pane, or one whose banner nothing can parse, has ever been visible.

**No new instrumentation.** The first source rides the `PostToolUse` hook Episko already registers (`tool_response.backgroundTaskId`) plus the log Claude Code writes beside the transcript.

## The kernel is the authority

`session_ports` walks every listening socket back up the ppid chain to a pane's PTY child — eight hops from a `vite` leaf to `episko.exe`, measured on a real machine. `reconcilePorts` then joins that against what panes have said, in a ladder:

1. A port a record already names is that record's — its own URL is better, carrying scheme and any base path.
2. **One** silent record and **one** loose port under the same pane are each other.
3. Whatever is left gets a row of its own.

It fails closed the moment either side is ambiguous: a row pointing at the wrong port is worse than one still saying "starting…".

`usefulPort` runs first and earns its place — a single `wrangler dev` holds **five** listening sockets, four of them a debugger and kernel-assigned control channels. Without the filter that is four pieces of noise in front of one useful row, on the surface whose whole value is that you can trust the count.

## Two calls worth reviewing

**Stopping is honest per source.** Episko owns a task's PTY, so its `✕` really stops it. An agent's shell is only ever *asked* — `TaskStop <id>` is prefilled into the session and you press Enter (the `handToTerminal` contract) — because a kill the agent never saw would leave it telling you the server is still up. A port row has no `✕`: we know which pid holds the socket, but it sits several hops below a pane that has its own.

**A crash stays on screen.** A server exiting on `EADDRINUSE` two seconds in is the commonest way this goes wrong; dropping the count 1 → 0 in silence is exactly what this feature replaces. A non-zero exit keeps its row until dismissed. A clean finish, or a stop you asked for, leaves.

## Cost

- Log tail capped at 32 KiB, and an idle server's log costs one `metadata()` call rather than a read — it is append-only, so length is an exact "has anything happened" test.
- The port scan returns before touching anything when no pane is open.
- One new dependency, `listeners`. Native APIs on every platform so this stays spawn-free like `ProcTable` beside it, and no bindgen — but on Windows it resolves `windows` 0.62 alongside tauri's 0.61. Taken because the alternative is hand-written libproc FFI for macOS, unverifiable from a Windows machine, in the one place where a wrong answer means reporting a port that does not exist. The reasoning is in `Cargo.toml`.

## Testing

`tsc` clean · **1282** vitest (48 new, in `test/servers.test.ts`) · **202** cargo · clippy `-D warnings` clean · no import cycles across 67 modules.

Fixtures are captured, not invented: the hook payloads came off the real CLI via a stdin-dumping `PostToolUse` hook, and the log excerpts are real vite / uvicorn output taken off disk.

**Windows is verified end to end** — live sockets, real payloads, real logs, real process attribution.

**macOS is compile-checked and reasoned, not run.** The added Rust has **zero `cfg` gates**, so the only platform surface is inside `listeners`, whose macOS half type-checks for `aarch64-apple-darwin`. `listeners_sees_a_socket_we_just_opened` binds its own `TcpListener` and demands the crate find it and attribute it to our pid — it cannot pass vacuously, so **CI's macOS leg is what actually answers this**. Watch that leg.

One assumption worth noting as closed rather than hoped: `bg_log_path` needs Episko's `env::temp_dir()` and Claude's `os.tmpdir()` to agree, and `spawn_claude` copies Episko's whole environment into the PTY child — so they read the same `TMPDIR` by construction.

If either half misbehaves the two cover each other: a failed socket scan falls back to the log path, and an unresolvable log path still gets its URL from the scan. Neither failure is silent-and-wrong; both degrade to less information.

`RELEASE.md` gained a click-through section for all of it, since every surface here is DOM, PTY or live telemetry.

## Known gap

Orphans — a server whose session has exited — remain invisible. Attribution is by ancestry and their chain is broken, so they belong to no pane and there is nobody to ask. Listing them needs a project-level answer (matching cwd or command line against known roots); that is a separate feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
