### PR TITLE
fix(health): a `#` comment is a comment, and Copy findings keeps its caveat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,8 +161,12 @@ Markers: `+` new · `~` changed · `!` fixed
   (`&'a str`) was read as an opening quote, which blanked the rest of its line — taking the
   brace with it, and skewing every span and depth measured after it in that file. CSS,
   SCSS, Bash and Kotlin-script files were measured by the backend and then never chipped,
-  because the two halves of the source-extension list had drifted apart. And a single
-  silenced error described itself as "This change addsline 42".
+  because the two halves of the source-extension list had drifted apart. A single
+  silenced error described itself as "This change addsline 42". A `#` comment in a Python
+  or shell file was read as code, so prose like `# never use a bare except:` earned a red
+  chip. And **Copy findings** rebuilt its set-level chips without the report, dropping the
+  *partial sweep* caveat from the text it hands to a session — the one line that says the
+  measurement is incomplete.
 
 ! **A Claude Code self-update no longer reads as 300 MiB of agent churn.** Claude Code
   updates itself by writing a whole new ~290 MiB binary, and it does that inside a session

--- a/src/diffview.ts
+++ b/src/diffview.ts
@@ -64,6 +64,12 @@ let activeFile = -1;
 // chips and a file not yet measured render identically, which is correct — neither is
 // making a claim.
 let chips: Chip[][] = [];
+// The report those chips came from, kept so the copy handler can rebuild the SAME
+// set-level chips the gate below and `renderSetChips` computed. It improvised with
+// `null` before, which dropped "partial sweep" / "findings incomplete" from the copied
+// text — precisely the caveat ./health added them to carry — and, when those were the
+// only findings, showed a button that copied "No code-health findings".
+let healthRep: HealthReport | null = null;
 // Bumped by every open, and captured by the measurement in flight. An answer whose
 // generation is stale belongs to a diff that is no longer on screen: opening one folder,
 // closing it and opening another must not paint the first one's chips on the second.
