### PR TITLE
fix(restore): a reload must not save the roster before it has read it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
+! **A session in a worktree no longer becomes a project of its own after a reload.**
+  Reattaching a pane needs the restore roster, which holds the identity it was launched
+  under — but the roster was writable from the first moment of a reload, when the session
+  map is still empty, so a second Ctrl+R landing inside that window (about a second, while
+  the agent probe runs) saved an empty one over it. Every pane then came back named after
+  its folder: invisible for a session launched in a repo root, where the folder *is* the
+  project, and wrong for one in a worktree, which took its branch folder to the top level
+  of the sidebar and kept it — the wrong identity was saved straight back to the roster,
+  so a restart brought it back. The roster is now unwritable until the run that reads it
+  has, and a pane reattached without one resolves the repo its folder is a checkout of
+  rather than assuming the folder is the project.
+
 ## 0.23.0 — 2026-08-26
 
 **Signed and notarized by Apple.** Nothing to clear on install.

--- a/src/gitwatch.ts
+++ b/src/gitwatch.ts
@@ -87,6 +87,13 @@ function under(dir: string, path: string): boolean {
   const d = norm(dir), p = norm(path);
   return d !== "" && (p === d || p.startsWith(d + "/"));
 }
+/// Two spellings of one directory, levelled by the `norm` above — exported so ./grouping
+/// can ask "is this checkout the repo root?" without growing a second normalisation rule
+/// for the trap the comment above describes: one side comes back resolved from Rust, the
+/// other is a `Sess.workdir` as the user spelled it.
+export function sameDir(a: string, b: string): boolean {
+  return norm(a) !== "" && norm(a) === norm(b);
+}
 
 type Checkout = { path: string; branch: string; exists: boolean };
 

--- a/src/grouping.ts
+++ b/src/grouping.ts
@@ -19,10 +19,10 @@
 // See test/grouping.test.ts.
 
 import { basename } from "./format";
-import { checkoutDir } from "./gitwatch";
+import { checkoutDir, sameDir } from "./gitwatch";
 import {
   bgWaiting, hasSessionState, isAgent, providerSessionKey,
-  type ExtSession, type LiveSess, type Phase, type Restorable, type Sess,
+  type ExtSession, type LiveSess, type Phase, type Restorable, type Sess, type WtHead,
 } from "./types";
 import { attnCleared, attnOrder } from "./attn";
 import { groupOf, type GroupDef } from "./projgroups";
