### PR TITLE
tests: typecheck them too, and fix the drift that had already happened

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,8 @@ jobs:
       - name: Install frontend deps
         run: pnpm install --frozen-lockfile
 
-      # Typechecks (tsc) and builds the frontend. Must run before cargo, because
+      # Typechecks both TS projects (`src/` and `test/` — see docs/testing.md for why
+      # they are separate) and builds the frontend. Must run before cargo, because
       # Tauri's `generate_context!` embeds `frontendDist` (../dist) at compile time
       # and errors if it's missing.
       - name: Build frontend (tsc + vite)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,9 @@ Episko is a Tauri v2 desktop app (Rust backend + vanilla-TS frontend) that launc
 pnpm install            # first time
 pnpm tauri dev      # run the app (Tauri + Vite dev server on fixed port 1420)
 pnpm tauri build    # production bundle
-pnpm build          # tsc typecheck + vite build (frontend only; the beforeBuildCommand)
-pnpm exec tsc --noEmit       # typecheck only (tsconfig is noEmit)
+pnpm build          # typechecks BOTH projects + vite build (frontend only; the beforeBuildCommand)
+pnpm exec tsc --noEmit       # typecheck src/ only (tsconfig is noEmit)
+pnpm exec tsc -p tsconfig.test.json --noEmit   # typecheck test/ (the other half)
 pnpm test               # vitest: frontend unit tests (test/*.test.ts)
 pnpm coverage           # the same suites with v8 coverage
 ```
@@ -26,9 +27,20 @@ Rust backend (run from `src-tauri/`): `cargo check`, `cargo test`, `cargo build`
 
 ## Testing
 
-**Unit-only: there is no end-to-end harness**, though the suites are substantial: roughly 800 vitest + 180 cargo tests, run in CI on both OSes; `tsc` (strict) is the real linter. The render, view and DOM-owning modules on both sides are untested by design, since anything touching the DOM, PTYs or live telemetry is verified by running the app, and **`RELEASE.md` holds that manual checklist** plus the tag/verify steps. Coverage is a yardstick with no gate on it, deliberately (`docs/testing.md` for the numbers and the vitest reporter trap).
+**Unit-only: there is no end-to-end harness**, though the suites are substantial: roughly 1400 vitest + 250 cargo tests, run in CI on both OSes; `tsc` (strict) is the real linter. The render, view and DOM-owning modules on both sides are untested by design, since anything touching the DOM, PTYs or live telemetry is verified by running the app, and **`RELEASE.md` holds that manual checklist** plus the tag/verify steps. Coverage is a yardstick with no gate on it, deliberately (`docs/testing.md` for the numbers and the vitest reporter trap).
 
 - **vitest runs in the `node` environment**: no module a test can reach may touch a browser global at module scope: `document`, `window`, *or* `navigator`. Platform predicates live in `dom.ts` (`IS_MAC`, `IS_WIN`) behind a `typeof navigator` guard; import those.
+- **`test/` is typechecked by a SECOND tsconfig, and the split is load-bearing.** The suites
+  need `@types/node` (three contract tests parse source with `node:fs`); `src/` must never
+  have it, because it is bundled for a webview and the only thing stopping a `process.env`
+  from compiling there is that node's globals are absent. So `tsconfig.json` keeps
+  `"types": []` — **without it TypeScript auto-loads every package under `node_modules/@types`
+  and that guard silently dies the moment anything adds `@types/node`** — and
+  `tsconfig.test.json` extends it with `types: ["node", "vite/client"]` and an ES2022 lib.
+  `pnpm build` runs both, so CI gates both. src files are compiled under each project, but
+  only the base one gates them, which is what keeps the guard real. Tests went unchecked
+  until 0.22.0 and had drifted: a `Sess` fixture still carried a field deleted two PRs
+  earlier, and two `HistEntry` fixtures were missing a required one.
 - Three **contract tests parse source rather than call it**: `dispatch.test.ts` (a `[data-*]` branch is unreachable unless its attribute is in the dispatcher's `closest()` selector), `ipc.test.ts` (an `invoke("x", {…})` must pass exactly the arguments `#[tauri::command] fn x` declares, since Tauri rejects the whole invoke on one missing key) and `tour.test.ts` (a tour step's anchor must resolve in `index.html`, the rail legend it teaches must match `GLYPH`/`GCLASS`, and a card that says *Settings › Sounds* must name a tab `settings.ts` ships). The first two joins had silently broken in production before the tests existed; the third is the same shape.
 - Rust tests are in-file `#[cfg(test)] mod tests`, several driving real `git` or the real `tiny_http` server; there is deliberately no `src-tauri/tests/` dir. Two `#[ignore]`d tests run against the real `claude` CLI via `cargo test -- --ignored`, which is a `RELEASE.md` step rather than a CI one.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,6 +3,27 @@
 > Rules and their reasons, compressed. The full narratives live in git history (CLAUDE.md before the split). Trust the code over the docs when they disagree, and fix the doc in the same commit.
 
 - **Coverage is a yardstick with no gate on it**, because render/DOM modules are untested by design. As of 0.15.0: ~90% statements over the modules the suites load, ~21% over all of `src/`, ~71% Rust lines (`cargo llvm-cov --summary-only`). vitest's `text` reporter hides any file at 100% in all four columns, so use `--coverage.reporter=json-summary` for per-file truth.