@@ -78,6 +84,7 @@ export async function openDiff(workdir: string, title: string, focus?: string) {
   focusPath = focus || "";
   files = [];
   chips = [];
+  healthRep = null;
   activeFile = -1;
   gen++;
   $("scrim").classList.add("show");
@@ -198,6 +205,7 @@ async function measureHealth(workdir: string, mine: number) {
   }
   // The overlay may have been closed, or reopened on another folder, while we measured.
   if (!diffOpen || mine !== gen) return;
+  healthRep = rep;
   const byPath = new Map(rep.files.map((h) => [h.path, h]));
   // The project's own thresholds when it set any, the defaults where it did not.
   const prefs = clampHealth(rep.prefs);
@@ -465,7 +473,7 @@ $("diffBody").addEventListener("click", (e) => {
 // raises an OS permission prompt (CLAUDE.md).
 $("diffCopy").addEventListener("click", () => {
   const title = `${$("diffTitle").textContent} · ${$("diffSub").textContent}`.trim();
-  const text = findingsText(title, files, chips, setChips(files, null));
+  const text = findingsText(title, files, chips, setChips(files, healthRep, !!$("diffBody").querySelector(".diff-trunc")));
   void writeText(text)
     .then(() => toast("Findings copied — paste them into a session"))
     .catch(() => toast("Couldn't reach the clipboard"));

--- a/src/health.ts
+++ b/src/health.ts
@@ -111,7 +111,22 @@ const SILENCED: { re: RegExp; what: string; inComment: boolean }[] = [
 /// A line that is nothing but a comment, for the patterns that are not themselves ones.
 /// Deliberately crude — the exact rule is per language and lives in `health.rs`; here it
 /// only has to stop a prose line mentioning `as any` from being read as code doing it.
+///
+/// Per path, because the marker is: `# never use a bare except:` in a Python file failed
+/// the brace-family test below, was probed as code, and earned a red chip — the exact
+/// false-positive class the CHANGELOG incident above is about, in the `#`-comment
+/// languages instead of prose. A SWITCH rather than a union of both markers, since in C
+/// a line-start `#` is a preprocessor directive — code, not commentary — and uniting
+/// them would silence real findings there. The `inComment: true` patterns (`# noqa`,
+/// `@ts-ignore`) are unaffected either way: they match regardless of the answer here.
 const COMMENTISH = /^\s*(\/\/|\*|\/\*)/;
+const HASH_COMMENTISH = /^\s*#/;
+/// The `#`-comment half of `isSourcePath`'s list, plus the configs the diff also shows.
+const HASH_EXTS = new Set(["py", "pyi", "rb", "sh", "bash", "zsh", "yml", "yaml", "toml"]);
+function commentishFor(path: string): RegExp {
+  const ext = path.includes(".") ? path.slice(path.lastIndexOf(".") + 1).toLowerCase() : "";
+  return HASH_EXTS.has(ext) ? HASH_COMMENTISH : COMMENTISH;
+}
 
 /// Blank the contents of string literals, so a line that *documents* a pattern is not
 /// read as a line that *does* it.
@@ -149,10 +164,11 @@ function blankLiterals(line: string): string {
 /// rather than of the diff.
 export function silencedIn(f: DiffFile): { line: number; what: string }[] {
   const out: { line: number; what: string }[] = [];
+  const commentish = commentishFor(f.path);
   for (const h of f.hunks) {
     for (const l of h.lines) {
       if (l.kind !== "add") continue;
-      const comment = COMMENTISH.test(l.text);
+      const comment = commentish.test(l.text);
       const probe = comment ? l.text : blankLiterals(l.text);
       for (const s of SILENCED) {
         if ((s.inComment || !comment) && s.re.test(probe)) {

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -65,6 +65,24 @@ describe("silencedIn", () => {
     expect(silencedIn(f)).toEqual([]);
   });
 
+  it("knows a Python comment when the file is Python", () => {
+    // `# never use a bare except:` failed the brace-family comment test, was probed as
+    // code, and earned a red chip — the prose false positive above, in the `#`-comment
+    // languages. The marker is read off the path, and it is a switch rather than a union
+    // of both markers: in C a line-start `#` is a directive, which is code.
+    const py = file("a.py", add("# never use a bare except: it hides everything", 3));
+    expect(silencedIn(py)).toEqual([]);
+    const sh = file("deploy.sh", add("# don't add eslint-disable style pragmas here", 4));
+    expect(silencedIn(sh).map((s) => s.what)).toEqual(["`eslint-disable`"]); // inComment: true still fires
+    const c = file("a.c", add("#define GUARD catch (e) {}", 9));
+    expect(silencedIn(c)).toHaveLength(1); // a C directive is code, not commentary
+  });
+
+  it("still finds the real thing under a hash comment two lines up", () => {
+    const f = file("a.py", add("# tolerate flaky reads", 6), add("except:", 7));
+    expect(silencedIn(f)).toEqual([{ line: 7, what: "a bare `except:`" }]);
+  });
+
   it("does fire on the ones that are comments by nature", () => {
     // @ts-ignore only ever appears in a comment; skipping comment lines would make the
     // rule unreachable rather than conservative.


### PR DESCRIPTION
The two findings from the pre-release light review, both in the health surface and both verified by tracing before fixing.

## `silencedIn` read a `#` comment as code

`COMMENTISH` knew only the brace-family markers (`//`, `*`, `/*`), so `# never use a bare except:` in a Python file failed the comment test, was probed as code, and matched the bare-`except:` pattern — the CHANGELOG-incident false-positive class the module exists to avoid, in the `#`-comment languages instead of prose.

The marker is now read off the path (`commentishFor`). Two decisions worth a look:

- **A switch, not a union.** Uniting both markers into one regex would be simpler — and wrong for C, where a line-start `#` is a preprocessor directive: code, not commentary, and a directive containing a matchable pattern should still chip.
- **The `inComment: true` patterns are untouched.** `# noqa` and `@ts-ignore` match regardless of the comment test's answer, so the fix cannot un-find the silencers that legitimately live in comments — and there's a test asserting that under the new path.

Tests fail against the bug (checked by reverting the fix: 1 of the new tests fails).

## Copy findings dropped the caveat it exists to carry

The health report was local to `measureHealth`, so the copy handler improvised with `setChips(files, null)` while the button's visibility gate used `setChips(files, rep)`. Two consequences, one worse than the other:

- The copied text lost the **partial sweep / findings incomplete** chips — the one line telling the receiving session the measurement didn't cover everything, on a surface whose premise is that the text is acted on unread.
- When those were the *only* findings, the button showed but copied "No code-health findings…" — the dead-button case the gate's own comment says it prevents.

The latest report now lives in module state beside `chips`, cleared on every open and stamped behind the same generation check `measureHealth` already uses, and the handler rebuilds the same chips the header renders — truncation flag included. The handler and the gate now read the same state, so they can no longer disagree.

`diffview` is DOM-owning and untested by design; the health half carries the tests.

## Checks

tsc clean on both projects · **1465** vitest (2 new) · **256** cargo (untouched) · `pnpm build` · CHANGELOG's existing health entry extended rather than a new one, since both bugs are in unreleased 0.22.0 code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)