### PR TITLE
signing: sign and notarize the macOS build

### DIFF
--- a/.github/release-install.md
+++ b/.github/release-install.md
@@ -3,15 +3,10 @@
 **macOS (Apple Silicon)**
 
 1. Download **Episko_*_aarch64.dmg** from the assets below.
-2. Episko is self-signed (not notarized by Apple), so macOS Gatekeeper blocks the first launch. Clear the quarantine flag once:
-   ```sh
-   xattr -dr com.apple.quarantine ~/Downloads/Episko_*.dmg
-   ```
-3. Open the `.dmg`, drag **Episko** into Applications, and launch it. If it's still blocked:
-   ```sh
-   xattr -dr com.apple.quarantine /Applications/Episko.app
-   ```
-Apple Silicon (M-series) only — Intel Macs aren't supported by this build.
+2. Open the `.dmg`, drag **Episko** into Applications, and launch it.
+
+Signed and notarized by Apple (Respeak GmbH), so there's no quarantine warning and nothing to
+clear by hand. Apple Silicon (M-series) only — Intel Macs aren't supported by this build.
 
 **Windows (x64)**
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,8 @@ name: release
 # their updater artifact. Every job targets the SAME tag, so tauri-action appends
 # its assets to the one GitHub Release and merges each platform into a single
 # latest.json the app's updater reads. The minisign key signs the updater artifacts
-# on every platform (OS code-signing is separate and not configured).
+# on every platform. OS code-signing is separate and OPT-IN per platform: each leg
+# detects its own secret and builds unsigned when it is absent (src-tauri/SIGNING.md).
 on:
   push:
     tags:
@@ -76,6 +77,32 @@ jobs:
         if: steps.sign.outputs.enabled == 'true'
         run: cargo install trusted-signing-cli
 
