### PR TITLE
fix: a cancelled Codex turn is not an outage, and a damaged preference is not a crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Markers: `+` new · `~` changed · `!` fixed
   rather than dropping the count back to zero and saying nothing. Nothing new is instrumented:
   it all rides the `PostToolUse` hook Episko already receives, and an idle server's log costs
   one length check rather than a read.
+
 + **A session the API kills overnight can now carry on by itself.** A 529, or a Wi-Fi
   interface that power-saved itself at 03:40, ends the turn — and the session then sits at
   its prompt until somebody types at it, which if it happened at midnight means eight
@@ -39,20 +40,6 @@ Markers: `+` new · `~` changed · `!` fixed
   it holds its attempts rather than spending them. The inspector's error card counts down
   to the next try; the only noise it makes is the moment it gives up and hands the session
   back to you.
-
-~ **Claude Code now gets a longer retry leash inside Episko.** Launches set
-  `CLAUDE_CODE_MAX_RETRIES=12` unless your own environment already sets it, which widens
-  the outage its own backoff rides out before the turn ends at all. A request that
-  eventually succeeds never needs the watchdog above.
-
-! **A Claude Code self-update no longer reads as 300 MiB of agent churn.** Claude Code
-  updates itself by writing a whole new ~290 MiB binary, and it does that inside a session
-  Episko launched — so the kernel charged those bytes to a `claude` process and the
-  inspector's disk figure showed a day's work having written thirty times what it really
-  did, in the first minute, on the first launch after a few days away. The update's own
-  size now comes back out of the figure and out of the rate beside it. Only bytes a new
-  binary on disk accounts for are ever discounted, so an agent writing hard still shows up
-  as an agent writing hard.
 
 + **And it asks the kernel, not just the output.** Episko now walks every listening TCP port
   back up the process tree to the pane it came from, so a server shows up whether or not
@@ -141,12 +128,40 @@ Markers: `+` new · `~` changed · `!` fixed
   transcript), and dispatching at a GitHub issue (the claim is handed back on a hook only
   Claude fires, so an uninstrumented agent would hold the issue forever).
 
+~ **Claude Code now gets a longer retry leash inside Episko.** Launches set
+  `CLAUDE_CODE_MAX_RETRIES=12` unless your own environment already sets it, which widens
+  the outage its own backoff rides out before the turn ends at all. A request that
+  eventually succeeds never needs the watchdog above.
+
 ~ **The diff overlay reviews like a pull request.** Expanding a working set used to give
   you the files back to back with nothing between them, so scrolling into the middle of one
   left nothing on screen saying which file you were in. There is now an **index down the
   left** — one row a file, grouped by folder, marking whichever file you are currently
   reading — and every **file header sticks** to the top while its file is under the pointer.
   Click a row in the index to go straight there.
+
+! **A Codex turn you stopped yourself is no longer treated as an outage.** Pressing Esc
+  in a Codex session reported the turn as *failed* rather than as stopped, which put the
+  red error card on the pane — and, with *Carry on after an API error* switched on, had
+  Episko type the prompt back in and press Enter about thirty seconds later, restarting
+  the work you had just cancelled. Only a real failure is a failure now; an unfamiliar
+  status still reports as one, because losing an error is worse than over-reporting it.
+
+! **A damaged preference no longer costs you the window.** Four keys — the per-project
+  agent, project colours, favourites and the sidebar order — were parsed at startup with
+  no guard, so a value truncated by a crash mid-write (or edited by hand) threw before
+  any of the app existed: a blank window, and no way in to clear the key that caused it.
+  Each one is now read for the shape it is meant to be, and anything else is discarded on
+  its own rather than taking the session with it.
+
+! **A Claude Code self-update no longer reads as 300 MiB of agent churn.** Claude Code
+  updates itself by writing a whole new ~290 MiB binary, and it does that inside a session
+  Episko launched — so the kernel charged those bytes to a `claude` process and the
+  inspector's disk figure showed a day's work having written thirty times what it really
+  did, in the first minute, on the first launch after a few days away. The update's own
+  size now comes back out of the figure and out of the rate beside it. Only bytes a new
+  binary on disk accounts for are ever discounted, so an agent writing hard still shows up
+  as an agent writing hard.
 
 ! **Keep-awake now survives the PC sleeping.** On Windows the assertion was set once and
   never re-stated, but Windows drops a thread's execution state across suspend/resume — so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,6 +277,14 @@ And the things that hold however the files are arranged:
 - **A turn that ended while its agents run on stays `background`.** The `Workflow` tool returns a run id in ~2s and `Stop` fires while its fleet runs for another twenty minutes, so `done` alone stopped meaning "your turn". `Sess.fanout` holds the run (named from the `PreToolUse{Workflow}` payload, with no disk and no backend) and **`Sess.agents` holds the agents still up, keyed by the `agent_id` both `Subagent*` hooks carry** — identity rather than a counter, for the same reason a tool call's Pre and Post pair by `tool_use_id`. Read it through `liveAgents`/`liveCount`, never by `.size`: an agent a *newer* fan-out inherited is stamped `orphanedAt` by `startFanout` and ages out on its own short window, because the hour that guards a live fleet only guards a ghost once the run that would report its Stop has been replaced (that is the "34 / 36" bug — see `docs/architecture.md`). `statusKey` answers `"background"` for a live fleet, and `needsYou` says no. **Never add a status to `GLYPH`/`GCLASS` without also adding it to `tray.ts`'s `SHAPE`**; see `docs/architecture.md`.
 - **A `localStorage` write on the telemetry path is a disk write**: statusLines land every ~10s per session. Three cadences, chosen deliberately: eager (`cc-usage`, small and unreconstructable), only-when-changed (`cc-cost-base`), floored and flushed on quit/midnight (`cc-usage-detail` 30s, `cc-io` 60s). Cap anything keyed by day. Sizes and reasoning: `docs/architecture.md`.
 - **Persistence is all `localStorage`**, every key prefixed `cc-`; `grep '"cc-'` for the current set.