@@ -194,6 +194,50 @@ export function orphanAdoptions(back: LiveSess[], roster: Restorable[]): { id: s
   return back
     .filter((b) => b.kind === "agent" && !!b.provider && !sessions.has(b.id))
     .map((b) => ({ id: b.id, workdir: b.workdir, provider: b.provider!, meta: roster.find((r) => r?.id === b.id) ?? null }));
+}
+/// Who an adopted orphan belongs to: the project it lists under, the key everything
+/// colours and groups by, and the checkout labels that go with them.
+///
+/// The roster answers this whenever it has an entry, and nothing may second-guess it:
+/// that is the identity the pane was LAUNCHED under, which re-derivation cannot beat —
+/// a favourite's own spelling of its path, a project the user renamed, a colorKey
+/// deliberately pinned to the repo by `launchWorktree`.
+///
+/// The rest exists for the entry that ISN'T there, and it is the half that was wrong.
+/// Falling back to the workdir makes the pane its own project, which is invisible for a
+/// session launched in a repo root — the workdir IS the colorKey there — and wrong for
+/// every session in a worktree, where it mints a top-level project named after the
+/// branch folder and scatters the repo across the rail. `worktree_heads` already knows
+/// which repo a folder is a checkout of, and it is spawn-free, so the caller asks it on
+/// the one path that reaches this: a reload that found no roster.
+///
+/// Fail-closed like every other checkout resolution here. A folder no repo claims (an
+/// unreadable roster, a scratch dir) keeps the old answer and becomes its own project,
+/// because the alternative is filing a pane under a repo we could not find.
+export function adoptIdentity(workdir: string, meta: Restorable | null, heads: readonly WtHead[]): {
+  project: string; colorKey: string; worktree: string | null; branch: string;
+} {
+  if (meta?.colorKey) {
+    return {
+      project: meta.project || basename(meta.colorKey) || "session",
+      colorKey: meta.colorKey, worktree: meta.worktree, branch: meta.branch || "",
+    };
+  }
+  // The pane's own CHECKOUT, not its raw workdir: `checkoutDir` is what already places a
+  // folder sitting several levels inside one, on the same longest-match rule the sidebar
+  // clusters by. An unplaceable folder comes back untouched and every answer below
+  // collapses to the old workdir one.
+  const checkout = checkoutDir(workdir, heads);
+  const root = heads.find((w) => w.is_main)?.path ?? checkout;
+  const own = heads.find((w) => sameDir(w.path, checkout));
+  return {
+    project: basename(root) || "session",
+    colorKey: root,
+    // The shape a worktree launch records (`launchWorktree` in ./panes): null for the
+    // repo's own checkout, the branch for any other.
+    worktree: sameDir(root, checkout) ? null : own?.branch || basename(checkout),
+    branch: own?.branch || "",
+  };
 }
 export function projectList(): ProjGroup[] {
   const list = allProjects();

--- a/src/mirror.ts
+++ b/src/mirror.ts
@@ -57,7 +57,20 @@ function rosterEntry(s: Sess): Restorable {
     title: s.title, lastActivity: s.lastActivity, provider: s.provider || "claude",
   };
 }