+      # macOS code-signing + notarization (Apple Developer ID) is OPT-IN on the same
+      # pattern: gated on APPLE_CERTIFICATE. Without it the mac leg builds ad-hoc
+      # signed exactly as before, and users clear quarantine by hand.
+      - name: Detect macOS signing secrets
+        id: macsign
+        if: matrix.platform == 'macos-latest'
+        shell: bash
+        run: |
+          if [ -n "${{ secrets.APPLE_CERTIFICATE }}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # notarytool wants the App Store Connect key as a FILE, so the base64 secret is
+      # materialised into the runner's temp dir and its path exported for the build
+      # step and the DMG step below. $RUNNER_TEMP is wiped when the job ends.
+      - name: Materialise the App Store Connect API key
+        if: steps.macsign.outputs.enabled == 'true'
+        shell: bash
+        run: |
+          KEY="$RUNNER_TEMP/AuthKey.p8"
+          echo "${{ secrets.APPLE_API_KEY_P8 }}" | base64 --decode > "$KEY"
+          chmod 600 "$KEY"
+          echo "APPLE_API_KEY_PATH=$KEY" >> "$GITHUB_ENV"
+
       # Install instructions ride in every release body so the top-of-list (latest)
       # release always carries them — GitHub cannot pin a release, so "always in the
       # newest one" is the equivalent. A tag with no changelog section still releases:
@@ -106,6 +133,13 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          # Apple Developer ID: the bundler imports the .p12 into a temporary keychain
+          # itself, then notarizes the .app with the API key and staples the ticket.
+          # All inert on Windows and when the secrets are absent.
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "Episko ${{ github.ref_name }}"
@@ -122,4 +156,35 @@ jobs:
           # When Windows signing is enabled, merge the signCommand overlay via
           # --config so tauri-action signs the .exe, NSIS setup, and .msi; otherwise
           # pass the matrix args unchanged (unsigned, as today).
-          args: ${{ steps.sign.outputs.enabled == 'true' && format('{0} --config src-tauri/tauri.signing.conf.json', matrix.args) || matrix.args }}
+          # The signingIdentity lives in the overlay rather than tauri.conf.json so a
+          # local `tauri build` stays ad-hoc and needs no certificate.
+          args: >-
+            ${{ steps.sign.outputs.enabled == 'true' && format('{0} --config src-tauri/tauri.signing.conf.json', matrix.args)
+             || steps.macsign.outputs.enabled == 'true' && format('{0} --config src-tauri/tauri.macos.signing.conf.json', matrix.args)
+             || matrix.args }}
+
+      # tauri-action notarizes and staples the .app, then builds the .dmg FROM that
+      # stapled app — but never notarizes the disk image itself, and the .dmg is what
+      # users download, so it is the file carrying the quarantine flag. Unnotarized it
+      # still raises "Apple could not verify this app is free of malware" on the first
+      # open, which is the whole friction signing exists to remove. Verified with
+      #   spctl -a -t open --context context:primary-signature -vv <dmg>
+      # ('-t install' is for installer packages and reports a misleading verdict on a
+      # disk image). The updater's .app.tar.gz needs nothing: the ticket is a plain
+      # file at Contents/CodeResources, stapled before the tarball is made.
+      - name: Notarize and staple the DMG
+        if: steps.macsign.outputs.enabled == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          DMG=$(ls src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg)
+          xcrun notarytool submit "$DMG" --wait \
+            --key-id "${{ secrets.APPLE_API_KEY }}" \
+            --key "$APPLE_API_KEY_PATH" \
+            --issuer "${{ secrets.APPLE_API_ISSUER }}"
+          xcrun stapler staple "$DMG"
+          spctl -a -t open --context context:primary-signature -vv "$DMG"
+          # tauri-action already uploaded the un-stapled .dmg under this name.
+          gh release upload "${{ github.ref_name }}" "$DMG" --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
+~ **macOS builds are signed by Respeak GmbH and notarized by Apple.** Installing is now
+  download, drag, open — the `xattr -dr com.apple.quarantine` dance is gone, and so is the
+  first-launch block. The reason this was worth doing is less visible than Gatekeeper:
+  macOS ties a folder-access grant to an app's *designated requirement*, and an ad-hoc
+  bundle has none that outlives a build — its requirement is literally the hash of that one
+  binary. So every release looked like a brand-new app and re-asked for Documents, Desktop,
+  Downloads and the microphone, which at a release every other day meant permission prompts
+  that never stayed answered no matter how often you clicked Allow. Signed, the requirement
+  names the team and the bundle id instead, which survives every rebuild and a certificate
+  renewal. **One last round of prompts on first launch after updating** — the old grants were
+  keyed to hashes that no longer exist — and then they stick. Signing is opt-in in CI and
+  gated on the certificate secret, so a fork or a local `tauri build` still produces an
+  ad-hoc bundle and needs no Apple account. The `.dmg` is notarized separately from the
+  `.app`, because the bundler notarizes what goes *inside* the disk image and not the image
+  itself, and the disk image is the file that carries the quarantine flag.
+
 ## 0.22.0 — 2026-08-25
 
 Episko runs the other coding agents too, and which one starts is a setting rather

--- a/src-tauri/SIGNING.md
+++ b/src-tauri/SIGNING.md
@@ -16,8 +16,9 @@ Three independent "signings" — do **not** conflate them:
 3. **macOS code-signing + notarization (Apple Developer ID)** — a **separate** Apple
    account (~99 $/yr). The Azure profile **cannot** sign macOS binaries. Notarization sits
    **on top of** Developer ID signing (Apple malware-scan + a stapled ticket); it does not
-   replace signing. Not configured yet — Episko is ad-hoc signed (`signingIdentity: "-"`)
-   and users clear quarantine with `xattr` (see the release notes in `release.yml`).
+   replace signing. **Configured** — see *macOS* below. A local `tauri build` still produces
+   an ad-hoc bundle, because the identity lives in an overlay CI merges rather than in
+   `tauri.conf.json`.
 
 ## Windows — activate Azure Trusted Signing
 
@@ -111,12 +112,111 @@ Microsoft's `signtool` + `Azure.CodeSigning.Dlib.dll` + a `metadata.json`, exact
 After signing works, drop the "isn't code-signed / SmartScreen may warn" line from the
 Windows section of `releaseBody` in `release.yml`.
 
-## macOS — separate track (not done)
+## macOS — Apple Developer ID
 
-Would need an Apple **Developer ID Application** cert + **notarization** (both, not either):
-set `bundle.macOS.signingIdentity` to the Developer ID, and give tauri-action
-`APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_PASSWORD` (app-specific
-password), `APPLE_TEAM_ID`. Own decision, own account — the Azure profile does not help here.
+Team **Q9P3NQ4858** (Respeak GmbH), identity `Developer ID Application: Respeak GmbH
+(Q9P3NQ4858)`, committed in `src-tauri/tauri.macos.signing.conf.json` and merged by
+`release.yml` via `--config` only when `APPLE_CERTIFICATE` exists. `tauri.conf.json` keeps
+`signingIdentity: "-"`, so a local build needs no certificate and nothing changes for a
+contributor who has none.
+
+### Why this is not cosmetic
+
+Gatekeeper is the visible half. The half that actually drove the work is **TCC**: macOS keys
+a folder-access grant to the app's *designated requirement*, and an ad-hoc bundle has no
+stable one — `codesign -d -r-` printed `designated => cdhash H"…"`, the hash of that exact
+binary. Every release therefore looked like a brand-new app and re-asked for Documents,
+Desktop, Downloads and the microphone. At roughly a release every other day that is a prompt
+storm, and no amount of clicking Allow ever stuck. Signed, the requirement reads
+
+    identifier "io.respeak.episko" and anchor apple generic
+      and certificate leaf[subject.OU] = Q9P3NQ4858
+
+which is stable across every rebuild, and across a certificate renewal within the same team.
+**After the first signed release each machine needs one reset**, since the old cdhash rows
+match nothing:
+
+```sh
+for s in SystemPolicyDocumentsFolder SystemPolicyDesktopFolder \
+         SystemPolicyDownloadsFolder Microphone; do
+  tccutil reset $s io.respeak.episko
+done
+```
+
+### The five repo secrets
+
+| Secret | What |
+| --- | --- |
+| `APPLE_CERTIFICATE` | base64 of the Developer ID `.p12` (cert **and** private key) |
+| `APPLE_CERTIFICATE_PASSWORD` | the `.p12` export password |
+| `APPLE_API_ISSUER` | App Store Connect issuer id (UUID) |
+| `APPLE_API_KEY` | App Store Connect key id |
+| `APPLE_API_KEY_P8` | base64 of the `.p8` private key |
+
+There is deliberately **no `APPLE_SIGNING_IDENTITY`**: the identity is not a secret and lives
+in the committed overlay, the same way the Azure account/profile do. Notarization uses an App
+Store Connect **Team Key** (needs all three of issuer/key-id/`.p8`) rather than an Apple ID +
+app-specific password, so it is not tied to one person's Apple ID. The Apple ID route still
+works if the key is ever unavailable — `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID` — but
+then only that person can release.
+
+`notarytool` wants the key as a **file**, so `release.yml` decodes `APPLE_API_KEY_P8` into
+`$RUNNER_TEMP` and exports `APPLE_API_KEY_PATH`.
+
+### The DMG is a second notarization, and tauri-action does not do it
+
+The bundler notarizes and staples the `.app`, then builds the `.dmg` **from** that stapled
+app and signs it — and stops. But the `.dmg` is what a user downloads, so it is the file that
+carries the quarantine flag, and an unnotarized disk image still raises *"Apple could not
+verify this app is free of malware"* on first open. That is the entire friction signing
+exists to remove, so `release.yml` submits the `.dmg` separately, staples it, and re-uploads
+it over the copy tauri-action already pushed (`gh release upload --clobber`).
+
+Check a disk image with the **disk-image** assessment, not the installer one:
+
+```sh
+spctl -a -t open --context context:primary-signature -vv <dmg>   # accepted
+spctl -a -t install -vv <dmg>                                    # MISLEADING on a .dmg
+```
+
+The updater's `.app.tar.gz` needs nothing extra: the ticket is a plain file at
+`Contents/CodeResources`, written before the tarball is built, and tar preserves it.
+
+### Verifying a build
+
+```sh
+codesign -dv --verbose=4 <app>   # TeamIdentifier=Q9P3NQ4858, flags=…(runtime), no `adhoc`
+codesign -d -r- <app>            # team-anchored DR, and NO cdhash
+spctl -a -vvv <app>              # accepted, source=Notarized Developer ID
+xcrun stapler validate <app>
+```
+
+`codesign -d -r-` is the one that matters. If a `cdhash` is still in the designated
+requirement, signing silently fell back to ad-hoc and nothing downstream is worth checking.
+
+### The certificate itself
+
+Created manually (Keychain Access CSR → developer.apple.com → **Developer ID Application** →
+**G2 Sub-CA**; "Previous Sub-CA" is for toolchains older than Xcode 11.4.1). Required role is
+**Account Holder** — an Admin cannot create one this way, only a cloud-managed variant.
+
+Two facts worth keeping in view. A team gets **five** Developer ID Application certificates
+ever, valid five years; you burn slots by re-issuing on each machine rather than importing
+the `.p12`. And the `.cer` Apple hands back is only the public half — the signing capability
+is the private key generated locally by the CSR, so **a lost private key is a lost
+certificate**, not something re-downloadable.
+
+One certificate covers the whole team, every product. Schwärzwerk on macOS would reuse this
+one; it is Windows signing that is separate (#2 above).
+
+### Where the material lives
+
+The KeePassXC vault, under `Respeak/Signing`: `Developer ID Application (Respeak)` with the
+`.p12` attached and its export password, `Apple notarization (Episko)` with the `.p8`
+attached plus key id / issuer id, and `Tauri updater key (Episko)` with `muster.key`. That
+last one is the irreplaceable one — its public half is compiled into `tauri.conf.json`, so
+losing it means no installed copy of Episko can ever update again. Pull material out with
+`keepassxc-cli attachment-export` rather than keeping loose copies on disk.
 
 ## Local build (no Azure / Tim values needed)
 
@@ -131,3 +231,16 @@ pnpm tauri build
 
 A throwaway key means the produced updater `.sig` won't verify against real releases — fine
 for just building and running the app locally. Use the real CI secret for an actual release.
+
+A local macOS build is **ad-hoc** unless you ask for otherwise, since the identity is in the
+overlay rather than `tauri.conf.json`. To reproduce a release build locally (certificate in
+your keychain, notarization credentials exported):
+
+```sh
+export APPLE_API_ISSUER=… APPLE_API_KEY=… APPLE_API_KEY_PATH=…/AuthKey_XXXX.p8
+pnpm tauri build --config src-tauri/tauri.macos.signing.conf.json
+```
+
+Add `--config '{"bundle":{"createUpdaterArtifacts":false}}'` to skip the minisign key
+entirely when all you want to check is signing. Expect the **first ever** submission from a
+new team to take ~35 minutes; later ones are under a minute.

--- a/src-tauri/tauri.macos.signing.conf.json
+++ b/src-tauri/tauri.macos.signing.conf.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "macOS": {
+      "signingIdentity": "Developer ID Application: Respeak GmbH (Q9P3NQ4858)"
+    }
+  }
+}