+- **Two tsconfigs, and `"types": []` is the load-bearing line.** `tsconfig.json` covers
+  `src/`, `tsconfig.test.json` extends it for `test/`; `pnpm build` runs both, so CI gates
+  both. The suites need `@types/node` — `dispatch`/`ipc`/`tour` parse source with `node:fs`
+  rather than importing it, and `usage.test.ts` reads `process.env.TZ` — plus an ES2022 lib
+  for `Array.prototype.at`, and `vite/client` (that project does not include
+  `src/vite-env.d.ts`, whose triple-slash reference is how the base project gets the `?raw`
+  SVG imports). But `src/` must **not** see node's globals: it is bundled for a webview, and
+  nothing else stops a `process.env` from compiling. TypeScript auto-loads every package
+  under `node_modules/@types` when `types` is unset, so merely *installing* `@types/node`
+  as a devDependency hands them to `src/` too — `"types": []` in the base config is what
+  prevents that, and it is easy to delete without noticing anything broke. Both halves have
+  a negative test worth repeating after any change here: put `process.env.HOME` in a `src/`
+  module (base project must fail) and a deleted `Sess` field in a fixture (test project must
+  fail).
+- **The suites went unchecked until 0.22.0**, when `include` was `["src"]` alone, and they
+  had drifted exactly as you would expect: a `Sess` fixture still carried `subagents` two
+  PRs after it was replaced by `agents`, two `HistEntry` fixtures were missing a `provider`
+  that had become required, and `exitSound("claude", …)` named a `SessKind` that no longer
+  existed. vitest never noticed — it strips types rather than checking them, so all of it
+  passed green. A fixture that lies about its type is a test asserting against a shape the
+  app cannot produce.
 - **Clippy**: keep it clean; if a lint wants a real change rather than a tidy-up, `#[allow]` it with a comment saying why.
 - **The cfg flip**: swap every `cfg(windows)` ↔ `cfg(not(windows))` in `src-tauri/src`, re-run `cargo clippy --all-targets`, then `git checkout -- src-tauri/src` to revert. Limits: it doesn't touch `cfg(target_os = …)`/`cfg(unix)` (`reveal_path`'s unused `exists` is a known false positive), and flipping `target_os` fails hard: `rusqlite` is macOS-only and the windows arms need crates macOS hasn't got, so CI's macOS leg is the only check for macOS-only arms. **Commit or stash your real changes first**, because the reverting checkout reverts everything in that directory.
 - **Fixture paths**: `env::temp_dir()` is a symlink spelling on macOS (`/var/folders` → `/private/var/folders`) and an 8.3 short name on the Windows runner; `git` and `physical_cwd` resolve paths before answering, so an unresolved fixture path fails on spelling alone. `scratch_dir` resolves before it returns, so use it, always.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && tsc -p tsconfig.test.json && vite build",
     "preview": "vite preview",
     "test": "vitest run",
     "coverage": "vitest run --coverage",
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",
+    "@types/node": "^26.3.0",
     "@vitest/coverage-v8": "^4.1.10",
     "typescript": "~5.6.2",
     "vite": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.11.4