+  **Every read of one narrows rather than trusts.** `state.ts` reads its preferences at
+  module scope in the module everything else imports, so a `JSON.parse` that throws there
+  is a blank window before any UI exists to say why — and a stored value is not safe just
+  because we wrote it (a crash mid-write truncates, and these are the keys people hand-edit).
+  A parseable value of the wrong shape is the sharper half: `"null"` and `"[]"` survive the
+  parse and only fail at the first property access, somewhere else entirely. Use `strMap` /
+  `strList` / `favList` / a `clamp*`, never a bare `JSON.parse`, and discard a bad value on
+  its own rather than letting it take the session (`test/state.test.ts`).
 - **Debug console** (🐞, bottom-right): in-app event log + live state via `dlog()`/`dbgSnapshot()`; flags unrouted telemetry and JS errors; mirrors a snapshot to `$TMPDIR/cc-launcher/episko-debug.json` for external tools. The snapshot is state-of-now and does not survive a crash. The durable timeline is the rolling `episko.log` (+ `panic.log`) in the OS app-log dir, which every `dlog()` tees into via `log_frontend` (`docs/architecture.md`).
 
 ## App-wide rules

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -226,6 +226,11 @@ function plan(v: unknown): Todo[] {
   })).filter((x) => x.content) : [];
 }
 