### PR DESCRIPTION
Signs and notarizes the macOS build with the Respeak GmbH Developer ID, so releases stop re-asking for folder permissions.

## Why

macOS keys a TCC folder grant to the app's *designated requirement*. An ad-hoc bundle has none that outlives a build — `codesign -d -r-` printed `designated => cdhash H"ec313b00…"`, the hash of that one binary. Every release therefore looked like a brand-new app and re-asked for Documents, Desktop, Downloads and the microphone, and at a release every other day no amount of clicking Allow ever stuck.

Signed, the requirement reads `identifier "io.respeak.episko" and anchor apple generic and certificate leaf[subject.OU] = Q9P3NQ4858` — stable across every rebuild, and across a certificate renewal within the same team. Gatekeeper (no more `xattr`) is the visible half; this was the half that actually hurt.

## Shape

Opt-in on the existing Windows pattern — gated on `APPLE_CERTIFICATE`, with the identity in `src-tauri/tauri.macos.signing.conf.json` merged via `--config` rather than in `tauri.conf.json`, so a local `tauri build` and a fork stay ad-hoc and need no Apple account.

`notarytool` wants the App Store Connect key as a *file*, so `APPLE_API_KEY_P8` is decoded into `$RUNNER_TEMP` and `APPLE_API_KEY_PATH` exported.

