### PR TITLE
fix(windows): keep-awake did not survive the PC sleeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
+! **Keep-awake now survives the PC sleeping.** On Windows the assertion was set once and
+  never re-stated, but Windows drops a thread's execution state across suspend/resume — so
+  the first sleep ended it permanently, and because the button only re-asks the backend when
+  its *flags* change (in *Until agents idle*, one session left at `done` holds them steady
+  for days), nothing ever restored it. The cup went on steaming over a machine that idle-slept
+  every half hour. The thread that owns the assertion now re-states it every 30s.
+
+! **A reload no longer strands the assertion.** Reloading the webview while caffeinated
+  restarted the button with no memory of it, leaving the backend holding the machine awake
+  with the cup painted off — and nothing short of quitting could stop it. Startup now clears
+  it explicitly.
+
 ## 0.21.0 — 2026-08-21
 
 A first run that explains itself, ⌘P to find any file in a project, and a tool call you

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -811,8 +811,8 @@ pub(crate) fn set_caffeinate(state: State<AppState>, active: bool, flags: Vec<St
 /// thread goes with the process.
 #[cfg(windows)]
 pub(crate) struct KeepAwake {
-    /// Dropping this releases the assertion: the parked thread's `recv()` fails,
-    /// it clears the execution state and exits.
+    /// Dropping this releases the assertion: the parked thread's `recv_timeout()`
+    /// reports the channel disconnected, it clears the execution state and exits.
     stop: Option<std::sync::mpsc::Sender<()>>,
     thread: Option<std::thread::JoinHandle<()>>,
 }
@@ -860,13 +860,78 @@ fn execution_state_for(flags: &[String]) -> u32 {
     es
 }
 
+/// How often the parked thread re-states its execution state.
+///
+/// **Windows does not preserve a thread's execution state across suspend/resume.**
+/// A single `SetThreadExecutionState` at arming time therefore holds only until the
+/// first sleep — after that the box idle-sleeps freely while the UI still shows the
+/// cup steaming, because the frontend only re-invokes on a *flag change* and in agent
+/// mode the flags can sit unchanged for days (one session left at `done` keeps
+/// `cafAgentsBusy()` true indefinitely). Nothing else would ever restore it, so the
+/// thread that owns the assertion re-states it on a tick instead.
+///
+/// 30s is comfortably under the one minute that is the shortest *Sleep after* Windows
+/// lets you configure, so a resume can never outrun the next re-assert.
+#[cfg(windows)]
+const REASSERT_EVERY: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Park a thread holding `es` until the returned handle is dropped, re-stating it
+/// every `every` so a suspend/resume can't quietly end the assertion.
+///
+/// The state must be set *and* released on the same thread, so the whole lifetime
+/// lives inside the closure: assert, hold, clear. Split out of `set_caffeinate` (and
+/// taking the interval rather than reading `REASSERT_EVERY` directly) so a test can
+/// drive the hold/re-assert/release cycle without an `AppState` and without a
+/// half-minute suite.
+#[cfg(windows)]
+fn spawn_keep_awake(
+    es: u32,
+    every: std::time::Duration,
+    on_reassert: impl Fn() + Send + 'static,
+) -> Result<KeepAwake, String> {
+    use std::sync::mpsc::{channel, RecvTimeoutError};
+    use windows_sys::Win32::System::Power::{SetThreadExecutionState, ES_CONTINUOUS};
+    let (stop, rx) = channel::<()>();
+    let (ready, ready_rx) = channel::<Result<(), String>>();
+    let thread = std::thread::spawn(move || {
+        // SAFETY: a plain flags-in/flags-out Win32 call with no pointers.
+        let prev = unsafe { SetThreadExecutionState(ES_CONTINUOUS | es) };
+        if prev == 0 {
+            let _ = ready.send(Err("SetThreadExecutionState refused the request".into()));
+            return;
+        }
+        let _ = ready.send(Ok(()));
+        // Hold until released, waking on each tick to re-state the assertion (see
+        // REASSERT_EVERY). `recv_timeout` reports `Disconnected` the moment the
+        // sender drops rather than at the next tick, so releasing stays prompt and
+        // `Drop`'s join can't stall the caller for up to half a minute.
+        while let Err(RecvTimeoutError::Timeout) = rx.recv_timeout(every) {
+            // SAFETY: as above. Re-stating the same state is idempotent, so this is
+            // a no-op except after a resume, which is the one time it matters.
+            unsafe { SetThreadExecutionState(ES_CONTINUOUS | es) };
+            on_reassert();
+        }
+        // SAFETY: same call; ES_CONTINUOUS alone clears our assertion.
+        unsafe { SetThreadExecutionState(ES_CONTINUOUS) };
+    });
+    // Surface a refusal as an error instead of a thread that quietly did nothing —
+    // the UI would otherwise paint the cup lit over a sleeping PC.
+    match ready_rx.recv() {
+        Ok(Ok(())) => Ok(KeepAwake { stop: Some(stop), thread: Some(thread) }),
+        Ok(Err(e)) => {
+            let _ = thread.join();
+            Err(e)
+        }
+        Err(_) => Err("keep-awake thread died before asserting".into()),
+    }
+}
+
 /// Toggle a Windows power assertion on or off — the `caffeinate` counterpart.
 /// Only ever one assertion is live: an existing one is dropped (which joins its
 /// thread and clears the state) first, so switching presets is a stop+restart.
 #[cfg(windows)]
 #[tauri::command]
 pub(crate) fn set_caffeinate(state: State<AppState>, active: bool, flags: Vec<String>) -> Result<(), String> {
-    use windows_sys::Win32::System::Power::{SetThreadExecutionState, ES_CONTINUOUS};
     let mut guard = state.caffeinate.lock().unwrap();
     guard.take(); // drop → releases whatever was asserted
     if !active || flags.is_empty() {
@@ -876,33 +941,7 @@ pub(crate) fn set_caffeinate(state: State<AppState>, active: bool, flags: Vec<St
     if es == 0 {
         return Err(format!("no Windows keep-awake equivalent for: {}", flags.join(" ")));
     }
-    let (stop, rx) = std::sync::mpsc::channel::<()>();
-    // The assertion must be set *and* released on the same thread, so the whole
-    // lifetime lives inside this closure: assert, park, clear.
-    let (ready, ready_rx) = std::sync::mpsc::channel::<Result<(), String>>();
-    let thread = std::thread::spawn(move || {
-        // SAFETY: a plain flags-in/flags-out Win32 call with no pointers.
-        let prev = unsafe { SetThreadExecutionState(ES_CONTINUOUS | es) };
-        if prev == 0 {
-            let _ = ready.send(Err("SetThreadExecutionState refused the request".into()));
-            return;
-        }
-        let _ = ready.send(Ok(()));
-        let _ = rx.recv(); // park until the sender is dropped
-        // SAFETY: same call; ES_CONTINUOUS alone clears our assertion.
-        unsafe { SetThreadExecutionState(ES_CONTINUOUS) };
-    });
-    // Surface a refusal as a command error instead of a thread that quietly did
-    // nothing — the UI would otherwise paint the cup lit over a sleeping PC.
-    match ready_rx.recv() {
-        Ok(Ok(())) => {}
-        Ok(Err(e)) => {
-            let _ = thread.join();
-            return Err(e);
-        }
-        Err(_) => return Err("keep-awake thread died before asserting".into()),
-    }
-    *guard = Some(KeepAwake { stop: Some(stop), thread: Some(thread) });
+    *guard = Some(spawn_keep_awake(es, REASSERT_EVERY, || {})?);
     Ok(())
 }
 
@@ -1293,6 +1332,46 @@ mod tests {
         // than lighting the cup over a machine that will happily sleep.
         assert_eq!(f(&["-m"]), 0);
         assert_eq!(f(&[]), 0);
+    }
+
+    /// The three things the hold loop has to get right at once: it re-states the
+    /// assertion (the whole point — Windows drops it across suspend/resume), it does
+    /// not mistake a tick for a release, and it still lets go immediately when asked.
+    /// All three are invisible from the outside, and the bug this replaced looked
+    /// identical from the outside, which is why they are counted rather than read.
+    #[cfg(windows)]
+    #[test]
+    fn keep_awake_holds_across_reassert_ticks_and_still_releases_promptly() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        use std::sync::Arc;
+        use std::time::{Duration, Instant};
+        use windows_sys::Win32::System::Power::ES_SYSTEM_REQUIRED;
+        let every = Duration::from_millis(5);
+        let ticks = Arc::new(AtomicU32::new(0));
+        let seen = Arc::clone(&ticks);
+        let awake = spawn_keep_awake(ES_SYSTEM_REQUIRED, every, move || {
+            seen.fetch_add(1, Ordering::Relaxed);
+        })
+        .expect("assertion refused");
+
+        // Twenty-odd ticks in. The bug this replaces was a bare `recv()`: it parks and
+        // releases exactly like the fix, so the only thing that tells them apart is
+        // whether the assertion is ever re-stated. Count that. (The hook sits on the
+        // line after the Win32 call, which is as close as a real extern call gets to
+        // observable.)
+        std::thread::sleep(every * 20);
+        assert!(ticks.load(Ordering::Relaxed) > 0, "assertion was never re-stated");
+        // And a timeout must not be treated as "release" — the easy mistake when
+        // swapping `recv` for `recv_timeout` — which would drop the assertion on the
+        // first tick while the UI still shows the cup steaming.
+        assert!(!awake.thread.as_ref().unwrap().is_finished(), "thread exited on a tick instead of holding");
+
+        // The other end of the same change: releasing must not wait for the next tick.
+        // `Drop` joins, and its caller is a `#[tauri::command]`, so a tick-long stall
+        // there would freeze the UI for REASSERT_EVERY on every preset switch.
+        let t = Instant::now();
+        drop(awake);
+        assert!(t.elapsed() < Duration::from_secs(1), "release waited for a tick: {:?}", t.elapsed());
     }
 
     /// The macOS half of the same setting. `set_caffeinate` spawns without a shell,

--- a/src/caffeinate.ts
+++ b/src/caffeinate.ts
@@ -106,6 +106,16 @@ function cafArmTimer() {
     cafTimerHandle = window.setTimeout(() => { cafArmed = false; reconcileCaf(); toast("Caffeinate ended"); }, cafTimerSec * 1000);
   }
 }
+// Clear any assertion the backend is still holding for us. A reload (⌘R) restarts
+// this module — cafArmed false, cafAssertKey "" — but leaves the Rust side untouched,
+// and reconcileCaf() then computes key "" against cafAssertKey "", sees no change and
+// invokes nothing. So a reload while caffeinated stranded the assertion: held forever,
+// with the cup painted off and no way to stop it short of quitting the app. Call this
+// once at boot, where "caffeinate always starts off" is decided (see main.ts). It is a
+// no-op against a backend holding nothing.
+export function initCaf() {
+  invoke("set_caffeinate", { active: false, flags: [] }).catch(() => {});
+}
 export function reconcileCaf() {
   const flags = cafDesiredFlags();
   const key = flags ? flags.join(" ") : "";

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,7 +69,7 @@ import {
 } from "./debug";
 import { basename, setHome } from "./format";
 import { rl, setRlLogger } from "./rl";
-import { closeCafPop, reconcileCaf, setCafHost } from "./caffeinate";
+import { closeCafPop, initCaf, reconcileCaf, setCafHost } from "./caffeinate";
 import { closeDiff, diffOpen, openDiff, setDiffCloseFootMenus } from "./diffview";
 import { closeExplorer, explorerOpen, openExplorer, setExplorerCloseFootMenus } from "./explorer";
 // The commit-graph panel needs nothing from here — it is opened from the project
@@ -1045,8 +1045,11 @@ initSidebarPeek();
 // rather than opening on top of it. `initTour` says whether it did.
 initChangelog(initTour());
 initFileDrop();
-// caffeinate always starts off — the assertion is bound to the last run's process
-// (`-w <pid>` on macOS, the parked thread on Windows) and died with it; renderAll's
-// reconcileCaf() paints the button. Note this is the ONE place agent-mode could
-// auto-assert on launch — but cafArmed is false at boot, so it stays dormant.
+// caffeinate always starts off — on a cold start the assertion is bound to the last
+// run's process (`-w <pid>` on macOS, the parked thread on Windows) and died with it;
+// renderAll's reconcileCaf() paints the button. Note this is the ONE place agent-mode
+// could auto-assert on launch — but cafArmed is false at boot, so it stays dormant.
+// initCaf() covers the case a dead process doesn't: a webview reload leaves the backend
+// asserting with nothing on this side left to remember it, so say so explicitly.
+initCaf();
 renderAll();


### PR DESCRIPTION
Reported as "the PC sleeps even though caffeinate is on, and the mug is animating".
It was, and the mug was right at the moment it started steaming — just badly out of date.

## What was wrong

**Windows does not preserve a thread's execution state across suspend/resume**, and
`set_caffeinate` asserted exactly once. The first sleep therefore ended the assertion
permanently, and nothing ever restored it: `reconcileCaf()` only invokes the backend
when the *flags* change, and in **Until agents idle** a single session left at `done`
keeps `cafAgentsBusy()` true indefinitely. So the flags sat at `-i` for days, the
backend was never asked again, `cafAssertKey` stayed non-empty, and `.caf.asserting`
kept the steam running over a machine idle-sleeping every half hour.

Traced on a live install (PID armed 08-22 21:28:49, still running):

| When | Kernel-Power 42 |
| --- | --- |
| 08-22 21:28 | armed — **no idle sleep for 3h20m** ✅ |
| 08-23 00:47 | `Application API` (explicit sleep) |
| 08-23 15:02, 18:13 | **System Idle** |
| 08-24 10:12, 11:25, 15:05, 18:22 | **System Idle** ×4 |

Every one ~15–22 min after the last hook, on a plain S3 desktop with an empty
`powercfg -requestsoverride`. It worked until the first resume and never again.

macOS is unaffected: `caffeinate -w <pid>` is a separate process holding an IOKit
assertion. The Windows port inherited the one-shot shape without the re-arm that
thread-scoped execution state needs.

## The fix

The thread that owns the assertion re-states it every 30s — comfortably under the one
minute that is the shortest *Sleep after* Windows can be configured to, so a resume
can't outrun the next re-assert. `recv_timeout` reports `Disconnected` the moment the
sender drops rather than at the next tick, so releasing stays prompt and `Drop`'s join
can't stall a `#[tauri::command]` for half a minute on every preset switch.

The thread is split out as `spawn_keep_awake` so the hold/re-assert/release cycle is
testable without an `AppState`.

**Second bug, found on the way:** reloading the webview restarted `caffeinate.ts` with
`cafArmed=false, cafAssertKey=""`, so `reconcileCaf()` compared `""` against `""`, saw
no change and invoked nothing — leaving the backend holding the machine awake with the
cup painted off, and no way to stop it short of quitting. `initCaf()` now clears it at
boot, where "caffeinate always starts off" is already decided.

## On the test

`keep_awake_holds_across_reassert_ticks_and_still_releases_promptly` **counts**
re-assertions rather than reading intent, because the bug it replaces parked and
released exactly like the fix does — a test that only checked "thread alive, releases
fast" passes against the broken version. Verified by reintroducing the bare `recv()`:

```
thread panicked: assertion was never re-stated
```

It also pins the two hazards the change itself introduces: a tick must not be mistaken
for a release, and a release must not wait for a tick.

## Gates

`cargo clippy --all-targets -- -D warnings` clean · `cargo test` 192 passed ·
`pnpm exec tsc --noEmit` clean · `pnpm test` 1234 passed · `changelog check` 2 entries.

Not covered by CI, and worth a manual check on the release list: arm the mug, sleep the
box, wake it, and confirm `powercfg -requests` (elevated) still shows `episko.exe` under
`SYSTEM:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