+      '@types/node':
+        specifier: ^26.3.0
+        version: 26.3.0
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
@@ -50,10 +53,10 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.3
-        version: 6.4.3
+        version: 6.4.3(@types/node@26.3.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@vitest/coverage-v8@4.1.10)(vite@6.4.3)
+        version: 4.1.10(@types/node@26.3.0)(@vitest/coverage-v8@4.1.10)(vite@6.4.3(@types/node@26.3.0))
 
 packages:
 
@@ -491,6 +494,9 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/node@26.3.0':
+    resolution: {integrity: sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==}
+
   '@vitest/coverage-v8@4.1.10':
     resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
     peerDependencies:
@@ -682,6 +688,9 @@ packages:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   vite@6.4.3:
     resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
@@ -1030,6 +1039,10 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/node@26.3.0':
+    dependencies:
+      undici-types: 8.3.0
+
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -1042,7 +1055,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@vitest/coverage-v8@4.1.10)(vite@6.4.3)
+      vitest: 4.1.10(@types/node@26.3.0)(@vitest/coverage-v8@4.1.10)(vite@6.4.3(@types/node@26.3.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -1053,13 +1066,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@6.4.3)':
+  '@vitest/mocker@4.1.10(vite@6.4.3(@types/node@26.3.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.3
+      vite: 6.4.3(@types/node@26.3.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -1254,7 +1267,9 @@ snapshots:
 
   typescript@5.6.3: {}
 
-  vite@6.4.3:
+  undici-types@8.3.0: {}
+
+  vite@6.4.3(@types/node@26.3.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.5)
@@ -1263,12 +1278,13 @@ snapshots:
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 26.3.0
       fsevents: 2.3.3
 
-  vitest@4.1.10(@vitest/coverage-v8@4.1.10)(vite@6.4.3):
+  vitest@4.1.10(@types/node@26.3.0)(@vitest/coverage-v8@4.1.10)(vite@6.4.3(@types/node@26.3.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@6.4.3)
+      '@vitest/mocker': 4.1.10(vite@6.4.3(@types/node@26.3.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -1285,9 +1301,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 6.4.3
+      vite: 6.4.3(@types/node@26.3.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 26.3.0
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -11,10 +11,10 @@ const sess = (id = "pane-1"): Sess => ({
   resumeId: id, branch: "main", worktree: null, title: "Codex",
   phase: "idle", phaseSince: 0, lastActivity: 0, attention: null,
   pendingCmd: "", pendingPermId: null, pendRisk: null, pendingPermissions: [], attnAt: 0, seenAt: 0,
-  subagents: 0, fanout: null, apiErr: null, drift: null,
+  agents: new Map(), fanout: null, apiErr: null, drift: null,
   model: "", ctxPct: null, ctxTokens: null, cost: null, durMs: null, tokenUsage: null, rateLimits: [], rateLimitScope: null,
   curTool: "", curArg: "", todos: [], ctxHist: [], costHist: [], git: null,
-  lastEvent: "", activity: [], files: [], tally: {}, kind: "agent", external: false,
+  lastEvent: "", activity: [], files: [], tally: {}, servers: [], kind: "agent", external: false,
   provider: "codex", capabilities: ["session-state", "activity", "context", "usage", "permissions", "resume", "history"],
   pane: {} as HTMLElement,
 });

--- a/test/dash.test.ts
+++ b/test/dash.test.ts
@@ -21,7 +21,7 @@ const dk = (back: number) => {
 };
 
 const hist = (o: Partial<HistEntry> = {}): HistEntry => ({
-  session_id: "s1", cwd: "/w/epi", project: "epi", branch: "main",
+  provider: "claude", session_id: "s1", cwd: "/w/epi", project: "epi", branch: "main",
   title: "a session", last_prompt: "", last_active: NOW / 1000, bytes: 10, exists: true,
   repo_root: "/w/epi", ...o,
 });

--- a/test/ghwork.test.ts
+++ b/test/ghwork.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import "./localstorage"; // must precede the subject imports
 import { CLAIM_STALE_MS, type ClaimRecord } from "../src/claim";
 import {
-  bucketOf, bucketed, byRecency, cardRows, closeComment, holderOf, isoDay, quietFor,
+  bucketOf, bucketed, cardRows, closeComment, holderOf, isoDay, quietFor,
   staleCandidates, STALE_DAYS, type GhThread, type KeptIssue,
 } from "../src/ghwork";
 

--- a/test/sound.test.ts
+++ b/test/sound.test.ts
@@ -274,8 +274,6 @@ describe("exitSound", () => {
   });
 
   it("treats anything else as merely having stopped, whatever the code", () => {
-    expect(exitSound("claude", 0)).toBe("ended");
-    expect(exitSound("claude", 1)).toBe("ended");
     expect(exitSound("shell", 0)).toBe("ended");
     // An agent pane has no verdict to report — only a task's exit code is one, and
     // reading a codex exit as taskFail would ring the failure chime on every quit.

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -276,7 +276,7 @@ describe("resolveDeps — VS Code names dependencies by label", () => {
   });
   it("resolves each label, in the order declared", () => {
     seed(run({ id: "npm:a", label: "a" }), run({ id: "npm:b", label: "b" }));
-    expect(resolveDeps(run({ dependsOn: ["b", "a"] }), new Set()).map((d) => d.label)).toEqual(["b", "a"]);
+    expect(resolveDeps(run({ dependsOn: ["b", "a"] }), new Set())?.map((d) => d.label)).toEqual(["b", "a"]);
   });
   // null and [] are different answers: "I could not resolve these" vs "there are
   // none". Returning [] for both is what used to run a task whose build had been

--- a/test/trail.test.ts
+++ b/test/trail.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { store } from "./localstorage"; // must precede the subject import
 import type { HistEntry } from "../src/history";
-import { usage, usageWindow, type UDay } from "../src/usage";
+import { usage, usageWindow } from "../src/usage";
 import {
   dayByProject, dayFacts, dayIsClosed, dayItems, dayKeyOf, deterministicHeadline, dominantProject,
   humanAuthors, projectDayFacts, sharedDay,
@@ -16,7 +16,7 @@ const at = (y: number, m: number, d: number, h = 12, min = 0) => new Date(y, m -
 const secs = (d: Date) => Math.floor(d.getTime() / 1000);
 
 const hist = (over: Partial<HistEntry> & { last_active: number }): HistEntry => ({
-  session_id: "s1", cwd: "/w/episko", project: "episko", branch: "dev",
+  provider: "claude", session_id: "s1", cwd: "/w/episko", project: "episko", branch: "dev",
   title: "", last_prompt: "", bytes: 10, exists: true, repo_root: "/w/episko",
   ...over,
 });
@@ -278,7 +278,6 @@ describe("what a day closed", () => {
 });
 
 describe("a day reads as one story, not two lists", () => {
-  const names = (k: string) => k.split("/").pop() || k;
   const sess = (id: string, whenMs: number) =>
     ({ id, title: id, project: "e", colorKey: "/w/e", branch: "", cwd: "/w", when: whenMs, exists: true });
   const cmt = (sha: string, whenSecs: number): TrailCommit =>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,15 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+
+    /* Ambient types: NONE automatically. Without this, TypeScript pulls in every package
+       under `node_modules/@types` — and since `@types/node` is a devDependency (for
+       `tsconfig.test.json`, which the suites need), that would hand node's globals to
+       `src/` as well. Nothing under `src/` may use them: it is bundled for a webview, so
+       a stray `process.env` has to fail here rather than at runtime. `vite/client` still
+       reaches this project through the triple-slash reference in `src/vite-env.d.ts`. */
+    "types": []
   },
   "include": ["src"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,25 @@
+// The suites, typechecked. Deliberately a second project rather than another entry in
+// `tsconfig.json`'s `include`, because the two halves need different ambient worlds and
+// merging them would cost a real guard:
+//
+//   · `test/` needs `@types/node` — three suites (dispatch, ipc, tour) parse source with
+//     `node:fs` rather than importing it, and `usage.test.ts` reads `process.env.TZ`.
+//   · `src/` must NOT have it. Nothing under `src/` may touch a node global: it is bundled
+//     for a webview, and today the only thing stopping `process.env` from compiling there
+//     is that the types are absent. Putting `test` into the base config would hand node's
+//     globals to `src/` too and quietly retire that check.
+//
+// src files still typecheck under BOTH projects (the suites import them), but only the
+// base config gates them, and it is the one without node types — so the guard survives.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // ES2022 for `Array.prototype.at`, which the suites use and the ES2020 lib lacks.
+    // Scoped here on purpose: `src/` stays on ES2020 until something there needs more.
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    // `vite/client` because `src/vite-env.d.ts` is not in this project's `include`, and
+    // without it the `?raw` SVG imports in `src/providers/logos.ts` have no declaration.
+    "types": ["node", "vite/client"]
+  },
+  "include": ["test"]
+}


### PR DESCRIPTION
`tsconfig.json` had `"include": ["src"]`, so `tsc` — the thing CLAUDE.md calls the real linter — never looked at `test/`. vitest strips types rather than checking them, so a fixture could claim a type it no longer matched and stay green forever. #111 flagged this as a known gap and left it out of scope; this is that PR.

## What had already drifted

All nine errors were real. None were noise, and every one is a fixture asserting against a shape the app cannot produce:

| Where | What |
|---|---|
| `agents.test.ts` | Built a `Sess` with `subagents` — replaced by `agents` in #110 — and without `servers` from #109. #101 added the file, and neither merge conflicted with it. |
| `dash.test.ts`, `trail.test.ts` | `HistEntry` fixtures missing `provider`, which #101 made required. |
| `sound.test.ts` | `exitSound("claude", …)` names a `SessKind` that no longer exists. The two `"agent"` cases below it already assert the same thing for code 0 and non-zero, so the lines went rather than being translated. |
| `tasks.test.ts` | `.map` on `resolveDeps`' `Runnable[] \| null`. Now `?.`, not `!` — a regression should fail as a clean assertion, not a TypeError. |
| `ghwork.test.ts`, `trail.test.ts` | Three dead symbols, including a `names` helper shadowed by a live one 126 lines above. |

## Why it is two tsconfigs and not one line

The halves need different ambient worlds:

- **`test/` needs `@types/node`** — `dispatch`/`ipc`/`tour` parse source with `node:fs` rather than importing it, and `usage.test.ts` reads `process.env.TZ`. Plus an **ES2022 lib** for `Array.prototype.at`, and **`vite/client`**, because that project does not include `src/vite-env.d.ts` — whose triple-slash reference is how the base project knows the `?raw` SVG imports in `providers/logos.ts`.
- **`src/` must have none of it.** It is bundled for a webview, and the absence of node's types is the only thing stopping a `process.env` from compiling there.

So `test/` gets its own project extending the base. src files compile under both, but only the base one gates them — which is what keeps the guard real.

## The line that is easy to delete without noticing

`"types": []`, now in the base config. TypeScript auto-loads **every** package under `node_modules/@types` when `types` is unset, so merely installing `@types/node` as a devDependency hands node's globals to `src/` too. The guard dies from the install, not from any edit to `src/` — I hit exactly this mid-change: the first version of this PR passed every gate while silently having retired it.

Verified by negative test in both directions, and the procedure is written into `docs/testing.md` so it can be repeated:

- `process.env.HOME` in a `src/` module → base project must fail. It does (`TS2591`).
- a deleted `Sess` field in a fixture → test project must fail. It does (`TS2561`).

## Gating

`pnpm build` is now `tsc && tsc -p tsconfig.test.json && vite build`, so CI gates both with no workflow change — only its comment was updated.

## Checks

`tsc` clean on both projects · **1403** vitest · **254** cargo · clippy `-D warnings` clean · `vite build` · no import cycles across 75 modules.

Docs updated in the same commit: `CLAUDE.md` (the commands block, the split and why `"types": []` matters, and the stale ~800/~180 test counts) and `docs/testing.md` (the full reasoning plus the negative-test procedure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)