+// The roster may not be WRITTEN before this run has READ it, and that is not tidiness.
+// `sessions` and `dormants` are both empty until `adoptOrphans` and `loadDormants` have
+// run, so a save landing before them writes `[]` over the identities every live pane is
+// about to be rebuilt from. A reload's `beforeunload` is exactly such a save, and two
+// Ctrl+R inside the boot window (adoption waits on the `list_agents` PATH probe, ~1s of
+// it) is all it takes: the second unload wipes the roster, the surviving boot adopts
+// every pane with `meta: null`, and each falls back to its workdir. For a pane launched
+// in a repo root that fallback is invisible — the workdir IS the colorKey there — but a
+// pane in a WORKTREE becomes its own top-level project named after the folder, and
+// `adoptSession` then persists that as its identity, so it survives every later restart.
+// Shipped; found by four `app started` lines 1.5s apart in episko.log.
+let rosterReady = false;
 function saveRoster() {
+  if (!rosterReady) return;
   const open = [...sessions.values()].filter((s) => hasAgentCapability(s, "resume") && s.workdir).map(rosterEntry);
   // Dormant rows the user hasn't dismissed stay on the roster, so a restart that
   // restores only some of them doesn't quietly discard the rest.
@@ -267,24 +280,34 @@ export function forgetDormant(id: string) {
 // machine that shuts down with six sessions open touches all six files at once, and
 // believing the file stamped every one of those rows with the reboot.
 export async function loadDormants() {
-  let roster: Restorable[] = [];
-  try { roster = JSON.parse(localStorage.getItem("cc-restore") || "[]") || []; } catch { roster = []; }
-  if (!Array.isArray(roster) || !roster.length) return;
-  const live = new Set([...sessions.keys()]);
-  const candidates: Restorable[] = [];
-  for (const r of roster) {
-    if (!r || typeof r.id !== "string" || typeof r.workdir !== "string" || !r.workdir) continue;
-    if (live.has(r.id)) continue;
-    if (!r.resumeId) r.resumeId = r.id;
-    if (!r.provider) r.provider = "claude"; // roster written before provider support
-    candidates.push(r);
+  try {
+    let roster: Restorable[] = [];
+    try { roster = JSON.parse(localStorage.getItem("cc-restore") || "[]") || []; } catch { roster = []; }
+    if (!Array.isArray(roster) || !roster.length) return;
+    const live = new Set([...sessions.keys()]);
+    const candidates: Restorable[] = [];
+    for (const r of roster) {
+      if (!r || typeof r.id !== "string" || typeof r.workdir !== "string" || !r.workdir) continue;
+      if (live.has(r.id)) continue;
+      if (!r.resumeId) r.resumeId = r.id;
+      if (!r.provider) r.provider = "claude"; // roster written before provider support
+      candidates.push(r);
+    }
+    const found = await reconcileProviderRestorables(candidates);
+    found.sort((a, b) => b.lastActivity - a.lastActivity);
+    setDormants(found);
+    if (dormants.length) dlog("info", `${dormants.length} restorable session${dormants.length === 1 ? "" : "s"} from a previous run`);
+  } finally {
+    // Whatever this run found — rows, an empty roster, or a provider that threw — the
+    // roster has now been read and every pane it identifies has been adopted, so a save
+    // can no longer erase what nothing has seen yet. In a `finally` because the only
+    // thing worse than saving too early is never saving again: this flag is the single
+    // gate on persistence, so no path out of here may skip it. The flush that follows
+    // is what rebuilds a roster an earlier boot window had already emptied.
+    rosterReady = true;
+    flushRoster();
+    renderAll();
   }
-  const found = await reconcileProviderRestorables(candidates);
-  found.sort((a, b) => b.lastActivity - a.lastActivity);
-  setDormants(found);
-  if (dormants.length) dlog("info", `${dormants.length} restorable session${dormants.length === 1 ? "" : "s"} from a previous run`);
-  flushRoster();
-  renderAll();
 }
 export function jumpExternal(pid: number) {
   invoke("focus_external_session", { pid }).catch((e) => toast("jump failed: " + e));

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -44,7 +44,7 @@ import { renderAttn, renderFoot } from "./footer";
 import { updateTray } from "./tray";
 import { closeExternalView, flushRoster, queueRosterSave, refreshDirtyStates } from "./mirror";
 import { openWt, refreshWtDialog } from "./worktree";
-import { nextAfterClose, nextInGroup, orphanAdoptions } from "./grouping";
+import { adoptIdentity, nextAfterClose, nextInGroup, orphanAdoptions } from "./grouping";
 import { probeIcon } from "./icons";
 import { addIo, ioCreditBps, ioExcludedMb } from "./usage";
 import { execCmd, exitWaiters, taskPrefs, type TaskLaunchOpts } from "./tasks";
@@ -282,8 +282,11 @@ async function adoptSession(o: { id: string; workdir: string; provider: string; 
   const provider = o.provider || m?.provider || "claude";
   const providerDef = provider === "claude" ? CLAUDE_CLI : agentDef(provider);
   const capabilities = providerDef?.capabilities ?? providerCapabilities(provider);
-  const project = m?.project || basename(o.workdir) || "session";
-  const colorKey = m?.colorKey ?? o.workdir;
+  // Only a roster-less orphan pays for this, and it is one spawn-free read of the
+  // repo's checkouts: enough for a pane in a worktree to adopt under its REPO rather
+  // than mint a project named after the branch folder (./grouping's `adoptIdentity`).
+  const heads = m ? [] : await invoke<WtHead[]>("worktree_heads", { dir: o.workdir }).catch(() => [] as WtHead[]);
+  const { project, colorKey, worktree, branch } = adoptIdentity(o.workdir, m, heads);
   probeIcon(colorKey);
   const pane = document.createElement("div");
   pane.className = "term-pane";
@@ -291,7 +294,7 @@ async function adoptSession(o: { id: string; workdir: string; provider: string; 
   const { term, fit } = provider === "claude" ? newClaudeTerm(o.id, pane) : newAgentTerm(o.id, pane);
   const s: Sess = {
     id: o.id, project, accent: accentFor(colorKey), workdir: o.workdir, colorKey,
-    resumeId: m?.resumeId ?? o.id, branch: m?.branch ?? "", worktree: m?.worktree ?? null,
+    resumeId: m?.resumeId ?? o.id, branch, worktree,
     title: m?.title ?? providerDef?.label ?? provider,
     phase: "idle", phaseSince: Date.now(), attnAt: 0, seenAt: Date.now(), lastActivity: m?.lastActivity ?? Date.now(),
     attention: null, pendingCmd: "", pendingPermId: null, pendRisk: null, pendingPermissions: [], agents: new Map(), fanout: null,

--- a/test/grouping.test.ts
+++ b/test/grouping.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../src/state";
 import { ATTN_DEFAULTS } from "../src/attn";
 import {
+  adoptIdentity,
   allProjects, attnPending, clusterByWorktree, clusterIsLive, dashHeads, dormantBusy,
   foldRunGroups,
   groupedProjects, groupPhase, groupSummary, needsYou, needsYouSessions,
@@ -1326,6 +1327,68 @@ describe("orphanAdoptions — which reload orphans get a pane rebuilt (#47)", ()
   it("never adopts a pane the frontend already has", () => {
     open(sess({ id: "o1" }));
     expect(orphanAdoptions([live()], [])).toEqual([]);
+  });
+});
+
+describe("adoptIdentity — which project an adopted orphan lists under", () => {
+  // What `worktree_heads` returns for a repo with one linked checkout, in the physical,
+  // normalised spelling Rust hands back.
+  const heads: WtHead[] = [
+    { path: "/w/epi", branch: "main", is_main: true, exists: true },
+    { path: "/w/.cc-worktrees/epi/feat-undo-redo", branch: "feat/undo-redo", is_main: false, exists: true },
+  ];
+
+  it("takes the roster's identity verbatim and never re-derives over it", () => {
+    // The launch identity beats anything the filesystem could say: a worktree launch
+    // deliberately pins colorKey to the repo, and a renamed project has no other home.
+    const m = dorm({ project: "Epi!", colorKey: "/w/epi", workdir: "/w/.cc-worktrees/epi/feat-undo-redo", worktree: "feat/undo-redo", branch: "feat/undo-redo" });
+    expect(adoptIdentity(m.workdir, m, heads)).toEqual({
+      project: "Epi!", colorKey: "/w/epi", worktree: "feat/undo-redo", branch: "feat/undo-redo",
+    });
+  });
+
+  it("files a roster-less worktree pane under its REPO, not as a project of its own", () => {
+    // The shipped bug: two fast Ctrl+R emptied the roster, every pane adopted with no
+    // meta, and this one became a top-level project named after its branch folder.
+    expect(adoptIdentity("/w/.cc-worktrees/epi/feat-undo-redo", null, heads)).toEqual({
+      project: "epi", colorKey: "/w/epi", worktree: "feat/undo-redo", branch: "feat/undo-redo",
+    });
+  });
+
+  it("leaves a roster-less pane in the repo root as the project itself", () => {
+    expect(adoptIdentity("/w/epi", null, heads)).toEqual({
+      project: "epi", colorKey: "/w/epi", worktree: null, branch: "main",
+    });
+  });
+
+  it("resolves a folder INSIDE a checkout to that checkout", () => {
+    // A task declares its own cwd and a shell inherits it, so a pane can sit several
+    // folders deep in the checkout it belongs to.
+    expect(adoptIdentity("/w/.cc-worktrees/epi/feat-undo-redo/ui/src", null, heads))
+      .toMatchObject({ colorKey: "/w/epi", worktree: "feat/undo-redo" });
+  });
+
+  it("levels the two spellings the comparison actually gets", () => {
+    // Rust normalises its side (`E:\…`, upper-cased drive); a `Sess.workdir` is however
+    // the user picked it. Compared raw, the repo stops matching its own worktree.
+    const win: WtHead[] = [
+      { path: "E:\\w\\epi", branch: "main", is_main: true, exists: true },
+      { path: "E:\\w\\.cc-worktrees\\epi\\feat", branch: "feat/x", is_main: false, exists: true },
+    ];
+    expect(adoptIdentity("e:/w/.cc-worktrees/epi/feat/", null, win))
+      .toMatchObject({ project: "epi", colorKey: "E:\\w\\epi", worktree: "feat/x" });
+  });
+
+  it("fails closed on a folder no repo claims", () => {
+    // No roster, a scratch dir, an unreadable repo — the old answer, deliberately: we
+    // will not file a pane under a repo we could not find.
+    expect(adoptIdentity("/w/scratch/thing", null, [])).toEqual({
+      project: "thing", colorKey: "/w/scratch/thing", worktree: null, branch: "",
+    });
+  });
+
+  it("names an unnamed roster entry after the key it kept", () => {
+    expect(adoptIdentity("/w/epi", dorm({ project: "", colorKey: "/w/epi" }), heads).project).toBe("epi");
   });
 });
 


### PR DESCRIPTION
A session running in a worktree turned into its own top-level project after a
webview reload — named after its branch folder, and it stayed that way across
restarts. Two independent defects, one of which made the other visible.

## The roster was writable before it had been read

`cc-restore` holds the identity each pane was launched under, and `adoptOrphans`
reattaches from it after a reload. But nothing stopped a save landing during the
boot window, when `sessions` and `dormants` are both still empty — adoption waits
on the `list_agents` PATH probe (~1s of it) and `loadDormants` runs after that.

Four `app started` lines 1.5 seconds apart in `episko.log` are what this looks
like from the outside: the `beforeunload` of each extra Ctrl+R wrote `[]` over
the roster, and the boot that survived adopted all five panes with `meta: null`
(`no roster entry`, five times).

`saveRoster` now refuses until `loadDormants` has run, announced from a
`finally` — the only thing worse than saving too early is never saving again, so
no path out of there may skip the flag. The flush that follows rebuilds a roster
an earlier boot window had already emptied.

## The roster-less fallback treated a checkout as a project

Adoption fell back to the workdir for both the project name and the colorKey.
That is invisible for a pane launched in a repo root, where the workdir IS the
colorKey — which is why four of the five panes looked fine — and wrong for one in
a worktree, which `allProjects` then had no choice but to mint a group for.
`adoptSession` saved that identity straight back, so a restart brought it back.

`adoptIdentity` (./grouping, tested) is now the one place that answers who an
adopted pane belongs to. The roster still wins whenever it has an entry — that is
the launch identity, and a worktree launch deliberately pins colorKey to the
repo. Without one, a spawn-free `worktree_heads` says which repo the folder is a
checkout of, so the pane files under that repo with its branch as the worktree
label. A folder no repo claims fails closed to the old answer.

`sameDir` is exported from ./gitwatch rather than compared by hand, because the
two sides of that comparison are the ones its own comment warns about: a path
normalised in Rust against a `Sess.workdir` as the user spelled it.

## Checks

| | |
| --- | --- |
| `pnpm build` | clean (both tsconfigs + vite) |
| `pnpm test` | 1472 passed, 37 files — 7 new in `grouping.test.ts` |
| import cycles | 0 across all 76 modules |
| `cargo` | untouched, no Rust in this change |

Not exercised in a running app: reload adoption is a manual `RELEASE.md` check.
The one worth doing is the repro — a session in a worktree, then Ctrl+R twice in
quick succession; it should stay under its repo, and the log should stop saying
`no roster entry`.

Note for anyone who already hit this: the wrong identity is persisted in
`cc-restore` and the roster rightly wins over re-derivation, so this fix does not
heal it retroactively. Close the pane (that drops it from the roster) and reopen
it from History, which resolves the repo root and resumes the same conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXb147sTLRaJQh8siJ2WHU
