### PR TITLE
perf: stop paying for animation and blur nobody is looking at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
++ Settings › Appearance › Visual effects: switches for animations, background blur, and
+  whether Episko keeps animating once the window is behind something else.
+~ Episko stops animating the moment the window loses focus, and picks up where it left
+  off when you come back. An animation you cannot see is telling you nothing, and every
+  one of them was holding the compositor at the monitor's refresh rate — which on a
+  144Hz Windows desktop is two and a half times the work it is on a 60Hz Mac.
+! Seventeen dialogs, popovers and scrims no longer blur what is behind them while they
+  are closed. They stay mounted at zero opacity so they can fade, and each was keeping a
+  live GPU render surface to frost a panel nobody could see.
+
 ## 0.23.0 — 2026-08-26
 
 **Signed and notarized by Apple.** Nothing to clear on install.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,13 +101,13 @@ The disk-I/O accounting behind `io_samples`/`io_retired` (run vs. day vs. all-ti
 - **Telemetry server** (`run_telemetry_server`) forwards `/hook` and `/statusline` POSTs as one `telemetry` event each; `/permission` is the blocking path described above.
 - Commands are registered in the `invoke_handler![...]` list at the bottom of `run()`; add new `#[tauri::command]` fns there.
 
-## Frontend (`src/`, `index.html`, `src/styles.css`): 76 modules
+## Frontend (`src/`, `index.html`, `src/styles.css`): 77 modules
 
 **No framework, and no longer one file.** 76 modules; `main.ts` is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing, so follow this render-everything pattern rather than mutating DOM directly. **`renderAll()` is coalesced**: a call only marks the pass due, and one flush per animation frame paints whatever state every event in that frame left behind, so a telemetry burst from N sessions costs a single paint. The rAF is paired with a 250ms `setTimeout` fallback, and that is not belt-and-braces: rAF never fires while the window is hidden, and the tray this pass repaints is exactly the surface being read then. The 🐞 console counts paints beside received events (`paints` in the stats line), so the batching is checkable while the app runs.
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (the seam map, which belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, the window controls (see docs/native-ui.md), and the `setInterval`s.
 
-**Tested logic modules** (thirty-one, with no DOM, no Tauri and no render imports; these are what the vitest suites cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it, plus `dispatch.test.ts` and `ipc.test.ts` which read source instead of importing it):
+**Tested logic modules** (thirty-two, with no DOM, no Tauri and no render imports; these are what the vitest suites cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it, plus `dispatch.test.ts` and `ipc.test.ts` which read source instead of importing it):
 
 | Module | What |
 | --- | --- |
@@ -145,6 +145,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 | `sound.ts` | which moments are worth hearing, the tones as data, and (the hard part) what stops a fleet becoming a fruit machine |
 | `keys.ts` | the bindable actions, a chord's parse/format/match, what happens when a rebind takes a chord somebody else had, and what the master switch turns off |
 | `footprefs.ts` | which segments the status bar shows: the table, the store, its repair, and why three of them have no switch |
+| `motion.ts` | which visual effects may cost a GPU frame: the table, the store, and the classes `<html>` carries for the two standing switches plus the background pause |
 | `tour.ts` | the guided tour's chapters and rules: when the picker is offered, what a step waits for, which panel its anchor needs open, and why a release intro is just a chapter (see docs/tour.md) |
 | `revive.ts` | carrying on after the API kills a turn: which failures a retry can fix, the backoff ladder, and the three things it must never type into |
 
@@ -276,6 +277,22 @@ And the things that hold however the files are arranged:
 - **A turn the API killed ends in `error`.** `StopFailure` sets `Sess.apiErr`; **`endTurn` is the single place that decides done vs. error**; every surface reads `phaseText(s)`, never `PILL_TEXT[s.phase]` directly. The trap (a 60s idle nudge that relabels the failure) shipped once; see `docs/architecture.md`.
 - **A turn that ended while its agents run on stays `background`.** The `Workflow` tool returns a run id in ~2s and `Stop` fires while its fleet runs for another twenty minutes, so `done` alone stopped meaning "your turn". `Sess.fanout` holds the run (named from the `PreToolUse{Workflow}` payload, with no disk and no backend) and **`Sess.agents` holds the agents still up, keyed by the `agent_id` both `Subagent*` hooks carry** — identity rather than a counter, for the same reason a tool call's Pre and Post pair by `tool_use_id`. Read it through `liveAgents`/`liveCount`, never by `.size`: an agent a *newer* fan-out inherited is stamped `orphanedAt` by `startFanout` and ages out on its own short window, because the hour that guards a live fleet only guards a ghost once the run that would report its Stop has been replaced (that is the "34 / 36" bug — see `docs/architecture.md`). `statusKey` answers `"background"` for a live fleet, and `needsYou` says no. **Never add a status to `GLYPH`/`GCLASS` without also adding it to `tray.ts`'s `SHAPE`**; see `docs/architecture.md`.
 - **A `localStorage` write on the telemetry path is a disk write**: statusLines land every ~10s per session. Three cadences, chosen deliberately: eager (`cc-usage`, small and unreconstructable), only-when-changed (`cc-cost-base`), floored and flushed on quit/midnight (`cc-usage-detail` 30s, `cc-io` 60s). Cap anything keyed by day. Sizes and reasoning: `docs/architecture.md`.
+- **An infinite animation and a `backdrop-filter` are a per-frame GPU cost, not a
+  one-off.** Each pins the WebView2 compositor to the monitor's refresh rate for as long
+  as it exists — 144Hz on a Windows desktop against the 60 this was designed at, which is
+  why the complaint arrived from Windows and not from the Mac. Two rules follow. **A
+  dialog that stays mounted at `opacity: 0` must not keep its blur**: seventeen do (that
+  is what lets them fade), and each was a live render surface for a panel nobody can see,
+  so the blur is gated on `:not(.show)`. And **the switches are ./motion's table and
+  nothing else** — `fx-still` (cancel), `fx-flat` (no blur) and `fx-idle` (paused while
+  the window is in the background, applied by main.ts's `onFocusChanged`), all put on
+  `<html>` by ./actions' `applyFx`. `fx-still` is a deliberate *superset* of the OS's own
+  `prefers-reduced-motion: reduce` — it flattens every transition where reduce names
+  eight and tames a ninth — but the two must agree on the four **substitutes**, the
+  places where an animation carries a state rather than decorating one and ending it
+  would delete information; `test/motion.test.ts` fails if those lists drift apart.
+  The cancel and the pause are separate on purpose — a paused animation resumes
+  mid-cycle, where a cancelled one would restart every session's glyph in lockstep.
 - **Persistence is all `localStorage`**, every key prefixed `cc-`; `grep '"cc-'` for the current set.
   **Every read of one narrows rather than trusts.** `state.ts` reads its preferences at
   module scope in the module everything else imports, so a `JSON.parse` that throws there

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -36,9 +36,11 @@ import {
   revivePrefs, setRevivePrefs as setRevivePrefsState,
   sortMode, setWtGroup as setWtGroupState, wtGroup,
   cmpBase, setCmpBase as setCmpBaseState,
+  motionPrefs, setMotionPrefs as setMotionPrefsState, winFocused, setWinFocused as setWinFocusedState,
   type SortMode, type WtGroup,
 } from "./state";
 import { footPrefsJson, toggleFootSeg, type FootSeg } from "./footprefs";
+import { ALL_FX_CLASSES, motionPrefsJson, rootFxClasses, toggleFx, type VisualFx } from "./motion";
 import {
   assignGroup, cleanGroupName, collapseAll, createGroup, deleteGroup, groupById,
   renameGroup, setCollapsed, type GroupStore,
@@ -417,6 +419,38 @@ export function setFootSeg(id: FootSeg) {
   setFootPrefs(toggleFootSeg(footPrefs, id));
   localStorage.setItem("cc-foot", footPrefsJson(footPrefs));
   renderAll();
+}
+
+/// Switch one visual effect on or off.
+///
+/// Here rather than in ./state for the usual reason: a setter there assigns and nothing
+/// else, so the persist and — in this case — the class that actually makes the change
+/// visible belong to the call site, and this is it.
+export function setFx(id: VisualFx) {
+  setMotionPrefsState(toggleFx(motionPrefs, id));
+  localStorage.setItem("cc-motion", motionPrefsJson(motionPrefs));
+  applyFx();
+}
+
+/// Put the current effect state on `<html>`, where the stylesheet reads it.
+///
+/// Every class ./motion can produce is removed before the current set is added, rather
+/// than each site toggling its own: the two inputs (the prefs and the window's focus)
+/// change independently and at unrelated moments, so a per-class toggle would need every
+/// caller to know about every class. Called on startup, on a pref change, and on each
+/// focus change.
+export function applyFx() {
+  const root = document.documentElement;
+  root.classList.remove(...ALL_FX_CLASSES);
+  root.classList.add(...rootFxClasses(motionPrefs, winFocused));
+}
+
+/// The window gained or lost focus. Cheap enough to call on every event — `applyFx` is
+/// three class operations and the browser no-ops a class list that did not change.
+export function setWindowFocused(v: boolean) {
+  if (v === winFocused) return;
+  setWinFocusedState(v);
+  applyFx();
 }
 export function toggleRail() { $("app").classList.toggle("rail-mini"); }
 // ⌘I / ◨. On a session this hides the inspector outright — nothing in it is

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ import {
   revealTouchedFile,
   copyPath, openTerminalIn, setActionsRenderAll, setAttnPrefs, setDefaultAgent, setKeyPrefs,
   setPeekPrefs, setPermMode, setProjectAgent, setRevivePrefs,
-  setFootSeg, setSort, setSoundPrefs, setTheme, setWtGroup, setCmpBase, tickRevive,
+  setFootSeg, setFx, applyFx, setWindowFocused, setSort, setSoundPrefs, setTheme, setWtGroup, setCmpBase, tickRevive,
   toggleInsp, toggleProjGroup, toggleRail, toggleTheme,
 } from "./actions";
 import { playSound, setSoundLogger } from "./chime";
@@ -156,6 +156,10 @@ void (async () => {
 // `IS_WIN` (a user-agent read) would hand a Chrome tab three buttons that can
 // only throw.
 if (IS_TAURI) document.documentElement.classList.add(IS_MAC ? "mac" : IS_WIN ? "win" : "linux");
+// Paint the stored visual-effect switches onto <html> before the first frame, so a
+// machine that has turned animation off never gets one — a class added after the first
+// paint would start every infinite animation and then cancel it.
+applyFx();
 
 // index.html hard-codes the mac glyphs; rewrite its static bits once on other
 // platforms (everything rendered from TS goes through MOD/chord instead, which now
@@ -262,7 +266,7 @@ setSettingsHost({
   setWtGroup, setPermMode, setDefaultAgent, setPeekPrefs, setSoundPrefs, setKeyPrefs, setAttnPrefs,
   setRevivePrefs,
   startTour: startChapter,
-  setFootSeg,
+  setFootSeg, setFx,
 });
 // The tour drives the app the way a user would, so the two things it cannot do itself
 // are typing into a pane and opening the window it just told you about.
@@ -839,6 +843,36 @@ if (IS_TAURI && (IS_MAC || IS_WIN)) {
   void win.onResized(() => { void syncWin(); });
   void syncWin();
 }
+
+// Stop animating while you are looking at something else.
+//
+// Every infinite animation in the stylesheet keeps the WebView2 compositor producing
+// frames at the monitor's refresh rate for as long as it runs, and none of them are
+// telling you anything while the window is behind your editor — which, for a fleet
+// watcher, is most of the day. So focus drives a class on <html> (see ./motion) and the
+// stylesheet pauses the lot.
+//
+// Tauri's `onFocusChanged` rather than the DOM's `focus`/`blur` where it exists: the
+// webview fires those for its own internal focus moves (clicking from a pane into the
+// sidebar blurs the textarea), and what matters here is the OS window, which is the only
+// thing that decides whether the animation is on a screen anybody is looking at. The DOM
+// pair is the fallback for `pnpm dev` in a plain browser, where there is no Tauri window
+// to ask.
+//
+// `visibilitychange` is a third source and not a duplicate of either: minimising leaves
+// a window "focused" as far as some compositors are concerned, and a fully occluded
+// window is the case where the saving is total.
+if (IS_TAURI) {
+  void getCurrentWindow().onFocusChanged(({ payload }) => setWindowFocused(payload));
+} else {
+  window.addEventListener("focus", () => setWindowFocused(true));
+  window.addEventListener("blur", () => setWindowFocused(false));
+}
+document.addEventListener("visibilitychange", () => {
+  // Only ever a way to *lose* animation, never to regain it: coming back visible does
+  // not mean coming back focused, and the focus listener above is what says so.
+  if (document.hidden) setWindowFocused(false);
+});
 $("railCollapse").addEventListener("click", toggleRail);
 $("railSort").addEventListener("click", cycleSort);
 $("inspBtn").addEventListener("click", toggleInsp);

--- a/src/motion.ts
+++ b/src/motion.ts
@@ -1,0 +1,128 @@
+// Which visual effects the app is allowed to spend a GPU on — the model behind
+// Settings › Appearance › Visual effects.
+//
+// Episko is a fleet watcher: the window sits open all day, often behind an editor,
+// often with nothing happening in it. Three things in the chrome cost a GPU frame
+// whether or not anything moved, and on Windows they cost noticeably more than on the
+// Mac this was designed on — WebView2 composites through DComp/D3D11 at the monitor's
+// refresh rate, and a Windows desktop is routinely 144Hz or better where a MacBook is
+// 60. The same stylesheet is therefore two-and-a-half times the work per second on the
+// machines that have complained about it.
+//
+// What is switchable, and why each is a separate switch rather than one "performance
+// mode": they fail differently. Animation is *information* here (a pulsing glyph is how
+// a busy session is told from a finished one at a glance in the rail), so somebody may
+// want to keep it and lose the blur. Blur is decoration only, so it is the first thing
+// most people will turn off and it costs nothing to lose. And the background pause is
+// neither — it is a straight win nobody trades anything for, which is why it defaults on
+// and is listed last.
+//
+// Pure logic, no DOM and no Tauri: the table, the store, its repair, and the class list
+// the root element wants. The applying is ./actions' (`applyFx`), on the same split as
+// ./footprefs and ./projgroups.
+
+/// A switchable effect. The order here is the order Settings lists them in.
+export type VisualFx = "motion" | "blur" | "idle";
+
+export interface VisualFxDef {
+  id: VisualFx;
+  /// The class `applyFx` puts on `<html>` when this effect is switched **off**. One
+  /// place joins the id to the stylesheet, so a rename cannot half-land.
+  cls: string;
+  label: string;
+  hint: string;
+}
+
+export const VISUAL_FX: readonly VisualFxDef[] = [
+  {
+    id: "motion", cls: "fx-still", label: "Animations",
+    hint: "The pulsing rail glyphs, the inspector's heartbeat, the loading shimmers and the panel fades. Switching this off is what the OS's own reduce-motion setting already does — Episko follows that too, so if you have set it system-wide this row is already answered.",
+  },
+  {
+    id: "blur", cls: "fx-flat", label: "Background blur",
+    hint: "The frosted glass behind dialogs, popovers and the command palette. Decoration only: with it off the same panels get a solid background, which is cheaper to composite and identical to read.",
+  },
+  {
+    id: "idle", cls: "fx-idle", label: "Keep animating in the background",
+    hint: "Off, Episko stops animating the moment the window loses focus and picks up again when you come back — nothing is lost, since an animation you cannot see is telling you nothing. Leave it off unless you keep the window visible beside something else and want the rail moving while you work there.",
+  },
+];
+
+const IDS = new Set<string>(VISUAL_FX.map((f) => f.id));
+
+/// What is switched **off**, rather than what is on.
+///
+/// Same reasoning as ./footprefs' `hidden`: an effect added in a later version cannot
+/// appear in a list written before it existed, so it arrives switched on, which is the
+/// right answer for a new thing nobody has opted out of yet. A record of booleans would
+/// hand every existing user `undefined` for it and force a `?? true` at each read — one
+/// that is easy to leave out at exactly one of them.
+///
+/// `idle` is the one whose *plain English* runs the other way ("keep animating in the
+/// background" is the expensive answer), and it is worded that way deliberately so the
+/// store stays uniform: in this list, present means off means cheap, for all three.
+export interface MotionPrefs { off: VisualFx[] }
+
+export const DEFAULT_MOTION: MotionPrefs = { off: ["idle"] };
+
+/// Read the stored value, keeping only ids this build knows.
+///
+/// An unknown id is dropped rather than carried: it would otherwise ride along forever,
+/// and an effect that is *renamed* would come back switched off for everyone who had
+/// turned its predecessor off. Anything unparseable falls back to the defaults, which is
+/// a state you can see and fix rather than a blank one you cannot.
+///
+/// A **first run** (`raw === null`) is not the same as an empty stored list: it takes
+/// `DEFAULT_MOTION`, which pauses in the background. Someone who has explicitly switched
+/// that on has `{ off: [] }` on disk, and must not be quietly re-defaulted at every start.
+export function parseMotionPrefs(raw: string | null): MotionPrefs {
+  if (raw === null) return { off: [...DEFAULT_MOTION.off] };
+  try {
+    const v = JSON.parse(raw) as { off?: unknown };
+    if (!Array.isArray(v.off)) return { off: [...DEFAULT_MOTION.off] };
+    const off = v.off.filter((x): x is VisualFx => typeof x === "string" && IDS.has(x));
+    return { off: [...new Set(off)] };
+  } catch {
+    return { off: [...DEFAULT_MOTION.off] };
+  }
+}
+
+export function motionPrefsJson(p: MotionPrefs): string {
+  return JSON.stringify({ off: p.off });
+}
+
+/// Is this effect on? The one predicate every reader goes through.
+export function fxOn(p: MotionPrefs, id: VisualFx): boolean {
+  return !p.off.includes(id);
+}
+
+/// Flip one effect, returning a new value — the store is replaced, never mutated, so a
+/// caller cannot accidentally skip the persist by having already changed what it holds.
+export function toggleFx(p: MotionPrefs, id: VisualFx): MotionPrefs {
+  if (!IDS.has(id)) return p;
+  return fxOn(p, id) ? { off: [...p.off, id] } : { off: p.off.filter((x) => x !== id) };
+}
+
+/// The classes `<html>` should carry, given the prefs and whether the window has focus.
+///
+/// Returned as a list rather than applied here because this module owns no DOM — and
+/// because returning it is what lets a test state the whole truth table in one place.
+///
+/// `fx-idle` is the one that is not a straight read of the store: it means "animation is
+/// suppressed *right now* because you are looking at something else", so it depends on
+/// focus as well as the pref. It is deliberately independent of `fx-still` rather than
+/// folded into it — the two answer different questions ("never animate" vs. "not while
+/// you are away"), and the stylesheet pauses for one and cancels for the other, because
+/// a paused animation resumes mid-cycle where a cancelled one restarts.
+export function rootFxClasses(p: MotionPrefs, focused: boolean): string[] {
+  const out: string[] = [];
+  if (!fxOn(p, "motion")) out.push("fx-still");
+  if (!fxOn(p, "blur")) out.push("fx-flat");
+  if (!fxOn(p, "idle") && !focused) out.push("fx-idle");
+  return out;
+}
+
+/// Every class this module can ever put on the root, so `applyFx` can clear the ones it
+/// is not setting without knowing which those are. Deriving it from the same table the
+/// setter reads is what keeps "add an effect" a one-line change.
+export const ALL_FX_CLASSES: readonly string[] = [...VISUAL_FX.map((f) => f.cls)];

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -18,6 +18,7 @@ import { agentCapabilitySummary, type Engine } from "./types";
 import { agentLogo } from "./providers/logos";
 import {
   allAgents, attnPrefs, availEngines, defaultAgentDef, engineDef, footPrefs,
+  motionPrefs,
   keyPrefs, missingAgents,
   peekPrefs, permissionModeFor, revivePrefs,
   setTermFontSize,
@@ -36,6 +37,7 @@ import {
 } from "./revive";
 import { LIT_COLOR } from "./sidebarview";
 import { FOOT_SEGS, footShown, type FootSeg } from "./footprefs";
+import { fxOn, VISUAL_FX, type VisualFx } from "./motion";
 import {
   bindKey, bindableCombo, comboKeys, comboOf, comboText, defaultKeyBinds, defaultKeyPrefs,
   isDefaultBind, isDefaultKeyPrefs, keyActionDef, KEY_GROUPS, resetKey, unbindKey,
@@ -96,6 +98,7 @@ export interface SettingsHost {
   // And for the status bar's segments — ./actions flips one through ./footprefs,
   // persists the hidden list, and repaints the bar.
   setFootSeg: (id: FootSeg) => void;
+  setFx: (id: VisualFx) => void;
   // And for the revive watchdog — ./actions clamps through ./revive, persists, and
   // repaints (the inspector's error card carries the countdown, so `renderAll`).
   setRevivePrefs: (p: RevivePrefs) => void;
@@ -140,7 +143,7 @@ let host: SettingsHost = {
   setTheme: () => {}, effectiveTheme: () => "dark", setSort: () => {}, setEngine: () => {},
   bumpFont: () => {}, applyFontSize: () => {}, refreshTokens: () => {},
   setWtGroup: () => {}, setPermMode: () => {}, setDefaultAgent: () => {}, setPeekPrefs: () => {}, setSoundPrefs: () => {},
-  setKeyPrefs: () => {}, setAttnPrefs: () => {}, setFootSeg: () => {}, setRevivePrefs: () => {},
+  setKeyPrefs: () => {}, setAttnPrefs: () => {}, setFootSeg: () => {}, setFx: () => {}, setRevivePrefs: () => {},
 };
 export function setSettingsHost(h: SettingsHost) { host = h; }
 
@@ -327,6 +330,17 @@ const SET_TABS: SetTab[] = [
           { value: "dark",  label: "Dark",  glyph: "☾", sub: "Dim surfaces" },
         ] },
       { kind: "font", label: "Terminal font size", hint: "Text size in embedded terminals (also ⌘+ / ⌘− / ⌘0)." },
+      // Visual effects. The note carries the reason once rather than each row repeating
+      // it, and the rows come straight off ./motion's table — there is no second list
+      // here to fall out of step with the stylesheet.
+      {
+        kind: "note", label: "Visual effects",
+        hint: "Episko sits open all day, so anything that animates or blurs is a GPU frame spent whether or not you are looking. These cost the most on a high-refresh Windows display, where the compositor redraws 144 times a second rather than 60. Nothing here changes what the app tells you — only how it draws it.",
+      },
+      ...VISUAL_FX.map((fx): SetControl => ({
+        kind: "toggle", set: `fx:${fx.id}`, label: fx.label, hint: fx.hint,
+        on: () => fxOn(motionPrefs, fx.id),
+      })),
     ],
   },
   {
@@ -1139,6 +1153,8 @@ function applySetting(set: string, val: string) {
   // `foot:<id>` rather than seven names in this chain: the ids are ./footprefs' and
   // adding a segment there should not mean editing a switch statement here too.
   else if (set.startsWith("foot:")) host.setFootSeg(set.slice(5) as FootSeg);
+  // `fx:<id>` for the same reason as `foot:` above — the ids are ./motion's table.
+  else if (set.startsWith("fx:")) host.setFx(set.slice(3) as VisualFx);
   else if (set === "untrust") untrustProject(val);
   else if (set === "unstop") clearStopRule(val);
   renderSettings();

--- a/src/state.ts
+++ b/src/state.ts
@@ -31,6 +31,7 @@ import { clampSoundPrefs, type SoundPrefs } from "./sound";
 import { agentInstalled, CLAUDE_CLI, pickAgent } from "./types";
 import type { AgentCli, DiffStat, Engine, ExtSession, Res, Restorable, Sess, WtHead } from "./types";
 import { parseFootPrefs, type FootPrefs } from "./footprefs";
+import { parseMotionPrefs, type MotionPrefs } from "./motion";
 
 export interface Favorite { name: string; path: string }
 const DEFAULT_FAVORITES: Favorite[] = [];
@@ -428,3 +429,17 @@ export const ioAll: Res = { readBps: 0, writeBps: 0, readMb: 0, writtenMb: 0, pr
 // permanently, so there is nothing left to cycle and nothing left to expand.
 export let footPrefs: FootPrefs = parseFootPrefs(localStorage.getItem("cc-foot"));
 export function setFootPrefs(p: FootPrefs) { footPrefs = p; }
+
+// Which visual effects are allowed to cost a GPU frame. The table, its repair and every
+// mutation of it are in ./motion; this is only where the parsed value lives and what
+// `applyFx` reads. Written through ./actions' `setFx`, per the
+// setters-assign-and-nothing-else rule.
+export let motionPrefs: MotionPrefs = parseMotionPrefs(localStorage.getItem("cc-motion"));
+export function setMotionPrefs(p: MotionPrefs) { motionPrefs = p; }
+
+// Whether the app window currently has focus. Not persisted — it is a fact about right
+// now, not a preference — and held here rather than read from `document.hasFocus()` at
+// each use because the webview and the OS window disagree during a drag, and the OS is
+// the one that decides whether you can see the animation.
+export let winFocused = true;
+export function setWinFocused(v: boolean) { winFocused = v; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -3247,3 +3247,107 @@ select.in-ctl { cursor: pointer; }
 /* The inspector's error card, when the watchdog owns the outcome: this note replaces
    "send the prompt again" and must not read as the same passive advice. */
 .attn-note.revive { color: var(--accent-ink); font-weight: 600; }
+
+/* ==========================================================================
+   Visual effects — Settings › Appearance, and the background pause
+   ==========================================================================
+   Episko's window sits open all day, usually behind an editor, usually with
+   nothing happening in it. Two things in this stylesheet cost a GPU frame
+   whether or not anything moved: an infinite animation, which pins the
+   WebView2 compositor to the monitor's refresh rate for as long as it runs,
+   and a `backdrop-filter`, which forces its own render surface and a readback
+   of everything behind it. Both are two-and-a-half times the work on a 144Hz
+   Windows desktop that they are on the 60Hz Mac this was designed on, which is
+   why the complaint arrived from Windows.
+
+   The classes come from ./motion via ./actions' `applyFx`; the ids and their
+   labels live in that table, so a switch added there is a switch here and
+   nowhere else. */
+
+/* ---- a closed dialog is not a backdrop ----------------------------------
+   Unconditional, and not a preference: seventeen dialogs, popovers and scrims
+   stay mounted at `opacity: 0` rather than `display: none`, because that is
+   what lets them fade. A transparent layer paints nothing — but a
+   `backdrop-filter` on it still promotes a render surface and keeps a
+   backdrop root alive, so the app was carrying seventeen live blur surfaces
+   at rest to fade in at most one of them.
+
+   Gating on `:not(.show)` rather than adding `visibility: hidden` to each
+   deliberately: `.show` is already the universal open flag (`.cfm` is the one
+   that also flips visibility, and it needed a `visibility 0s .14s` transition
+   of its own to keep its fade). Touching seventeen `transition` shorthands to
+   repeat that trick is a lot of risk for a fade nobody sees; removing the
+   filter costs nothing, because the thing it blurs is invisible anyway. */
+.expdlg:not(.show), .diffdlg:not(.show), .calldlg:not(.show), .graphdlg:not(.show),
+.scrim:not(.show), .palette:not(.show), .runpop:not(.show), .indlg:not(.show),
+.mgrdlg:not(.show), .wtdlg:not(.show), .setdlg:not(.show), .cfm-scrim:not(.show),
+.cfm:not(.show), .ovl:not(.show), .dsh-scrim:not(.show), .dsh:not(.show),
+.cl-dlg:not(.show) {
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+/* ---- fx-flat: background blur off ---------------------------------------
+   Decoration only, so this is the cheapest thing to give up and the first row
+   most people will reach for. The frosted panels get their solid surface
+   colour instead of a translucent one: in every case the translucency is the
+   *last* layer of a `background` shorthand, i.e. the background-color, so one
+   `background-color` here replaces it and leaves the gradient sheen on top
+   alone. The scrims keep their own translucency — a scrim that went opaque
+   would hide the app rather than dim it. */
+:root.fx-flat *, :root.fx-flat *::before, :root.fx-flat *::after {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+:root.fx-flat .expdlg, :root.fx-flat .diffdlg, :root.fx-flat .calldlg,
+:root.fx-flat .graphdlg, :root.fx-flat .palette, :root.fx-flat .runpop,
+:root.fx-flat .indlg, :root.fx-flat .mgrdlg, :root.fx-flat .wtdlg,
+:root.fx-flat .setdlg, :root.fx-flat .cfm, :root.fx-flat .ovl,
+:root.fx-flat .dsh, :root.fx-flat .cl-dlg, :root.fx-flat .tour-card,
+:root.fx-flat .colorpop, :root.fx-flat .menupop, :root.fx-flat .dbg-panel,
+:root.fx-flat .gcommit, :root.fx-flat .run-grp, :root.fx-flat .bk-h {
+  background-color: var(--panel);
+}
+
+/* ---- fx-still: animations off -------------------------------------------
+   A universal rule rather than a second list of selectors to keep in step with
+   the `reduce` blocks: running every animation to its end in a thousandth of a
+   millisecond cancels the infinite ones outright, and no animation added later
+   can be one this misses.
+
+   It is deliberately a *superset* of `prefers-reduced-motion: reduce`, not a
+   copy of it. Reduce kills eight transitions by name and merely tames a ninth
+   (`.setdlg` keeps its fade and loses only the resize); this flattens all of
+   them. That is the right answer for a row labelled Animations — somebody who
+   turns it off wants the app to stop moving, not to stop moving in eight
+   specific places — and it costs nothing at rest either way, since a
+   transition only runs for the 160ms after you click something. What the two
+   must agree on is the *substitutes* below, because those are information.
+
+   The four exceptions below are the places where an animation was carrying
+   the whole of a state rather than decorating one, so ending it instantly
+   would delete information. Their values are the ones the matching `reduce`
+   blocks already chose — `test/motion.test.ts` fails if the two lists drift. */
+:root.fx-still *, :root.fx-still *::before, :root.fx-still *::after {
+  animation-delay: 0s !important;
+  animation-duration: .001ms !important;
+  animation-iteration-count: 1 !important;
+  transition-delay: 0s !important;
+  transition-duration: .001ms !important;
+}
+:root.fx-still .srow.lit { background: color-mix(in srgb, var(--lit-c, var(--st-done)) 18%, transparent); }
+:root.fx-still .pgroup.arming .parm { opacity: 0; }
+:root.fx-still .wt-sk i { opacity: .6; }
+:root.fx-still .u-spin { border-top-color: var(--accent); }
+
+/* ---- fx-idle: paused while the window is in the background --------------
+   `animation-play-state` rather than the cancellation above, and that is the
+   whole difference between the two: this one is temporary and reversible, so
+   a pulse must come back mid-cycle where it stopped rather than restarting
+   every session's glyph in lockstep the moment you click back into the
+   window. Transitions are left alone — they are already over by the time you
+   have looked away, and pausing one mid-fade would strand a dialog at half
+   opacity until you returned. */
+:root.fx-idle *, :root.fx-idle *::before, :root.fx-idle *::after {
+  animation-play-state: paused !important;
+}

--- a/test/motion.test.ts
+++ b/test/motion.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import {
+  ALL_FX_CLASSES, DEFAULT_MOTION, VISUAL_FX, fxOn, motionPrefsJson, parseMotionPrefs,
+  rootFxClasses, toggleFx, type MotionPrefs,
+} from "../src/motion";
+
+const CSS = readFileSync(new URL("../src/styles.css", import.meta.url), "utf8");
+
+describe("the visual-effects table", () => {
+  it("names a class for every effect, and never the same one twice", () => {
+    const cls = VISUAL_FX.map((f) => f.cls);
+    expect(cls.every(Boolean)).toBe(true);
+    expect(new Set(cls).size).toBe(cls.length);
+    expect(new Set(VISUAL_FX.map((f) => f.id)).size).toBe(VISUAL_FX.length);
+  });
+  it("exports every class it can produce, so applyFx can clear what it is not setting", () => {
+    // The whole point of ALL_FX_CLASSES is that `applyFx` removes classes it does not
+    // know it set. An effect missing from it would leave its class stuck on <html>
+    // forever after one toggle — switched off with no way back short of a restart.
+    for (const f of VISUAL_FX) expect(ALL_FX_CLASSES).toContain(f.cls);
+  });
+  // Each class must actually appear in the stylesheet. A pref whose class nothing reads
+  // is a switch that visibly does nothing, and `tsc` has no opinion about a string.
+  it("has a stylesheet rule behind every class", () => {
+    for (const f of VISUAL_FX) expect(CSS).toContain(`:root.${f.cls}`);
+  });
+});
+
+describe("parseMotionPrefs — the store and its repair", () => {
+  // A first run pauses in the background; someone who has switched that on has an empty
+  // list on disk and must not be re-defaulted at every start. The two cases look alike
+  // and are not, which is the only reason this module has a `raw === null` branch.
+  it("pauses in the background on a first run, and remembers a choice not to", () => {
+    expect(parseMotionPrefs(null)).toEqual(DEFAULT_MOTION);
+    expect(parseMotionPrefs(null).off).toContain("idle");
+    expect(parseMotionPrefs('{"off":[]}')).toEqual({ off: [] });
+  });
+  it("reads back what it wrote", () => {
+    const p: MotionPrefs = { off: ["motion", "blur"] };
+    expect(parseMotionPrefs(motionPrefsJson(p))).toEqual(p);
+  });
+  it("falls back to the defaults on anything unparseable", () => {
+    for (const raw of ["", "{", "null", "[]", '{"off":"motion"}', '{"nope":1}']) {
+      expect(parseMotionPrefs(raw)).toEqual(DEFAULT_MOTION);
+    }
+  });
+  it("drops an id this build does not know, rather than carrying it forever", () => {
+    expect(parseMotionPrefs('{"off":["motion","glitter"]}')).toEqual({ off: ["motion"] });
+  });
+  it("de-duplicates", () => {
+    expect(parseMotionPrefs('{"off":["blur","blur"]}')).toEqual({ off: ["blur"] });
+  });
+});
+
+describe("fxOn / toggleFx", () => {
+  it("treats absence as on", () => {
+    expect(fxOn({ off: [] }, "motion")).toBe(true);
+    expect(fxOn({ off: ["motion"] }, "motion")).toBe(false);
+    expect(fxOn({ off: ["motion"] }, "blur")).toBe(true);
+  });
+  it("round-trips a flip and never mutates what it was given", () => {
+    const p: MotionPrefs = { off: [] };
+    const off = toggleFx(p, "blur");
+    expect(p.off).toEqual([]); // the input is untouched
+    expect(fxOn(off, "blur")).toBe(false);
+    expect(fxOn(toggleFx(off, "blur"), "blur")).toBe(true);
+  });
+  it("ignores an id it does not know", () => {
+    const p: MotionPrefs = { off: ["blur"] };
+    expect(toggleFx(p, "glitter" as never)).toBe(p);
+  });
+});
+
+describe("rootFxClasses — the whole truth table", () => {
+  it("adds nothing when everything is on and the window has focus", () => {
+    expect(rootFxClasses({ off: [] }, true)).toEqual([]);
+  });
+  it("still adds nothing when everything is on and focus is lost", () => {
+    // `idle` ON is the expensive answer — it means "keep animating in the background".
+    expect(rootFxClasses({ off: [] }, false)).toEqual([]);
+  });
+  it("pauses only once focus is actually lost", () => {
+    expect(rootFxClasses({ off: ["idle"] }, true)).toEqual([]);
+    expect(rootFxClasses({ off: ["idle"] }, false)).toEqual(["fx-idle"]);
+  });
+  it("carries the two standing switches regardless of focus", () => {
+    for (const focused of [true, false]) {
+      expect(rootFxClasses({ off: ["motion"] }, focused)).toEqual(["fx-still"]);
+      expect(rootFxClasses({ off: ["blur"] }, focused)).toEqual(["fx-flat"]);
+    }
+  });
+  it("combines all three", () => {
+    expect(rootFxClasses({ off: ["motion", "blur", "idle"] }, false))
+      .toEqual(["fx-still", "fx-flat", "fx-idle"]);
+  });
+  // fx-still cancels and fx-idle pauses, so the two must stay separate classes: folding
+  // the pause into the cancel would restart every session's glyph in lockstep on return.
+  it("keeps the cancel and the pause as different classes", () => {
+    expect(rootFxClasses({ off: ["motion", "idle"] }, false)).toContain("fx-still");
+    expect(rootFxClasses({ off: ["motion", "idle"] }, false)).toContain("fx-idle");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The contract half: this reads styles.css rather than calling anything.
+//
+// `fx-still` is a deliberate superset of `prefers-reduced-motion: reduce`: it flattens
+// every transition where reduce names eight and tames a ninth. The bulk of it is
+// drift-proof by construction — the universal rule ends every animation, including ones
+// added later. What is NOT drift-proof, and what the two modes MUST agree on, is the
+// short list of places where an animation carries a *state* rather than decorating one,
+// where ending it instantly would delete information and a static substitute has to take
+// over. Those exist twice: once in a `reduce` block, once under `fx-still`. Two lists
+// that must agree is exactly the shape this repo keeps getting bitten by.
+describe("fx-still keeps the substitutes the OS's reduce setting defines", () => {
+  // Selectors whose `reduce` block supplies a substitute value, not just `animation: none`.
+  const SUBSTITUTED = [".srow.lit", ".pgroup.arming .parm", ".wt-sk i", ".u-spin"];
+
+  it("gives every substituted selector the same treatment under fx-still", () => {
+    for (const sel of SUBSTITUTED) {
+      expect(CSS, `${sel} has a reduce-mode substitute`).toContain(`${sel} { animation: none;`);
+      expect(CSS, `${sel} needs the same substitute under :root.fx-still`).toContain(`:root.fx-still ${sel} {`);
+    }
+  });
+
+  // The reverse direction: a substitute under fx-still that no reduce block asked for
+  // means the two modes have started to look different, which is the drift this guards.
+  it("adds no fx-still substitute the reduce blocks do not have", () => {
+    const declared = [...CSS.matchAll(/:root\.fx-still ([^{,]+?) \{/g)]
+      .map((m) => m[1].trim())
+      .filter((sel) => !sel.startsWith("*")); // the universal cancel, not a substitute
+    expect(declared.length).toBeGreaterThan(0);
+    for (const sel of declared) expect(SUBSTITUTED).toContain(sel);
+  });
+
+  it("cancels rather than pauses, so nothing is left stranded mid-fade", () => {
+    expect(CSS).toContain("animation-iteration-count: 1 !important");
+    expect(CSS).toContain(":root.fx-idle *");
+    // The pause must not touch transitions: a dialog caught mid-fade would stay at half
+    // opacity until you clicked back into the window.
+    const idleBlock = CSS.slice(CSS.indexOf(":root.fx-idle *"));
+    expect(idleBlock).not.toContain("transition-duration");
+  });
+});
+
+// Seventeen dialogs stay mounted at opacity 0 so they can fade. Each one that keeps a
+// `backdrop-filter` while closed is a live render surface for a panel nobody can see.
+describe("a closed dialog carries no backdrop", () => {
+  it("gates every mounted-but-closed blur on .show", () => {
+    // Every rule that declares a blur, minus the ones that are display:none when closed
+    // (those cost nothing already) and the sub-headers whose parent dialog gates them.
+    const FREE = ["colorpop", "menupop", "tour-card", "dbg-panel", "gcommit", "run-grp", "bk-h"];
+    const blurred = new Set<string>();
+    for (const m of CSS.matchAll(/^\.([\w-]+)[^{]*\{[^}]*backdrop-filter/gm)) blurred.add(m[1]);
+    for (const cls of blurred) {
+      if (FREE.includes(cls)) continue;
+      expect(CSS, `.${cls} blurs while closed`).toContain(`.${cls}:not(.show)`);
+    }
+  });
+});


### PR DESCRIPTION
Answers a report that Episko draws a lot of GPU on Windows while sitting idle.

## What was actually costing it

Two things in the stylesheet cost a GPU frame whether or not anything moved, and both are ~2.5x the work on a 144Hz Windows desktop that they are on the 60Hz Mac this was designed at — which is why the complaint arrived from Windows.

**Seventeen dialogs, popovers and scrims kept a live `backdrop-filter` while closed.** They stay mounted at `opacity: 0` rather than `display: none` because that is what lets them fade, and a `backdrop-filter` on a transparent layer still promotes a render surface and keeps a backdrop root alive. This was the only *unconditional* cost — it ran with the app doing nothing at all.

**Nothing paused when the window lost focus.** There was no `visibilitychange` or focus listener anywhere in the 77 modules, so whatever was animating kept the compositor ticking behind your editor.

Two things I checked and did **not** change, having first suspected both:

- **`cursorBlink`.** xterm's `CursorBlinkStateManager` only starts its interval when the terminal is focused, and the WebGL renderer pauses/resumes it on blur/focus. One cursor, in one terminal, only while the window has focus. Not a factor.
- **The animations are all activity-gated** — a rail glyph only pulses for a session that is working or wants you, the inspector's heart only while `working`/`thinking`/fan-out. A quiet app animates close to nothing. (`.p-work` turns out to be dead CSS with no emitter anywhere; left in place, noted here.)

## The change

**A closed dialog is no longer a backdrop.** Gated on `:not(.show)` rather than adding `visibility: hidden` to each: `.show` is already the universal open flag, and rewriting seventeen `transition` shorthands to replicate `.cfm`'s `visibility 0s .14s` trick is a lot of risk for a fade nobody sees. Unconditional, not a preference.

**Animation stops when the window loses focus.** Tauri's `onFocusChanged` rather than the DOM `focus`/`blur` pair — the webview fires those for its own internal focus moves (clicking from a pane into the sidebar blurs the textarea) and what matters is the OS window. The DOM pair is the `pnpm dev` fallback; `visibilitychange` is a one-way lose-it for minimise.

**Settings › Appearance › Visual effects** — Animations, Background blur, and "Keep animating in the background" (defaults to pausing). New `src/motion.ts` on the `footprefs.ts` pattern: the table, the store, its repair, and `rootFxClasses`. Wired `state.ts` → `actions.ts` (`setFx`/`applyFx`) → `settings.ts`, per the setters-assign-and-nothing-else rule.

`fx-still` cancels, `fx-idle` pauses, and the two are separate on purpose: a paused animation resumes mid-cycle where a cancelled one would restart every session's glyph in lockstep on return. `fx-still` is a deliberate **superset** of `prefers-reduced-motion: reduce` — it flattens every transition where reduce names eight and tames a ninth — but the two must agree on the four **substitutes**, the places where an animation carries a state rather than decorating one and ending it would delete information.

## Tests

`test/motion.test.ts`, 21 tests. Sixteen are ordinary unit tests over the store and the truth table; five read `styles.css` rather than calling it, in the same idiom as `dispatch.test.ts`/`ipc.test.ts`/`tour.test.ts`:

- every `VisualFx.cls` has a `:root.<cls>` rule behind it (a switch whose class nothing reads does nothing, and `tsc` has no opinion about a string)
- the four `fx-still` substitutes match the `reduce` blocks they mirror, in **both** directions
- every mounted-but-closed blurred surface carries its `:not(.show)` gate

## Verified

`pnpm test` 1486 passing · `tsc` clean on both projects · `pnpm build` clean · `madge --circular` reports none.

Then ran it: blur → `fx-idle` → `animation-play-state: paused`; focus → class removed → `running`. All three toggles render in Appearance, apply their class to `<html>`, and persist to `cc-motion`.

## Not touched

`GL_POOL_MAX` (8 live WebGL contexts). That tradeoff is documented at length in `terminal.ts` with two rejected alternatives, and it is GPU *memory* rather than per-frame cost — worth measuring before second-guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