## The DMG is a second notarization

tauri-action notarizes and staples the `.app`, then builds the `.dmg` **from** that stapled app and stops. But the `.dmg` is what users download, so it is the file carrying the quarantine flag, and unnotarized it still raises *"Apple could not verify this app is free of malware"* on first open. A post-build step submits it, staples it, asserts `spctl` accepts it, and re-uploads over the copy tauri-action already pushed.

Checking a disk image needs the disk-image assessment; `-t install` is for installer packages and reports a misleading verdict on a `.dmg`.

The updater's `.app.tar.gz` needs nothing — the ticket is a plain file at `Contents/CodeResources`, stapled before the tarball is built.

## Verified locally

Full chain proven end to end on a real build before any of this was wired:

```
codesign -d -r-   → identifier "io.respeak.episko" … certificate leaf[subject.OU] = Q9P3NQ4858   (no cdhash)
codesign -dv      → TeamIdentifier=Q9P3NQ4858, flags=0x10000(runtime), adhoc gone, timestamped
spctl (app)       → accepted, source=Notarized Developer ID
spctl (dmg)       → accepted, after the separate submission
stapler validate  → both
```

First-ever submission from the new team took ~35 minutes; the second took under one. That appears to be new-account overhead rather than anything about the setup.

## Note for whoever installs the first signed build

The designated requirement changes, so the old cdhash-keyed grants match nothing and you get **one** last round of permission prompts, then they stick:

```sh
for s in SystemPolicyDocumentsFolder SystemPolicyDesktopFolder SystemPolicyDownloadsFolder Microphone; do
  tccutil reset $s io.respeak.episko
done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)