+/// Turn statuses that mean "somebody stopped this", not "this went wrong". Codex has
+/// used more than one spelling across versions, so this is a small set rather than a
+/// single equality test.
+const ABORTED: ReadonlySet<string> = new Set(["aborted", "cancelled", "canceled", "interrupted", "stopped"]);
+
 export function codexEvents(e: ProviderEvent): AgentEvent[] {
   const p = obj(e.params);
   const child = p.episkoChild === true;
@@ -246,7 +251,25 @@ export function codexEvents(e: ProviderEvent): AgentEvent[] {
     case "turn/started": return [{ type: "turn-started" }];
     case "turn/completed": {
       const t = obj(p.turn); const status = text(t.status);
-      return [{ type: "turn-completed", failed: status !== "completed", detail: clip(t.error), durationMs: Number.isFinite(t.durationMs) ? Number(t.durationMs) : null }];
+      // A turn the USER stopped is not a failure, and the distinction is load-bearing
+      // rather than cosmetic. `finishAgentTurn(s, true, …)` stamps a generic
+      // `apiErr {kind:"unknown"}`, which buckets as `other` in ./revive — a bucket that
+      // is ON in `REVIVE_DEFAULTS`. So with the watchdog enabled, pressing Esc in the
+      // Codex TUI was answered ~30s later by Episko typing the prompt back in and
+      // pressing Enter, restarting the exact work you had just cancelled. Revive's whole
+      // premise is "the API killed it, not you", and only the adapter can tell them
+      // apart.
+      //
+      // Unknown statuses still count as failures: reporting an outage that was really
+      // something else costs a retry, while silently calling a failure "done" loses the
+      // error card altogether. Same direction the item mappers above take.
+      const stopped = ABORTED.has(status);
+      return [{
+        type: "turn-completed",
+        failed: !stopped && status !== "completed",
+        detail: clip(t.error),
+        durationMs: Number.isFinite(t.durationMs) ? Number(t.durationMs) : null,
+      }];
     }
     case "item/started": case "item/completed": return itemEvents(e.method, p);
     case "turn/plan/updated": return [{ type: "plan", todos: plan(p.plan) }];

--- a/src/state.ts
+++ b/src/state.ts
@@ -37,13 +37,13 @@ const DEFAULT_FAVORITES: Favorite[] = [];
 // Re-derive each display name from its path on load: it's always the basename, and
 // this self-heals favorites persisted before the Windows-path fix (whose stored name
 // was the full backslash path).
-export let FAVORITES: Favorite[] = (JSON.parse(localStorage.getItem("cc-favorites") || "null") || DEFAULT_FAVORITES)
+export let FAVORITES: Favorite[] = favList(localStorage.getItem("cc-favorites"))
   .map((f: Favorite) => ({ ...f, name: basename(f.path) }));
 export function setFavorites(f: Favorite[]) { FAVORITES = f; }
 export function saveFavorites() { localStorage.setItem("cc-favorites", JSON.stringify(FAVORITES)); }
 // User-defined sidebar order (project path keys), set by drag-drop. Projects not
 // listed here keep their natural order after the listed ones.
-export let projOrder: string[] = JSON.parse(localStorage.getItem("cc-proj-order") || "null") || [];
+export let projOrder: string[] = strList(localStorage.getItem("cc-proj-order"));
 export function setProjOrder(o: string[]) { projOrder = o; }
 export function saveProjOrder() { localStorage.setItem("cc-proj-order", JSON.stringify(projOrder)); }
 // The user's named, collapsible groups of projects, and which project is in which.
@@ -171,10 +171,35 @@ function safeParse<T>(raw: string | null): Partial<T> | null {
   try { return raw ? JSON.parse(raw) : null; } catch { return null; }
 }
 
+/// The three narrowing reads the preferences above use. Declarations, so they hoist to
+/// the readers near the top of the file.
+///
+/// Every one of these runs at MODULE SCOPE in the module everything else imports, so a
+/// `JSON.parse` that throws here is not a broken preference — it is a blank window, with
+/// no in-app surface left to clear the key that caused it. "It was valid when we wrote
+/// it" is not a guarantee either: a crash mid-write truncates, and these keys are the
+/// ones people hand-edit. So each one *narrows* rather than trusts, and anything that is
+/// not the shape the app then indexes into is discarded whole — the cost is one forgotten
+/// preference instead of the session. `loadPermissionModes` below already did this.
+function strMap(raw: string | null): Record<string, string> {
+  const v = safeParse<Record<string, string>>(raw);
+  if (!v || typeof v !== "object" || Array.isArray(v)) return {};
+  return Object.fromEntries(Object.entries(v).filter(([, m]) => typeof m === "string")) as Record<string, string>;
+}
+function strList(raw: string | null): string[] {
+  const v = safeParse<string[]>(raw);
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+}
+function favList(raw: string | null): Favorite[] {
+  const v = safeParse<Favorite[]>(raw);
+  if (!Array.isArray(v)) return DEFAULT_FAVORITES;
+  return v.filter((f): f is Favorite => !!f && typeof f === "object" && typeof f.path === "string");
+}
+
 // A hand-picked accent per project path, overriding the hash below. A `const` map
 // mutated in place (like `sessions`), so it needs no setter; the colour picker in
 // main.ts still owns writing it back to localStorage.
-export const colorOverrides: Record<string, string> = JSON.parse(localStorage.getItem("cc-colors") || "{}");
+export const colorOverrides: Record<string, string> = strMap(localStorage.getItem("cc-colors"));
 // The project accent. Here rather than in format.ts because it reads the override
 // map above, and format.ts must not depend on state (this module already imports
 // it). Same hash seeds branch colours, so the sidebar's colour language is one.
@@ -308,8 +333,7 @@ export function setDefaultAgent(id: string) { defaultAgent = id; }
 // inherits one answer. Same shape and the same reasoning as `cc-task-onstop`: a
 // personal preference, in localStorage, never a committed project fact — a colleague
 // opening the same repo keeps whichever agent *they* drive.
-export const agentByProject: Record<string, string> =
-  JSON.parse(localStorage.getItem("cc-agent-by-project") || "{}");
+export const agentByProject: Record<string, string> = strMap(localStorage.getItem("cc-agent-by-project"));
 export function setProjectAgent(colorKey: string, id: string | null) {
   if (id) agentByProject[colorKey] = id; else delete agentByProject[colorKey];
 }

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -52,6 +52,30 @@ describe("Codex provider adapter", () => {
       .toMatchObject({ type: "permission", id: "ask-1", tool: "Bash", risk: "high" });
   });
 
+  // A turn you stopped yourself must not look like an outage. The chain this guards is
+  // four modules long and every link already existed: `failed: true` → `finishAgentTurn`
+  // stamps `apiErr {kind:"unknown"}` → ./revive buckets `unknown` as `other` → `other` is
+  // in `REVIVE_DEFAULTS.kinds`, so the watchdog types the prompt back in and presses
+  // Enter. Asserting on `failed` alone would pass against the bug for the wrong reason,
+  // so this asserts the thing that actually matters: no `apiErr` on the session.
+  it("treats a turn somebody stopped as done, not as a failure to be revived", () => {
+    for (const status of ["aborted", "cancelled", "canceled", "interrupted", "stopped"]) {
+      const s = sess();
+      for (const ev of codexEvents(raw("turn/completed", { turn: { status } }))) applyAgentEvent(s, ev);
+      expect(s.apiErr, `${status} stamped an apiErr`).toBeNull();
+      expect(s.phase, `${status} left the pane in error`).toBe("done");
+    }
+  });
+
+  it("still reports a real failure, and an unfamiliar status, as one", () => {
+    for (const status of ["failed", "some_status_codex_adds_later"]) {
+      const s = sess();
+      for (const ev of codexEvents(raw("turn/completed", { turn: { status, error: "500 upstream" } }))) applyAgentEvent(s, ev);
+      expect(s.apiErr, `${status} lost its error`).not.toBeNull();
+      expect(s.phase).toBe("error");
+    }
+  });
+
   it("keeps child tools and approvals while ignoring child lifecycle", () => {
     const child = { threadId: "child-1", episkoChild: true };
     expect(codexEvents(raw("turn/completed", { ...child, turn: { status: "completed" } }))).toEqual([]);

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { store } from "./localstorage"; // must precede the subject import
+
+// `state.ts` is the module every other module imports, and it reads its preferences at
+// MODULE SCOPE. So a `JSON.parse` that throws in here is not a lost preference — it is a
+// blank window, before any UI exists to tell you why or to clear the key that did it.
+//
+// A stored value is not trustworthy just because we wrote it: a crash mid-write leaves
+// truncated JSON, and these are exactly the keys people hand-edit. Same staging as
+// `usage.test.ts`'s "ignores a corrupt baseline key rather than failing to boot" — seed
+// the key, evaluate the module again, and assert it came up.
+//
+// The shapes below are chosen because each one gets PAST a plain `JSON.parse` and only
+// fails later, at the first property access, far away from here. `"null"` and `"[]"`
+// parse perfectly.
+const boot = async () => { vi.resetModules(); return import("../src/state"); };
+
+describe("state.ts boots whatever localStorage holds", () => {
+  beforeEach(() => { store.clear(); });
+
+  it("survives a truncated write of every key it reads at import time", async () => {
+    for (const k of ["cc-agent-by-project", "cc-colors", "cc-favorites", "cc-proj-order"]) {
+      store.clear();
+      store.set(k, '{"a":');     // what a crash mid-write leaves behind
+      await expect(boot(), `${k} took the app down`).resolves.toBeTruthy();
+    }
+  });
+
+  it("refuses a parseable value of the wrong shape, rather than passing it on", async () => {
+    // Each of these parses, so only a shape check catches it. `null` is the sharp one:
+    // `agentByProject[key]` on it throws at the project menu, not here.
+    for (const raw of ["null", "[]", '"a string"', "42"]) {
+      store.clear();
+      store.set("cc-agent-by-project", raw);
+      store.set("cc-colors", raw);
+      const s = await boot();
+      expect(s.agentByProject, `cc-agent-by-project = ${raw}`).toEqual({});
+      expect(s.colorOverrides, `cc-colors = ${raw}`).toEqual({});
+    }
+  });
+
+  it("keeps the good entries out of a half-corrupt map", async () => {
+    store.set("cc-agent-by-project", JSON.stringify({ "/w/a": "codex", "/w/b": 7, "/w/c": null }));
+    const s = await boot();
+    expect(s.agentByProject).toEqual({ "/w/a": "codex" });
+  });
+
+  it("keeps a list a list, and drops entries that are not paths", async () => {
+    store.set("cc-proj-order", JSON.stringify(["/w/a", 7, null, "/w/b"]));
+    store.set("cc-favorites", JSON.stringify([{ path: "/w/a", name: "stale" }, { name: "no path" }, null]));
+    const s = await boot();
+    expect(s.projOrder).toEqual(["/w/a", "/w/b"]);
+    // The name is re-derived from the path on load, which is the existing self-heal.
+    expect(s.FAVORITES).toEqual([{ path: "/w/a", name: "a" }]);
+  });
+
+  it("still reads a well-formed value", async () => {
+    // The other half of the contract: narrowing must not throw the good data away.
+    store.set("cc-agent-by-project", JSON.stringify({ "/w/epi": "codex" }));
+    store.set("cc-proj-order", JSON.stringify(["/w/epi"]));
+    const s = await boot();
+    expect(s.agentByProject).toEqual({ "/w/epi": "codex" });
+    expect(s.projOrder).toEqual(["/w/epi"]);
+  });
+});


### PR DESCRIPTION
The two highest-severity findings from the 0.22.0 review. Both are silent, and one only exists because two PRs that never met in CI now share a branch.

## A Codex turn you cancelled restarted itself

`turn/completed` mapped `failed: status !== "completed"`, so Esc in the Codex TUI was a failure. The chain from there was already fully built:

`failed: true` → `finishAgentTurn` stamps `apiErr {kind:"unknown"}` → `reviveKind("unknown")` is not terminal and not networkish, so it buckets as `other` → **`other` is in `REVIVE_DEFAULTS.kinds`** → with *Carry on after an API error* switched on, `tickRevive` types `REVIVE_PROMPT` and presses **Enter** about thirty seconds later, restarting the work you had just cancelled.

Revive's whole premise is *"the API killed it, not you"*, and only the adapter can tell those apart. This is the one place in the app that presses Enter unattended, which is what makes it worth fixing rather than noting.

Worth seeing: the item mappers directly above already used the positive `item.status === "failed"`. Only the turn used the negative `!== "completed"`. An unfamiliar status still reports as a failure — losing an error card is worse than over-reporting one, and that matches what the item mappers do.

This became reachable when #114 (revive) and #101 (the Codex adapter) landed on the same branch; neither PR's CI could see it alone.

## A damaged preference cost you the window

Four keys were read at module scope with a bare `JSON.parse`: `cc-agent-by-project`, `cc-colors`, `cc-favorites`, `cc-proj-order`. `state.ts` is imported by everything, so a value truncated by a crash mid-write threw **before any UI existed** — blank window, and no in-app surface left to clear the key that caused it.

The parseable-but-wrong shapes are the sharper half: `"null"` and `"[]"` survive `JSON.parse` and only fail at the first property access, somewhere else entirely. `agentByProject["/w/x"]` on `null` throws in the project menu, nowhere near the cause.

`loadPermissionModes` in the same file already narrowed for exactly this reason. These four did not, so they now do — via `strMap` / `strList` / `favList`, each discarding a bad value on its own instead of taking the session with it. The review named only `cc-agent-by-project`; the other three are the same statement pattern two lines away, and fixing one while leaving its twins would have been odd.

## Both suites were checked against the bug they replace

Neither is vacuous, which matters here because both fixes are the kind that pass trivially if you assert the wrong thing:

- Restoring the `turn/completed` mapping → **1 of the new agent tests fails**. It deliberately asserts `s.apiErr === null` rather than `failed === false`, because asserting on the flag would pass against the bug for the wrong reason.
- Restoring the four parses → **4 of the 5 in the new `test/state.test.ts` fail**. The fifth asserts well-formed data still loads and must pass either way.

`test/state.test.ts` follows `usage.test.ts`'s existing "ignores a corrupt baseline key rather than failing to boot" staging: seed the key, `vi.resetModules()`, re-import.

## Checks

tsc clean on both projects · **1461** vitest (7 new) · **254** cargo · clippy `-D warnings` clean · `pnpm build` · no import cycles.

CLAUDE.md gains the persistence rule this establishes: every `localStorage` read narrows rather than trusts, and why the parseable-but-wrong shape is the one to design against.

## Still open from the review

Twelve findings remain — the `health` measurement cluster is next in its own PR. The rest (`panes.ts` favicon probe, `diffview` copy dropping the truncation caveat, unbounded `cc-agent-token-base`, `pollServers` scanning before its early return, the `pty.rs` runtime leak, the `agent.rs` port TOCTOU, and two cleanups) are unaddressed so far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)