### PR TITLE
Settings › Diagnostics: record what the interface weighs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
++ **Settings › Diagnostics — find out what the interface is holding.** Left running for a
+  day with a fleet of panes, Episko can slowly get heavier until it feels sluggish, and
+  the reload that fixes it also destroys the evidence. **Record performance vitals** takes
+  a reading every few minutes — DOM nodes, JS heap, canvases, terminal buffers, the
+  per-session structures — and writes one line per sample into the rolling `episko.log`,
+  where it survives both a crash and a reload. The tab shows the drift since recording
+  started and names anything climbing faster than a leak would have to. It ships off,
+  because the one thing it cannot do is tell you about a day it was not watching.
++ **The web inspector, in the shipped app.** Settings › Diagnostics opens the webview's own
+  developer tools, so a heap snapshot or a CPU profile no longer needs a special relaunch
+  with a debugging port. `EPISKO_SOURCEMAP=1 pnpm tauri build` makes a build whose profiles
+  name our own functions instead of minified ones.
++ **Terminal scrollback is now a setting** — 1,000, 4,000 or the previous 8,000 lines per
+  pane. Across a fleet this is the largest single thing a long-running Episko holds, and a
+  pane only gives it back when its session ends. Lowering it applies to the panes already
+  open.
++ **Reload the interface**, as a button that says what it does. It was always the fix for a
+  sluggish window and always looked like it would kill your fleet: it does not, because
+  Episko itself holds the terminals and every pane is re-adopted with its scrollback.
+
 ## 0.23.0 — 2026-08-26
 
 **Signed and notarized by Apple.** Nothing to clear on install.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,13 +101,13 @@ The disk-I/O accounting behind `io_samples`/`io_retired` (run vs. day vs. all-ti
 - **Telemetry server** (`run_telemetry_server`) forwards `/hook` and `/statusline` POSTs as one `telemetry` event each; `/permission` is the blocking path described above.
 - Commands are registered in the `invoke_handler![...]` list at the bottom of `run()`; add new `#[tauri::command]` fns there.
 
-## Frontend (`src/`, `index.html`, `src/styles.css`): 76 modules
+## Frontend (`src/`, `index.html`, `src/styles.css`): 77 modules
 
-**No framework, and no longer one file.** 76 modules; `main.ts` is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing, so follow this render-everything pattern rather than mutating DOM directly. **`renderAll()` is coalesced**: a call only marks the pass due, and one flush per animation frame paints whatever state every event in that frame left behind, so a telemetry burst from N sessions costs a single paint. The rAF is paired with a 250ms `setTimeout` fallback, and that is not belt-and-braces: rAF never fires while the window is hidden, and the tray this pass repaints is exactly the surface being read then. The 🐞 console counts paints beside received events (`paints` in the stats line), so the batching is checkable while the app runs.
+**No framework, and no longer one file.** 77 modules; `main.ts` is **bootstrap only**. State lives in a `sessions: Map<session_id, Sess>` (owned by `state.ts`) plus module-level variables; **every mutation ends by calling `renderAll()`**, which re-renders the sidebar, mini-rail, inspector, header, footer, attention badge, and tray from scratch. There is no diffing, so follow this render-everything pattern rather than mutating DOM directly. **`renderAll()` is coalesced**: a call only marks the pass due, and one flush per animation frame paints whatever state every event in that frame left behind, so a telemetry burst from N sessions costs a single paint. The rAF is paired with a 250ms `setTimeout` fallback, and that is not belt-and-braces: rAF never fires while the window is hidden, and the tray this pass repaints is exactly the surface being read then. The 🐞 console counts paints beside received events (`paints` in the stats line), so the batching is checkable while the app runs.
 
 What `main.ts` still holds, deliberately: the imports and the whole of the `setXHost`/`setX` wiring (the seam map, which belongs in the file that owns the graph), the one-time startup blocks, `renderAll()`, every `listen()` handler, the delegated `[data-*]` click dispatcher and the global keydown, the ResizeObserver, the quit guard, the debug-console button wiring, the window controls (see docs/native-ui.md), and the `setInterval`s.
 
-**Tested logic modules** (thirty-one, with no DOM, no Tauri and no render imports; these are what the vitest suites cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it, plus `dispatch.test.ts` and `ipc.test.ts` which read source instead of importing it):
+**Tested logic modules** (thirty-two, with no DOM, no Tauri and no render imports; these are what the vitest suites cover, one `test/*.test.ts` per module bar `types.ts`, whose discriminants are exercised through the four suites that import it, plus `dispatch.test.ts` and `ipc.test.ts` which read source instead of importing it):
 
 | Module | What |
 | --- | --- |
@@ -147,6 +147,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 | `footprefs.ts` | which segments the status bar shows: the table, the store, its repair, and why three of them have no switch |
 | `tour.ts` | the guided tour's chapters and rules: when the picker is offered, what a step waits for, which panel its anchor needs open, and why a release intro is just a chapter (see docs/tour.md) |
 | `revive.ts` | carrying on after the API kills a turn: which failures a retry can fix, the backoff ladder, and the three things it must never type into |
+| `perf.ts` | what the interface weighs and what that is allowed to mean: the counter table and the three kinds (only an unbounded one may accuse), the drift between two readings, the greppable log line, and the scrollback knob |
 
 **Shared**: `state.ts` (the session map, the stage pointer, every persisted preference) and `dom.ts` (`$`, `toast`, the shared scrim, `IS_MAC`/`MOD`/`chord`).
 
@@ -156,7 +157,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 
 **Behaviour**, IPC and DOM all the way down, so untested too, and therefore the thinnest ice in the app: `panes` (the four spawners + a pane's lifecycle), `terminal` (the xterm plumbing), `taskrun` (run on stop), `actions` (the app-level verbs), `icons` (the per-project glyph store).
 
-Four rules keep that graph honest. **There are no import cycles across the 76 modules; re-run a cycle check after any change that adds an import.**
+Four rules keep that graph honest. **There are no import cycles across the 77 modules; re-run a cycle check after any change that adds an import.**
 
 - **Dependency direction is state ← render ← wiring.** A logic module must not import render code or `main.ts`.
 - **When an extracted function needs something that lives further up**, resolve it in this order: (1) **move the callee down too** if it is itself leaf-shaped, which is why `icons.ts` sits below `sidebar.ts` and `usage.ts` below `phase.ts`; (2) **a settable hook defaulting to a no-op** (`setRlLogger`, `setPanesRenderAll`) when the callee genuinely belongs to the render layer; (3) **an extra parameter** only as a last resort, since it changes a signature the move was supposed to leave alone. A control panel touching many things it doesn't own may take **one host object** instead of N setters (`settings`, `palui`, `projmenu`); prefer per-callee setters below ~4.
@@ -286,6 +287,20 @@ And the things that hold however the files are arranged:
   `strList` / `favList` / a `clamp*`, never a bare `JSON.parse`, and discard a bad value on
   its own rather than letting it take the session (`test/state.test.ts`).
 - **Debug console** (🐞, bottom-right): in-app event log + live state via `dlog()`/`dbgSnapshot()`; flags unrouted telemetry and JS errors; mirrors a snapshot to `$TMPDIR/cc-launcher/episko-debug.json` for external tools. The snapshot is state-of-now and does not survive a crash. The durable timeline is the rolling `episko.log` (+ `panic.log`) in the OS app-log dir, which every `dlog()` tees into via `log_frontend` (`docs/architecture.md`).
+- **A leak that takes fifteen hours cannot be diagnosed from a snapshot.** `dbgSnapshot`
+  is state-of-now, so the *growth* half is **Settings › Diagnostics** (./perf decides,
+  ./debug samples): one reading every few minutes, teed into the rolling `episko.log` via
+  `log_frontend` — **never `dlog`**, which would push real events out of the 400-entry
+  ring the panel exists to show. Three rules. It **ships off** and the tab says why, since
+  the recorder has to be armed before the day it is needed. A counter's `kind` decides
+  what it may accuse: only an unbounded `growth` one, never a `level` (scrollback lines
+  saturate at their ceiling by design) or a `rate` (a total that counts is not a leak) —
+  the health.ts rule, one level down. And **no verdict under half an hour or across a
+  reload**: a busy turn makes any counter look alarming, and the reload that fixes this
+  bug resets every one of them to zero, which reads as a cure. The tab's other three rows
+  are the inspector (the `devtools` Cargo feature ships it in release builds), the
+  scrollback limit, and the reload itself — a button because it *looks* like it kills
+  your fleet and does not.
 
 ## App-wide rules
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,15 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["test"] }
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon", "image-png"] }
+# `devtools` puts the web inspector in RELEASE builds too, not just debug ones. Episko is
+# a webview app people leave running for days, and the fault that needs it — the renderer
+# slowly saturating a core until the page is reloaded — only ever appears in a real
+# session on a real fleet, never in `tauri dev`. Without this, diagnosing it meant
+# relaunching the shipped binary under a WebView2 remote-debugging port and reading
+# minified frames. Opening it is a switch in Settings > Diagnostics, so the inspector
+# ships available rather than open. (Tauri's note: this uses private APIs on macOS, which
+# matters for the App Store and not for Developer ID distribution, which is what we do.)
+tauri = { version = "2", features = ["tray-icon", "image-png", "devtools"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -127,6 +127,20 @@ fn write_debug_file(contents: String) -> Result<String, String> {
 /// Forwarding it here puts the whole timeline (UI + backend) in one durable,
 /// time-ordered file: after #12 the backend was crash-visible but the UI half
 /// wasn't. Fire-and-forget from the frontend; a dropped line is not worth an error.
+/// Open the webview's own inspector on the main window.
+///
+/// A command rather than a menu item or an accelerator because the inspector is not a
+/// thing to reach by accident in a shipped app: this is only ever called from Settings >
+/// Diagnostics, where the sentence next to the button says what it is for. The `devtools`
+/// Cargo feature (see Cargo.toml) is what makes the call exist in a release build at all
+/// — without it `open_devtools` is compiled out and this would not build.
+///
+/// Idempotent by way of the webview: opening an already-open inspector focuses it.
+#[tauri::command]
+fn open_devtools(window: tauri::WebviewWindow) {
+    window.open_devtools();
+}
+
 #[tauri::command]
 fn log_frontend(level: String, msg: String) {
     match level.as_str() {
@@ -622,6 +636,7 @@ pub fn run() {
             platform::reveal_file,
             write_debug_file,
             log_frontend,
+            open_devtools,
             update_tray,
             confirm_quit
         ])

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -15,7 +15,7 @@ import { $, toast } from "./dom";
 import { ask } from "./confirm";
 import { basename } from "./format";
 import { probeIcon } from "./icons";
-import { refit } from "./terminal";
+import { applyScrollback, refit } from "./terminal";
 import { activeCwd, closeSession, launch, launchShell } from "./panes";
 import { closePeek, renderMini, renderSidebar } from "./sidebar";
 import { renderSettings } from "./settings";
@@ -34,11 +34,14 @@ import {
   setProjGroups, setSortMode, SORT_META, SORT_MODES,
   soundPrefs, setSoundPrefs as setSoundPrefsState,
   revivePrefs, setRevivePrefs as setRevivePrefsState,
+  vitalsPrefs, setVitalsPrefs as setVitalsPrefsState,
+  termScrollback, setTermScrollback as setTermScrollbackState,
   sortMode, setWtGroup as setWtGroupState, wtGroup,
   cmpBase, setCmpBase as setCmpBaseState,
   type SortMode, type WtGroup,
 } from "./state";
 import { footPrefsJson, toggleFootSeg, type FootSeg } from "./footprefs";
+import { vitalsPrefsJson, type VitalsPrefs } from "./perf";
 import {
   assignGroup, cleanGroupName, collapseAll, createGroup, deleteGroup, groupById,
   renameGroup, setCollapsed, type GroupStore,
@@ -209,6 +212,54 @@ export function setRevivePrefs(p: RevivePrefs) {
   localStorage.setItem("cc-revive", JSON.stringify(revivePrefs));
   renderAll();
   renderSettings(); // the ladder preview redraws at the new timings
+}
+
+// And for the vitals recorder. `renderSettings` alone, like the sounds above: the series
+// has exactly one surface, the tab the switch is on. ./debug reads `vitalsPrefs` live on
+// its tick, so nothing has to be pushed to it and no interval is rebuilt — see the note
+// on `tickVitals` for why that matters more here than it looks.
+export function setVitalsPrefs(p: VitalsPrefs) {
+  setVitalsPrefsState(p);
+  localStorage.setItem("cc-vitals", vitalsPrefsJson(vitalsPrefs));
+  renderSettings();
+}
+
+// The scrollback limit, pushed onto every pane already open as well as stored for the
+// next one. `renderSettings` alone: xterm redraws its own viewport when the buffer
+// changes and nothing else in the app displays a line count — the Diagnostics readout
+// picks the new total up on its next sample rather than being repainted at it.
+export function setScrollback(lines: number) {
+  setTermScrollbackState(lines);
+  localStorage.setItem("cc-scrollback", String(termScrollback));
+  applyScrollback(sessions.values(), termScrollback);
+  renderSettings();
+}
+
+// The webview's inspector. Nothing to persist and nothing to repaint — the window it
+// opens is the browser's, not ours.
+export function openDevtools() {
+  void invoke("open_devtools").catch((e) => { dlog("warn", `devtools open failed: ${e}`); toast("Could not open the inspector"); });
+}
+
+/// Reload the interface, keeping every session.
+///
+/// This is the documented workaround for the renderer going sluggish after a long day,
+/// and it is a button rather than folklore for one reason: it *looks* like it should
+/// kill your fleet, so without something in the app saying otherwise nobody reaches for
+/// it. Nothing is lost — the backend owns the PTYs, and `adoptOrphans` re-adopts every
+/// pane from `live_sessions` on the way back up, replaying each one's scrollback from the
+/// backend's own ring.
+///
+/// Asked rather than done, because "every pane rebuilds itself" is a visible few seconds
+/// and a keystroke mid-prompt would be lost in it.
+export async function reloadUi() {
+  const ok = await ask(
+    "Reload the interface?\n\nEvery session keeps running — the terminals are held by Episko itself and each pane is re-adopted with its scrollback.\n\nThis clears whatever the interface has accumulated, which is what makes it responsive again.",
+    { title: "Reload interface", kind: "info", okLabel: "Reload", cancelLabel: "Cancel" },
+  );
+  if (!ok) return;
+  dlog("info", "reloading the webview by request (Settings › Diagnostics)");
+  location.reload();
 }
 
 // ---------- the revive watchdog ----------

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -19,10 +19,14 @@ import { esc } from "./format";
 import { rl } from "./rl";
 import {
   activeId, dirtyByFolder, externals, extMirrorId, folderDirty, isDirty,
-  pastMirrorId, revivePrefs, sessions, termEngine,
+  pastMirrorId, revivePrefs, sessions, termEngine, vitalsPrefs,
 } from "./state";
 import { liveCount, orphanAgents, type Sess } from "./types";
 import { reviveDeadline } from "./revive";
+import {
+  driftVerdict, leakSuspects, pushVitals, vitalsDrift, vitalsLine,
+  type Vitals, type VitalsDrift,
+} from "./perf";
 
 // A lightweight in-app event log + live state snapshot, surfaced via the 🐞 button
 // (in the footer) and mirrored to a fixed file (episko-debug.json) so an external
@@ -47,6 +51,74 @@ export function dlog(lvl: DbgLvl, msg: string) {
   // Fire-and-forget: the in-memory ring above is the source of truth for the panel.
   invoke("log_frontend", { level: lvl, msg }).catch(() => {});
 }
+
+// ---------- performance vitals ----------
+//
+// The in-memory half of the series ./perf models. Sampling lives here because it is the
+// one thing in the feature that reads live state — `document`, `performance.memory` and
+// every open pane's terminal buffer — and this module already owns both the snapshot and
+// the tee into the durable log.
+//
+// **The tee is deliberately `log_frontend` rather than `dlog`.** A vitals line is not an
+// event: it says nothing happened, three hundred times a day. Through `dlog` it would
+// push real events out of the 400-entry ring the debug panel exists to show, and bury
+// the unrouted-telemetry warnings that are the whole reason that ring is worth reading.
+// It still lands in `episko.log` beside them, in the same timeline, which is the only
+// place any of this had to be.
+export const vitalsRing: Vitals[] = [];
+let lastSample = 0;
+
+/// One reading of the frontend's weight. Everything here is O(panes) or a single DOM
+/// count, which is why the cadence can be measured in minutes without anybody noticing.
+function sampleVitals(): Vitals {
+  const list = [...sessions.values()];
+  const sum = (f: (s: Sess) => number) => list.reduce((n, s) => n + f(s), 0);
+  // Chromium exposes `performance.memory`; WebKit does not, and a missing heap figure is
+  // reported as 0 rather than faked — a flat zero column reads as "not available here",
+  // where an invented number would put a clean verdict on the one counter that matters
+  // most. See `heapMB`'s row in ./perf's table.
+  const mem = (performance as Performance & { memory?: { usedJSHeapSize: number } }).memory;
+  return {
+    t: Date.now(),
+    upMs: Math.round(performance.now()),
+    dom: document.getElementsByTagName("*").length,
+    heapMB: mem ? Math.round(mem.usedJSHeapSize / 1048576) : 0,
+    canvases: document.getElementsByTagName("canvas").length,
+    files: sum((s) => s.files.length),
+    servers: sum((s) => s.servers.length),
+    termLines: sum((s) => s.term?.buffer.normal.length ?? 0),
+    panes: list.length,
+    gl: list.filter((s) => s.gl).length,
+    acts: sum((s) => s.activity.length),
+    hist: sum((s) => s.ctxHist.length + s.costHist.length),
+    paints: telem.renders,
+    events: telem.rx,
+  };
+}
+
+/// Called on a fixed short tick from main.ts; this decides whether a sample is due.
+///
+/// The cadence is checked here rather than by rebuilding a `setInterval` whenever the
+/// picker changes, for the reason every interval in this app is module-scope and
+/// permanent: an interval that is cleared and recreated from a settings handler is one
+/// stray early return away from a feature that silently stops recording, and *silently
+/// stopped recording* is indistinguishable from *nothing is leaking*.
+export function tickVitals(prefsEnabled: boolean, everyMs: number) {
+  if (!prefsEnabled) { lastSample = 0; return; }
+  const now = Date.now();
+  // A first sample the moment it is switched on, so the readout has something to say
+  // before the first interval elapses.
+  if (lastSample && now - lastSample < everyMs) return;
+  lastSample = now;
+  const v = sampleVitals();
+  pushVitals(vitalsRing, v);
+  invoke("log_frontend", { level: "info", msg: vitalsLine(v) }).catch(() => {});
+}
+
+/// What Settings › Diagnostics draws, handed over through the settings host rather than
+/// imported, so the control panel keeps taking its readings from somebody else's module.
+export function currentDrift(): VitalsDrift | null { return vitalsDrift(vitalsRing); }
+
 function dbgIssues() { return dbgLog.reduce((n, e) => n + (e.lvl === "info" ? 0 : 1), 0); }
 export function renderDbgBadge() {
   const n = dbgIssues();
@@ -96,6 +168,20 @@ export function dbgSnapshot() {
     // something, and when" is one question about the app, and an external tool reading
     // the snapshot should not have to scan the fleet to answer it.
     nextRevive: (() => { const at = reviveDeadline(sessions.values(), revivePrefs, Date.now()); return at ? new Date(at).toISOString() : null; })(),
+    // The growth series in summary — the counters themselves are in `episko.log`, one
+    // line per sample, which is the form that survives the reload this bug is fixed by.
+    // What belongs here is the standing answer: is it recording, over how long, and is
+    // anything climbing. Kept small on purpose, because `flushDebug` skips a write when
+    // the body is unchanged and a live figure in here would defeat that guard on every
+    // four-second pass.
+    vitals: (() => {
+      const d = currentDrift();
+      return {
+        recording: vitalsPrefs.enabled, everyMs: vitalsPrefs.everyMs, samples: vitalsRing.length,
+        verdict: driftVerdict(vitalsPrefs, d),
+        growing: leakSuspects(d).map((r) => `${r.id} +${Math.round(r.perHour)}/h (${r.first} → ${r.last})`),
+      };
+    })(),
     log: dbgLog.slice(-250),
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,7 @@ import {
   copyPath, openTerminalIn, setActionsRenderAll, setAttnPrefs, setDefaultAgent, setKeyPrefs,
   setPeekPrefs, setPermMode, setProjectAgent, setRevivePrefs,
   setFootSeg, setSort, setSoundPrefs, setTheme, setWtGroup, setCmpBase, tickRevive,
+  setVitalsPrefs, setScrollback, openDevtools, reloadUi,
   toggleInsp, toggleProjGroup, toggleRail, toggleTheme,
 } from "./actions";
 import { playSound, setSoundLogger } from "./chime";
@@ -73,7 +74,7 @@ import {
 } from "./worktree";
 import {
   dbgLog, dbgSnapshot, dlog, flushDebug, renderDbgBadge, renderDbgPanel, telem,
-  toggleDbg,
+  toggleDbg, currentDrift, tickVitals,
 } from "./debug";
 import { basename, setHome } from "./format";
 import { rl, setRlLogger } from "./rl";
@@ -107,7 +108,7 @@ import {
 import {
   activeId, ALL_ENGINES, availEngines, dashMirror, dormants, externals, extMirrorId,
   FAVORITES, keyPrefs, markWorkdirStale, mirror, pastMirrorId, sessions, setAvailAgents, setAvailEngines,
-  setTermEngine, setTermFontSize, sortMode, stageGroup, termEngine,
+  setTermEngine, setTermFontSize, sortMode, stageGroup, termEngine, vitalsPrefs,
 } from "./state";
 import { activeBind, comboMatches, digitOf, matchAction, type KeyAction } from "./keys";
 import { orderedSessions, syncAttn } from "./grouping";
@@ -263,6 +264,8 @@ setSettingsHost({
   setRevivePrefs,
   startTour: startChapter,
   setFootSeg,
+  setVitalsPrefs, setScrollback, openDevtools, reloadUi,
+  vitalsDrift: currentDrift,
 });
 // The tour drives the app the way a user would, so the two things it cannot do itself
 // are typing into a pane and opening the window it just told you about.
@@ -1025,6 +1028,10 @@ window.addEventListener("unhandledrejection", (e) => dlog("error", `unhandled re
 dlog("info", "app started");
 flushDebug();
 setInterval(flushDebug, 4000);
+// The vitals recorder. A fixed short tick that asks ./debug whether a sample is due,
+// rather than an interval rebuilt whenever the cadence changes — see `tickVitals` for
+// why an interval this feature depends on must never be cleared and recreated.
+setInterval(() => tickVitals(vitalsPrefs.enabled, vitalsPrefs.everyMs), 20_000);
 
 // scour each known project for a favicon/logo once, so the sidebar shows real icons
 FAVORITES.forEach((f) => probeIcon(f.path));

--- a/src/panes.ts
+++ b/src/panes.ts
@@ -53,7 +53,7 @@ import {
   effectiveAgent, engineDef,
   externals, extMirrorId, FAVORITES, ioAll, pastMirrorId, permissionModeFor,
   sessions, setActiveId, setDormants, setStageGroup, stageGroup, termEngine,
-  termFontSize, worktreesByRepo, wtSig,
+  termFontSize, termScrollback, worktreesByRepo, wtSig,
 } from "./state";
 import { providerPermissionMode } from "./providers";
 
@@ -72,7 +72,7 @@ function launchPermission(agent: AgentCli) {
 // adoption of a reload orphan, so the two cannot drift on options or key wiring.
 function newClaudeTerm(id: string, pane: HTMLElement): { term: Terminal; fit: FitAddon } {
   const term = new Terminal({
-    fontFamily: MONO, fontSize: termFontSize, cursorBlink: true, scrollback: 8000,
+    fontFamily: MONO, fontSize: termFontSize, cursorBlink: true, scrollback: termScrollback,
     theme: { background: "#0c0b11", foreground: "#dcd8e6", cursor: "#c3b6f0", selectionBackground: "#3a3350" },
   });
   const fit = new FitAddon();
@@ -89,7 +89,7 @@ function newClaudeTerm(id: string, pane: HTMLElement): { term: Terminal; fit: Fi
 // launches and reload adoption both go through this constructor so input cannot drift.
 function newAgentTerm(id: string, pane: HTMLElement): { term: Terminal; fit: FitAddon } {
   const term = new Terminal({
-    fontFamily: MONO, fontSize: termFontSize, cursorBlink: true, scrollback: 8000,
+    fontFamily: MONO, fontSize: termFontSize, cursorBlink: true, scrollback: termScrollback,
     theme: { background: "#0c0b11", foreground: "#dcd8e6", cursor: "#c3b6f0", selectionBackground: "#3a3350" },
   });
   const fit = new FitAddon();
@@ -354,7 +354,7 @@ export async function launchShell(project: string, workdir: string, opts: { colo
   pane.className = "term-pane";
   $("terminals").appendChild(pane);
   const term = new Terminal({
-    fontFamily: MONO, fontSize: termFontSize, cursorBlink: true, scrollback: 8000,
+    fontFamily: MONO, fontSize: termFontSize, cursorBlink: true, scrollback: termScrollback,
     theme: { background: "#0c0b11", foreground: "#dcd8e6", cursor: "#c3b6f0", selectionBackground: "#3a3350" },
   });
   const fit = new FitAddon();
@@ -458,7 +458,7 @@ export async function launchTask(r: Runnable, project: string, opts: TaskLaunchO
     + `<span class="pc-x" data-close="${id}" title="Close this pane">✕</span>`;
   pane.appendChild(cap);
   const term = new Terminal({
-    fontFamily: MONO, fontSize: termFontSize, cursorBlink: false, scrollback: 8000,
+    fontFamily: MONO, fontSize: termFontSize, cursorBlink: false, scrollback: termScrollback,
     theme: { background: "#0c0b11", foreground: "#dcd8e6", cursor: "#c3b6f0", selectionBackground: "#3a3350" },
   });
   const fit = new FitAddon();

--- a/src/perf.ts
+++ b/src/perf.ts
@@ -1,0 +1,285 @@
+// The Diagnostics tab's model: what the frontend records about its own weight, what
+// those numbers mean, and the two knobs that change behaviour rather than observe it.
+//
+// This exists because of a bug shape the rest of the app has no answer for. Episko is
+// meant to be left up for days, and after roughly fifteen hours with a fleet of panes
+// the webview's renderer saturates a core: every hover and click lags until the page is
+// reloaded, which frees ~130MB and costs no sessions (the backend holds the PTYs and
+// `adoptOrphans` re-adopts the panes). Every *snapshot* of that state looks fine. The
+// debug console's `dbgSnapshot` is state-of-now by construction, so nothing in it can
+// ever show a counter that has been climbing since breakfast — and by the time the app
+// is slow enough to investigate, the only honest move is the reload that destroys the
+// evidence.
+//
+// So the thing worth building is not another readout. It is a **time series that is
+// already running before anybody notices**: one sample every few minutes, teed into the
+// rolling `episko.log` where it survives a crash and a reload, so the question "which
+// number grew overnight?" is answered by `grep vitals` rather than by catching the app
+// in the act. Recording is what makes a slow leak findable at all; that is why it is one
+// switch and not a mode you have to remember to enter.
+//
+// Pure logic, no DOM and no Tauri — ./debug reads the live values (it is the module that
+// already owns both the snapshot and the log tee) and hands them here. The split matters
+// for one reason beyond the usual: sampling touches `document` and `performance.memory`,
+// which vitest's node environment does not have, and the interesting half is what the
+// numbers *mean*, which is testable exactly because it never looks at them itself.
+
+/// What kind of question a counter answers — and therefore what it is allowed to accuse.
+///
+/// The distinction is the whole reason this table exists rather than a flat list of
+/// numbers. A **growth** counter has no ceiling, so a steady climb is a leak. A **level**
+/// is bounded by design (a cap, a pool, the size of the fleet), so its value is worth
+/// seeing and its slope means nothing — reporting one as a leak would be the health.ts
+/// mistake of a rule that fires on ordinary behaviour, and here it would fire on the
+/// structures already ruled out by measurement. A **rate** is a monotonic total whose
+/// only meaningful form is per-hour; it always climbs, and saying so is noise.
+export type VitalKind = "growth" | "level" | "rate";
+
+/// One sample's counters. Ordered as the table below lists them, which is the order the
+/// log line writes and the readout draws — there is no second list to fall out of step.
+export interface VitalCounts {
+  dom: number;
+  heapMB: number;
+  canvases: number;
+  files: number;
+  servers: number;
+  termLines: number;
+  panes: number;
+  gl: number;
+  acts: number;
+  hist: number;
+  paints: number;
+  events: number;
+}
+export type VitalId = keyof VitalCounts;
+
+/// A sample: the counters, when they were taken, and how long the *page* had been up.
+///
+/// `upMs` is page uptime rather than process uptime, and the difference is the point: a
+/// reload is the workaround for this bug, so a series that spanned one would otherwise
+/// show every growth counter dropping to zero and read as a fix. A drop in `upMs`
+/// between two samples is how a consumer knows the series restarted.
+export interface Vitals extends VitalCounts { t: number; upMs: number }
+
+export interface VitalDef {
+  id: VitalId;
+  /// The key written into the log line. Short on purpose: this is grepped, not read.
+  key: string;
+  label: string;
+  kind: VitalKind;
+  /// Per hour, what a genuine leak looks like in this counter. `growth` only — the two
+  /// other kinds must never carry one, which `leakSuspects` relies on.
+  climb?: number;
+  hint: string;
+}
+
+/// Every counter, why it is here, and (for the five that can accuse) what rate of climb
+/// is worth naming. The thresholds are set from the one measured incident rather than
+/// from taste: a reload freed ~130MB after ~15h, so a heap climbing 4MB/h reproduces it,
+/// and the DOM and canvas numbers are scaled to "visible cost within a day".
+export const VITALS: readonly VitalDef[] = [
+  {
+    id: "dom", key: "dom", label: "DOM nodes", kind: "growth", climb: 200,
+    hint: "Every element in the document. renderAll rebuilds markup in place, so a steady climb means something is being appended and never removed — the shape a detached-node leak takes.",
+  },
+  {
+    id: "heapMB", key: "heap", label: "JS heap", kind: "growth", climb: 4,
+    hint: "Megabytes of live JavaScript. The measured incident freed about 130MB on reload after fifteen hours, which is this counter at roughly 9MB an hour.",
+  },
+  {
+    id: "canvases", key: "canvas", label: "Canvases", kind: "growth", climb: 1,
+    hint: "xterm's WebGL renderer draws into a handful of canvases per pane and the pool caps live contexts at eight. This is bounded in a healthy app, so anything that climbs is an addon that was never disposed.",
+  },
+  {
+    id: "files", key: "files", label: "Context files", kind: "growth", climb: 500,
+    hint: "One entry per path every session has read, edited or created. Bounded by the size of the projects in practice, not by a cap.",
+  },
+  {
+    id: "servers", key: "srv", label: "Background shells", kind: "growth", climb: 5,
+    hint: "Dev servers and watchers the agents left running. A handful is normal; a count that only ever rises means records are being kept for shells that ended.",
+  },
+  {
+    id: "termLines", key: "term", label: "Scrollback lines", kind: "level",
+    hint: "Lines held across every pane's terminal buffer. Bounded by the scrollback setting times the number of panes, so it saturates rather than leaks — but the ceiling itself is worth seeing, because it is the largest single thing a long-lived fleet holds.",
+  },
+  { id: "panes", key: "panes", label: "Panes", kind: "level", hint: "Open sessions. The denominator for everything above." },
+  { id: "gl", key: "gl", label: "WebGL contexts", kind: "level", hint: "Panes currently holding a pooled renderer. Capped at eight by design." },
+  {
+    id: "acts", key: "acts", label: "Timeline rows", kind: "level",
+    hint: "Tool calls held across every session's activity timeline. Capped per session, and already ruled out by measurement — recorded so a regression in that cap would be visible rather than suspected.",
+  },
+  {
+    id: "hist", key: "hist", label: "Sparkline points", kind: "level",
+    hint: "Context and cost history points across the fleet. Capped per session, like the timeline above, and here for the same reason.",
+  },
+  { id: "paints", key: "paints", label: "Paints", kind: "rate", hint: "renderAll passes that actually painted. Coalesced to one per animation frame, so this should stay well under the event rate." },
+  { id: "events", key: "ev", label: "Telemetry events", kind: "rate", hint: "Hook and statusLine payloads received. The load the app is actually under, and what the paint rate has to be read against." },
+];
+
+const BY_ID = new Map<VitalId, VitalDef>(VITALS.map((v) => [v.id, v]));
+
+// ---------- the two preferences ----------
+
+/// How often to sample, in milliseconds. Three choices rather than a stepper, because
+/// the honest range is narrow: below a minute the series is mostly noise from a single
+/// busy turn, and above a quarter of an hour a fifteen-hour incident lands in sixty
+/// points, which is too coarse to see where a climb began.
+export const VITALS_EVERY = [60_000, 300_000, 900_000] as const;
+export const VITALS_DEFAULTS = { enabled: false, everyMs: 300_000 } as const;
+
+export interface VitalsPrefs { enabled: boolean; everyMs: number }
+
+/// Ships **off**, and that is a real cost worth stating: the first time anybody hits this
+/// bug they will have no series, and the honest answer is "switch it on and come back
+/// tomorrow". It stays off anyway, on the same rule as the sound alerts — a feature that
+/// writes to a log file on a timer, forever, on every install, to serve a fault most
+/// users will never see, is not something to turn on by default. What the tab owes in
+/// exchange is saying plainly that it has to be armed *before* the day it is needed.
+export function clampVitalsPrefs(p: Partial<VitalsPrefs> | null | undefined): VitalsPrefs {
+  const every = Number(p?.everyMs);
+  return {
+    enabled: p?.enabled === true,
+    everyMs: (VITALS_EVERY as readonly number[]).includes(every) ? every : VITALS_DEFAULTS.everyMs,
+  };
+}
+export function vitalsPrefsJson(p: VitalsPrefs): string { return JSON.stringify(p); }
+
+/// How many samples to keep in memory. A day at the coarsest cadence, or four hours at
+/// the finest — the ring is only what the readout draws, since the durable series is the
+/// log file and is not bounded by anything here.
+export const VITALS_CAP = 300;
+
+/// Terminal scrollback, in lines per pane.
+///
+/// A knob rather than a constant because it is the one number here that changes the
+/// app's weight instead of measuring it: eight thousand lines across a fleet is the
+/// largest structure a long-lived session holds, and `trimScrollback` only ever reclaims
+/// it from panes that have *ended*. Dialling it down is both a way to test whether that
+/// is what goes wrong overnight and, if it is, the fix.
+export const SCROLLBACK_OPTS = [1000, 4000, 8000] as const;
+export const SCROLLBACK_DEFAULT = 8000;
+
+/// Snap to a known option. An unknown value falls back to the shipped default rather
+/// than to the nearest neighbour: this is read at module scope from a hand-editable
+/// store, and silently honouring `50` would give somebody a terminal with no history and
+/// no clue why.
+export function clampScrollback(raw: unknown): number {
+  const n = Number(raw);
+  return (SCROLLBACK_OPTS as readonly number[]).includes(n) ? n : SCROLLBACK_DEFAULT;
+}
+
+// ---------- the series ----------
+
+/// Append a sample, dropping the oldest past the cap. Mutates, like ./debug's own event
+/// ring it sits beside, because the caller owns one long-lived array for the session.
+export function pushVitals(ring: Vitals[], v: Vitals, cap = VITALS_CAP): void {
+  ring.push(v);
+  if (ring.length > cap) ring.splice(0, ring.length - cap);
+}
+
+/// The one line written to `episko.log`, and the only durable form of any of this.
+///
+/// Compact `key=value` pairs behind a fixed `vitals` prefix, so a day of them is one
+/// `grep vitals episko.log` away from a table — and stable in field order and spelling,
+/// because the consumer is a person with a terminal or an agent reading the log, and
+/// either will be diffing lines written hours apart by two different runs.
+export function vitalsLine(v: Vitals): string {
+  const fields = VITALS.map((d) => `${d.key}=${v[d.id]}`).join(" ");
+  return `vitals up=${Math.round(v.upMs / 60_000)}m ${fields}`;
+}
+
+export interface DriftRow {
+  id: VitalId; label: string; kind: VitalKind;
+  first: number; last: number; delta: number;
+  /// Change per hour. For a `rate` counter this is the rate itself, which is the only
+  /// form it has ever meant anything in.
+  perHour: number;
+  /// Growth as a share of where it started, or null when it started at zero — where a
+  /// percentage is either infinite or a lie.
+  pct: number | null;
+}
+export interface VitalsDrift { spanMs: number; samples: number; reloaded: boolean; rows: DriftRow[] }
+
+/// Below half an hour, no verdict. Two samples ten minutes apart across one busy turn
+/// can show any counter climbing at an alarming rate, and a diagnostic that cries leak
+/// on its first reading teaches you to close the tab.
+export const MIN_SPAN_MS = 30 * 60_000;
+
+/// First sample against last. Deliberately not a regression or a windowed slope: the
+/// question this feature exists to answer is "is the app heavier than it was this
+/// morning", and endpoints answer exactly that without inventing a confidence nobody
+/// asked for.
+export function vitalsDrift(ring: readonly Vitals[]): VitalsDrift | null {
+  if (ring.length < 2) return null;
+  const a = ring[0], b = ring[ring.length - 1];
+  const spanMs = b.t - a.t;
+  if (spanMs <= 0) return null;
+  const hours = spanMs / 3_600_000;
+  return {
+    spanMs, samples: ring.length,
+    // A page uptime that went backwards means the webview reloaded inside this window,
+    // so the growth counters restarted from nothing and every delta below spans two
+    // different lives of the page. Reported rather than repaired: the caller can say so.
+    reloaded: b.upMs < a.upMs,
+    rows: VITALS.map((d) => {
+      const first = a[d.id], last = b[d.id];
+      const delta = last - first;
+      return {
+        id: d.id, label: d.label, kind: d.kind, first, last, delta,
+        perHour: delta / hours,
+        pct: d.kind !== "rate" && first > 0 ? (delta / first) * 100 : null,
+      };
+    }),
+  };
+}
+
+/// Which counters are climbing hard enough to name, worst first.
+///
+/// Only `growth` rows can qualify, only past `MIN_SPAN_MS`, and only across a series
+/// that did not reload underneath itself — three refusals rather than a hedged answer,
+/// because the whole value of this readout is that when it does name something, that is
+/// worth acting on. Ranked by how far past its own threshold each one is, so counters
+/// measured in wildly different units still compare.
+export function leakSuspects(d: VitalsDrift | null): DriftRow[] {
+  if (!d || d.spanMs < MIN_SPAN_MS || d.reloaded) return [];
+  return d.rows
+    .filter((r) => {
+      const climb = BY_ID.get(r.id)?.climb;
+      return r.kind === "growth" && climb != null && r.delta > 0 && r.perHour >= climb;
+    })
+    .sort((x, y) => y.perHour / BY_ID.get(y.id)!.climb! - x.perHour / BY_ID.get(x.id)!.climb!);
+}
+
+/// The sentence the Diagnostics tab leads with. One line, and it says which of the four
+/// states you are in — not recording, recording but too early to say, recording and
+/// clean, or recording and here is what grew.
+export function driftVerdict(prefs: VitalsPrefs, d: VitalsDrift | null): string {
+  if (!prefs.enabled) return "Not recording. Switch this on and leave it on — a leak that takes fifteen hours cannot be caught after it happens.";
+  if (!d) return "Recording. The first reading needs two samples.";
+  if (d.reloaded) return "The interface reloaded during this window, so the counters restarted. A fresh reading builds from here.";
+  if (d.spanMs < MIN_SPAN_MS) return `Recording — ${fmtSpanShort(d.spanMs)} so far. Half an hour is the shortest window worth a verdict.`;
+  const bad = leakSuspects(d);
+  if (!bad.length) return `Nothing growing over ${fmtSpanShort(d.spanMs)}. Every unbounded counter is flat or falling.`;
+  // The labels go in as written. Lowercasing them to fit the sentence turned "JS heap"
+  // and "DOM nodes" into "js heap" and "dom nodes", which reads as a typo in the one
+  // sentence anybody will quote back.
+  return `Over ${fmtSpanShort(d.spanMs)}: ${bad.map((r) => `${r.label} +${fmtPerHour(r.perHour)}/h`).join(", ")}.`;
+}
+
+/// Hours and minutes, no seconds — every span this module reports is measured in hours,
+/// and a whole number of them drops the minutes rather than saying "16h 0m".
+export function fmtSpanShort(ms: number): string {
+  const m = Math.round(ms / 60_000);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  return m % 60 ? `${h}h ${m % 60}m` : `${h}h`;
+}
+
+/// A rate a person can read at a glance. Sub-unit rates keep one decimal, because the
+/// heap threshold is 4MB/h and rounding 3.6 to 4 would make a clean reading look flagged.
+export function fmtPerHour(n: number): string {
+  const a = Math.abs(n);
+  if (a >= 1000) return Math.round(n).toLocaleString();
+  if (a >= 10) return String(Math.round(n));
+  return n.toFixed(1);
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -19,7 +19,7 @@ import { agentLogo } from "./providers/logos";
 import {
   allAgents, attnPrefs, availEngines, defaultAgentDef, engineDef, footPrefs,
   keyPrefs, missingAgents,
-  peekPrefs, permissionModeFor, revivePrefs,
+  peekPrefs, permissionModeFor, revivePrefs, termScrollback, vitalsPrefs,
   setTermFontSize,
   SORT_META, SORT_MODES, sortMode, soundPrefs, termEngine, termFontSize, wtGroup,
   type SortMode, type WtGroup,
@@ -36,6 +36,10 @@ import {
 } from "./revive";
 import { LIT_COLOR } from "./sidebarview";
 import { FOOT_SEGS, footShown, type FootSeg } from "./footprefs";
+import {
+  driftVerdict, fmtPerHour, fmtSpanShort, leakSuspects, SCROLLBACK_OPTS, VITALS,
+  VITALS_EVERY, type VitalsDrift, type VitalsPrefs,
+} from "./perf";
 import {
   bindKey, bindableCombo, comboKeys, comboOf, comboText, defaultKeyBinds, defaultKeyPrefs,
   isDefaultBind, isDefaultKeyPrefs, keyActionDef, KEY_GROUPS, resetKey, unbindKey,
@@ -99,6 +103,16 @@ export interface SettingsHost {
   // And for the revive watchdog — ./actions clamps through ./revive, persists, and
   // repaints (the inspector's error card carries the countdown, so `renderAll`).
   setRevivePrefs: (p: RevivePrefs) => void;
+  // Diagnostics. The first two are the usual ./actions setters; the last three are not
+  // settings at all — an inspector, a reload and a reading — which is why they arrive
+  // here rather than being reached through a `cc-` key like everything above them.
+  setVitalsPrefs: (p: VitalsPrefs) => void;
+  setScrollback: (lines: number) => void;
+  openDevtools: () => void;
+  reloadUi: () => void;
+  /// The growth series so far, from ./debug's ring. A reader on the host for the same
+  /// reason `effectiveTheme` is one: this window draws it and owns none of it.
+  vitalsDrift: () => VitalsDrift | null;
 }
 /// The Agent control's hint. Computed rather than fixed because the sentence that
 /// matters depends on the machine: with nothing else installed, "what a new session
@@ -141,6 +155,8 @@ let host: SettingsHost = {
   bumpFont: () => {}, applyFontSize: () => {}, refreshTokens: () => {},
   setWtGroup: () => {}, setPermMode: () => {}, setDefaultAgent: () => {}, setPeekPrefs: () => {}, setSoundPrefs: () => {},
   setKeyPrefs: () => {}, setAttnPrefs: () => {}, setFootSeg: () => {}, setRevivePrefs: () => {},
+  setVitalsPrefs: () => {}, setScrollback: () => {}, openDevtools: () => {}, reloadUi: () => {},
+  vitalsDrift: () => null,
 };
 export function setSettingsHost(h: SettingsHost) { host = h; }
 
@@ -188,7 +204,12 @@ type SetControl =
   // and a `render` tab would also widen the dialog for four rows of text.
   | { kind: "guide"; label: string; hint?: string }
   // Independently-toggled values — "which providers to scan" isn't a pick-one.
-  | { kind: "multi"; set: string; label: string; hint?: string; on: () => string[]; segs: () => SetSeg[]; empty?: string };
+  | { kind: "multi"; set: string; label: string; hint?: string; on: () => string[]; segs: () => SetSeg[]; empty?: string }
+  // A button that *does* something rather than storing a choice — the inspector and the
+  // reload. It rides the same `data-set`/`data-val` join as every other control, so it
+  // needs no wiring of its own; `danger` gives it the destructive colour the confirm
+  // dialog uses, for an action somebody should read the hint before pressing.
+  | { kind: "action"; set: string; label: string; hint?: string; btn: string; danger?: boolean };
 // Most tabs are a list of declarative controls; a tab may instead supply `render`
 // for a bespoke pane (the Usage analytics tab), which also widens the dialog.
 interface SetTab { id: string; label: string; glyph: string; controls: () => SetControl[]; render?: () => string }
@@ -451,6 +472,59 @@ const SET_TABS: SetTab[] = [
     controls: () => [
       { kind: "guide", label: "Guided tour",
         hint: "Replay any chapter, any time. Nothing here opens by itself after the first run — when a release adds something worth showing, What's new offers it and you can say no." },
+    ],
+  },
+  {
+    id: "diag", label: "Diagnostics", glyph: "◔",
+    // Three things in one tab because they are one problem: what the interface weighs,
+    // how to look at it, and the two numbers that change it. The order is deliberate —
+    // recording first, because it is the only one that has to be switched on *before*
+    // the day it is needed, and every other row here is something you can reach for
+    // after the fact.
+    controls: () => [
+      {
+        kind: "note", label: "Why this tab exists",
+        hint: "Left running for a day with a fleet of panes, the interface can slowly get heavier until it feels sluggish — and a reload fixes it, which also destroys the evidence. Recording leaves a trail in the log file so the next time it happens there is something to read.",
+      },
+      {
+        kind: "toggle", set: "perf:vitals", label: "Record performance vitals",
+        hint: "Samples what the interface is holding — DOM nodes, heap, terminal buffers, the per-session structures — and writes one line per sample into Episko's rolling log, where it survives a crash and a reload. Costs a fraction of a millisecond each time.",
+        on: () => vitalsPrefs.enabled,
+        preview: () => vitalsPreview(),
+      },
+      {
+        kind: "seg", set: "perf:every", label: "Sample every",
+        hint: "How often a reading is taken. Below a minute is mostly noise from whatever turn happens to be running; above a quarter of an hour a fifteen-hour slide lands in too few points to see where it started.",
+        dim: () => !vitalsPrefs.enabled,
+        active: () => String(vitalsPrefs.everyMs),
+        segs: () => VITALS_EVERY.map((ms) => ({
+          value: String(ms),
+          label: ms < 3_600_000 ? `${ms / 60_000} min` : `${ms / 3_600_000} h`,
+          glyph: ms === 60_000 ? "◕" : ms === 300_000 ? "◑" : "◔",
+          sub: ms === 60_000 ? "Finest; four hours in memory" : ms === 300_000 ? "A full day in memory" : "Coarsest; lightest log",
+        })) },
+      {
+        kind: "note", label: "Two things that change the weight",
+        hint: "Everything above only watches. These two act — the first on what the app holds from now on, the second on what it is holding right now.",
+      },
+      {
+        kind: "seg", set: "perf:scroll", label: "Terminal scrollback",
+        hint: "Lines of history each pane keeps. Across a fleet this is the largest single thing a long-running Episko holds, and a pane only gives it back when its session ends. Lowering it applies to the panes already open and drops their oldest lines at once.",
+        active: () => String(termScrollback),
+        segs: () => SCROLLBACK_OPTS.map((n) => ({
+          value: String(n),
+          label: `${n.toLocaleString()} lines`,
+          glyph: n === 1000 ? "▁" : n === 4000 ? "▄" : "█",
+          sub: n === 1000 ? "Lightest; roughly a screen of recent history" : n === 4000 ? "Half the default" : "The default",
+        })) },
+      {
+        kind: "action", set: "perf:reload", label: "Reload the interface", btn: "Reload",
+        hint: "Rebuilds the window from scratch and gives back whatever it had accumulated. No session is lost: Episko itself holds the terminals, and every pane is re-adopted with its scrollback. This is the fix when it has already gone sluggish.",
+      },
+      {
+        kind: "action", set: "perf:devtools", label: "Web inspector", btn: "Open",
+        hint: "The webview's own developer tools. Memory takes a heap snapshot you can compare against one from just after a reload; Performance records a profile. This is what turns “something is growing” into a name.",
+      },
     ],
   },
   {
@@ -1095,6 +1169,12 @@ function renderSetControl(c: SetControl): string {
       ? `<div class="set-group"><div class="set-inline">${inner}</div>${c.preview()}</div>`
       : `<div class="set-group set-inline">${inner}</div>`;
   }
+  if (c.kind === "action") {
+    // Same row shape as a toggle, with a button where the switch would be — so a tab that
+    // mixes settings and verbs still reads as one list rather than two.
+    return `<div class="set-group set-inline"><div class="set-itxt">${head}</div>`
+      + `<button class="set-abtn${c.danger ? " danger" : ""}" data-set="${c.set}" data-val="1">${esc(c.btn)}</button></div>`;
+  }
   if (c.kind === "multi") {
     const on = c.on();
     const segs = c.segs();
@@ -1116,6 +1196,44 @@ function renderSetControl(c: SetControl): string {
   ).join("");
   return `<div class="set-group${dim}">${head}<div class="seg">${opts}</div></div>`;
 }
+// ---- Settings > Diagnostics: the growth series, drawn ----
+//
+// The verdict sentence is always shown and the table only when there is something in it,
+// because the four states this can be in are genuinely different answers and an empty
+// grid says none of them. What the table shows is first-sample against last, per counter,
+// with its kind spelled out: a `level` reading high is information, a `growth` reading
+// high is a suspect, and without that distinction the row for scrollback lines — which is
+// supposed to saturate near its ceiling — looks like the worst leak on the list.
+//
+// Only the flagged rows are coloured. Everything else is deliberately plain: this is a
+// table somebody reads once a day at most, and a column of amber arrows on counters that
+// are behaving would make the one that isn't harder to find, not easier.
+function vitalsPreview(): string {
+  const d = host.vitalsDrift();
+  const verdict = driftVerdict(vitalsPrefs, d);
+  const bad = new Set(leakSuspects(d).map((r) => r.id));
+  const cls = bad.size ? "sv-warn" : "";
+  const head = `<div class="set-vitals"><div class="sv-verdict ${cls}">${esc(verdict)}</div>`;
+  if (!d) return `${head}</div>`;
+  const rows = d.rows.map((r) => {
+    const def = VITALS.find((v) => v.id === r.id);
+    // A rate is a running total, so its start and end values are meaningless on their own
+    // and only the per-hour column says anything. Blanking the other two is the honest
+    // rendering; showing "8,123 → 20,441" invites somebody to read a leak into a counter
+    // whose whole job is to keep counting.
+    const rate = r.kind === "rate";
+    const sign = r.delta > 0 ? "+" : "";
+    return `<tr class="${bad.has(r.id) ? "sv-bad" : ""}" title="${escAttr(def?.hint ?? "")}">`
+      + `<td>${esc(r.label)}<span class="sv-kind">${r.kind}</span></td>`
+      + `<td class="mono">${rate ? "–" : r.last.toLocaleString()}</td>`
+      + `<td class="mono">${rate ? "–" : `${sign}${r.delta.toLocaleString()}`}</td>`
+      + `<td class="mono">${sign}${fmtPerHour(r.perHour)}</td></tr>`;
+  }).join("");
+  return `${head}<table class="sv-tbl"><thead><tr><th>Counter</th><th>Now</th><th>Change</th><th>Per hour</th></tr></thead>`
+    + `<tbody>${rows}</tbody></table>`
+    + `<div class="sv-foot">${d.samples} samples over ${esc(fmtSpanShort(d.spanMs))} · the full series is in episko.log, one line per sample behind <span class="mono">vitals</span></div></div>`;
+}
+
 // Dispatch a segmented pick to the existing setter, then repaint the picker.
 function applySetting(set: string, val: string) {
   if (set === "theme") host.setTheme(val as "dark" | "light");
@@ -1139,6 +1257,13 @@ function applySetting(set: string, val: string) {
   // `foot:<id>` rather than seven names in this chain: the ids are ./footprefs' and
   // adding a segment there should not mean editing a switch statement here too.
   else if (set.startsWith("foot:")) host.setFootSeg(set.slice(5) as FootSeg);
+  // `perf:*` rather than five loose names, on the same reasoning as `foot:` above: these
+  // belong to one tab and one module, and two of them are verbs rather than settings.
+  else if (set === "perf:vitals") host.setVitalsPrefs({ ...vitalsPrefs, enabled: val === "1" });
+  else if (set === "perf:every") host.setVitalsPrefs({ ...vitalsPrefs, everyMs: +val });
+  else if (set === "perf:scroll") host.setScrollback(+val);
+  else if (set === "perf:reload") { void host.reloadUi(); return; }
+  else if (set === "perf:devtools") { host.openDevtools(); return; }
   else if (set === "untrust") untrustProject(val);
   else if (set === "unstop") clearStopRule(val);
   renderSettings();

--- a/src/state.ts
+++ b/src/state.ts
@@ -28,6 +28,7 @@ import { clampPeekPrefs, type PeekPrefs } from "./peek";
 import { clampRevivePrefs, type RevivePrefs } from "./revive";
 import { clampGroups, type GroupStore } from "./projgroups";
 import { clampSoundPrefs, type SoundPrefs } from "./sound";
+import { clampScrollback, clampVitalsPrefs, type VitalsPrefs } from "./perf";
 import { agentInstalled, CLAUDE_CLI, pickAgent } from "./types";
 import type { AgentCli, DiffStat, Engine, ExtSession, Res, Restorable, Sess, WtHead } from "./types";
 import { parseFootPrefs, type FootPrefs } from "./footprefs";
@@ -428,3 +429,16 @@ export const ioAll: Res = { readBps: 0, writeBps: 0, readMb: 0, writtenMb: 0, pr
 // permanently, so there is nothing left to cycle and nothing left to expand.
 export let footPrefs: FootPrefs = parseFootPrefs(localStorage.getItem("cc-foot"));
 export function setFootPrefs(p: FootPrefs) { footPrefs = p; }
+
+// Whether the frontend records its own weight on a timer, and how often. One JSON blob
+// under cc-perf for the same reason as cc-attn above: two fields that are only ever set
+// together, from one switch and one picker in the same group. The model — what is
+// sampled, what each counter is allowed to accuse, and the log line — is ./perf's.
+export let vitalsPrefs: VitalsPrefs = clampVitalsPrefs(safeParse(localStorage.getItem("cc-vitals")));
+export function setVitalsPrefs(p: VitalsPrefs) { vitalsPrefs = clampVitalsPrefs(p); }
+
+// Lines of scrollback each new terminal keeps. Read here and applied by ./panes at
+// creation and by ./terminal to the panes already open, so a change reaches a fleet
+// that has been up for hours — which is the only fleet the setting is for.
+export let termScrollback: number = clampScrollback(localStorage.getItem("cc-scrollback"));
+export function setTermScrollback(n: number) { termScrollback = clampScrollback(n); }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1864,6 +1864,33 @@ select.in-ctl { cursor: pointer; }
 .set-freset { margin-left: 6px; height: 30px; padding: 0 12px; border-radius: 8px; cursor: pointer; font: 600 11px var(--font-ui); color: var(--muted); background: transparent; border: 1px solid var(--hair); }
 .set-freset:hover { color: var(--text); border-color: var(--hair-strong); }
 
+/* ---------- Diagnostics tab ---------- */
+/* The action button: a settings row whose right-hand control is a verb rather than a
+   switch. Sized to `.sw`'s row so a tab that mixes the two still reads as one list. */
+.set-abtn { flex: none; height: 30px; padding: 0 14px; border-radius: 8px; cursor: pointer; font: 650 11.5px var(--font-ui); color: var(--text); background: var(--surface); border: 1px solid var(--hair-strong); }
+.set-abtn:hover { border-color: var(--accent-line); background: var(--surface-2); }
+.set-abtn.danger { color: var(--st-error); border-color: color-mix(in srgb, var(--st-error) 34%, transparent); }
+.set-abtn.danger:hover { background: color-mix(in srgb, var(--st-error) 10%, transparent); }
+
+/* The growth readout under the recording switch. A panel rather than bare rows because
+   it is the one thing on this tab that is a *reading* and not a control, and the border
+   is what stops it being read as another settable row. */
+.set-vitals { margin-top: 10px; padding: 11px 12px; border: 1px solid var(--hair); border-radius: 10px; background: var(--bg-2); }
+.sv-verdict { font-size: 11.5px; line-height: 1.45; color: var(--muted); max-width: 62ch; }
+.sv-verdict.sv-warn { color: var(--st-working); font-weight: 600; }
+.sv-tbl { width: 100%; border-collapse: collapse; margin-top: 10px; font-size: 11px; }
+.sv-tbl th { text-align: right; font-weight: 600; color: var(--muted-2); padding: 0 0 5px; border-bottom: 1px solid var(--hair); }
+.sv-tbl th:first-child { text-align: left; }
+.sv-tbl td { text-align: right; padding: 4px 0; color: var(--muted); border-bottom: 1px solid var(--hair); }
+.sv-tbl td:first-child { text-align: left; color: var(--text); }
+.sv-tbl tr:last-child td { border-bottom: 0; }
+/* Only a flagged row takes colour — see the note on `vitalsPreview`. */
+.sv-tbl tr.sv-bad td, .sv-tbl tr.sv-bad td:first-child { color: var(--st-working); }
+/* The kind, set small beside the name so "level" and "growth" are readable as a property
+   of the counter rather than as another column to scan. */
+.sv-kind { margin-left: 7px; font: 600 9.5px var(--font-mono); letter-spacing: .04em; text-transform: uppercase; color: var(--muted-2); }
+.sv-foot { margin-top: 9px; font-size: 10.5px; color: var(--muted-2); max-width: 62ch; line-height: 1.45; }
+
 /* ---------- Usage analytics tab ---------- */
 .setdlg.wide { width: min(1120px, 96vw); height: min(884px, 92vh); }
 .u-pane { display: flex; flex-direction: column; gap: 16px; }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -100,7 +100,7 @@ export function detachWebgl(s: Sess) {
   for (const c of canvases) { c.width = 0; c.height = 0; }
 }
 
-// An ended resumable agent pane keeps up to 8000 lines of scrollback it can never grow
+// An ended resumable agent pane keeps a full buffer of scrollback it can never grow
 // again, tens of MB across a day — while provider history can reopen the conversation.
 // So the buffer is reclaimed once the pane is done: immediately
 // when it ends off stage, and on the way *off* the stage when you watched it end (the
@@ -109,6 +109,22 @@ export function detachWebgl(s: Sess) {
 export function trimScrollback(s: Sess) {
   if (!s.term || s.term.options.scrollback === 0) return;
   try { s.term.options.scrollback = 0; } catch { /* pane already disposed */ }
+}
+
+// Push a changed scrollback setting onto the panes already open. The setting exists for
+// a fleet that has been up for hours, so applying it only to *new* terminals would mean
+// the one thing it can help never gets it.
+//
+// **A pane already trimmed to 0 is left alone**, which is the whole subtlety here: that
+// zero is `trimScrollback`'s deliberate reclaim on an ended pane, not a value anybody
+// chose, and handing it 4000 back would refill the buffer this app just freed. Lowering
+// the limit drops the oldest lines at once (xterm applies it on assignment); raising it
+// only sets the new ceiling, since the lines it would have kept are already gone.
+export function applyScrollback(list: Iterable<Sess>, lines: number) {
+  for (const s of list) {
+    if (!s.term || s.term.options.scrollback === 0) continue;
+    try { s.term.options.scrollback = lines; } catch { /* pane disposed mid-pass */ }
+  }
 }
 
 // The whole custom key rule for a shell pane, in one handler — xterm keeps only the

--- a/test/perf.test.ts
+++ b/test/perf.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampScrollback, clampVitalsPrefs, driftVerdict, fmtPerHour, fmtSpanShort, leakSuspects,
+  MIN_SPAN_MS, pushVitals, SCROLLBACK_DEFAULT, SCROLLBACK_OPTS, VITALS, VITALS_CAP,
+  VITALS_DEFAULTS, VITALS_EVERY, vitalsDrift, vitalsLine, vitalsPrefsJson,
+  type VitalCounts, type Vitals,
+} from "../src/perf";
+
+const HOUR = 3_600_000;
+
+/// A sample with every counter at zero, so a test names only the ones it is about.
+function sample(t: number, over: Partial<VitalCounts & { upMs: number }> = {}): Vitals {
+  return {
+    t, upMs: t,
+    dom: 0, heapMB: 0, canvases: 0, files: 0, servers: 0, termLines: 0,
+    panes: 0, gl: 0, acts: 0, hist: 0, paints: 0, events: 0,
+    ...over,
+  };
+}
+
+/// Two samples `hours` apart, the second differing by `over`.
+function series(hours: number, over: Partial<VitalCounts & { upMs: number }>): Vitals[] {
+  const t0 = 1_700_000_000_000;
+  return [sample(t0), sample(t0 + hours * HOUR, { upMs: t0 + hours * HOUR, ...over })];
+}
+
+describe("the counter table", () => {
+  it("has a unique id and log key for every counter", () => {
+    expect(new Set(VITALS.map((v) => v.id)).size).toBe(VITALS.length);
+    expect(new Set(VITALS.map((v) => v.key)).size).toBe(VITALS.length);
+  });
+  // The whole accusation rule reads `climb != null && kind === "growth"`, so a threshold
+  // on a level or a rate would arm a counter that is bounded or monotonic by design — a
+  // permanent false positive on the two kinds that exist precisely to not be accused.
+  it("carries a climb threshold on growth counters and on nothing else", () => {
+    for (const v of VITALS) {
+      if (v.kind === "growth") expect(v.climb, `${v.id} is growth and needs a threshold`).toBeGreaterThan(0);
+      else expect(v.climb, `${v.id} is a ${v.kind} and must not have one`).toBeUndefined();
+    }
+  });
+  it("says something about every counter, since the table is the only documentation the tab has", () => {
+    for (const v of VITALS) {
+      expect(v.label.length).toBeGreaterThan(2);
+      expect(v.hint.length).toBeGreaterThan(30);
+    }
+  });
+});
+
+describe("clampVitalsPrefs — the store and its repair", () => {
+  it("is off with nothing stored, which is what a fresh install gets", () => {
+    expect(clampVitalsPrefs(null)).toEqual(VITALS_DEFAULTS);
+    expect(clampVitalsPrefs(undefined).enabled).toBe(false);
+  });
+  // The switch has to be an explicit `true`. A stored `"yes"`, a `1` or a truthy object
+  // would otherwise start a recorder nobody asked for on a store somebody hand-edited.
+  it("only ever reads a literal true as on", () => {
+    expect(clampVitalsPrefs({ enabled: true }).enabled).toBe(true);
+    for (const junk of [1, "true", {}, [], "on"]) {
+      expect(clampVitalsPrefs({ enabled: junk as never }).enabled).toBe(false);
+    }
+  });
+  it("refuses a cadence that is not one of the three offered", () => {
+    expect(clampVitalsPrefs({ everyMs: 60_000 }).everyMs).toBe(60_000);
+    for (const junk of [0, -1, 42, 86_400_000, NaN, "300000" as never, null as never]) {
+      expect(clampVitalsPrefs({ everyMs: junk as number }).everyMs).toBe(VITALS_DEFAULTS.everyMs);
+    }
+  });
+  it("round-trips through its stored form", () => {
+    const p = { enabled: true, everyMs: VITALS_EVERY[2] };
+    expect(clampVitalsPrefs(JSON.parse(vitalsPrefsJson(p)))).toEqual(p);
+  });
+});
+
+describe("clampScrollback", () => {
+  it("keeps the three offered sizes", () => {
+    for (const n of SCROLLBACK_OPTS) expect(clampScrollback(String(n))).toBe(n);
+  });
+  // Snapping to the *default* rather than to the nearest option is the deliberate half:
+  // a stored `50` honoured as 1000 is defensible, but honoured as 50 it is a terminal
+  // with no history and nothing on screen saying why.
+  it("falls back to the default for anything else, rather than to the nearest size", () => {
+    for (const junk of [null, undefined, "", "lots", 0, -1, 50, 999, 12_000, NaN]) {
+      expect(clampScrollback(junk)).toBe(SCROLLBACK_DEFAULT);
+    }
+  });
+});
+
+describe("pushVitals", () => {
+  it("keeps the newest samples and drops the oldest past the cap", () => {
+    const ring: Vitals[] = [];
+    for (let i = 0; i < 5; i++) pushVitals(ring, sample(i), 3);
+    expect(ring.length).toBe(3);
+    expect(ring.map((v) => v.t)).toEqual([2, 3, 4]);
+  });
+  it("holds a useful span at the default cap", () => {
+    // 300 samples at the five-minute cadence is a full day, which is the incident length
+    // this whole feature is sized for.
+    expect((VITALS_CAP * 300_000) / HOUR).toBeGreaterThanOrEqual(24);
+  });
+});
+
+describe("vitalsLine — the durable form", () => {
+  const line = vitalsLine(sample(0, { upMs: 90 * 60_000, dom: 1842, heapMB: 118, panes: 6 }));
+  it("is greppable behind one stable prefix", () => {
+    expect(line.startsWith("vitals ")).toBe(true);
+  });
+  it("writes every counter, in the table's order, as key=value", () => {
+    expect(line).toContain("dom=1842");
+    expect(line).toContain("heap=118");
+    expect(line).toContain("panes=6");
+    const keys = [...line.matchAll(/(\w+)=/g)].map((m) => m[1]);
+    expect(keys).toEqual(["up", ...VITALS.map((v) => v.key)]);
+  });
+  it("reports page uptime in minutes, so a reload is visible as a drop", () => {
+    expect(line).toContain("up=90m");
+  });
+});
+
+describe("vitalsDrift", () => {
+  it("says nothing at all with fewer than two samples", () => {
+    expect(vitalsDrift([])).toBeNull();
+    expect(vitalsDrift([sample(0)])).toBeNull();
+  });
+  it("compares first against last and reports the rate per hour", () => {
+    const d = vitalsDrift(series(4, { dom: 800 }))!;
+    const dom = d.rows.find((r) => r.id === "dom")!;
+    expect(dom.first).toBe(0);
+    expect(dom.last).toBe(800);
+    expect(dom.delta).toBe(800);
+    expect(dom.perHour).toBe(200);
+  });
+  it("uses the whole ring's endpoints, not the last pair", () => {
+    const t0 = 1_700_000_000_000;
+    const ring = [0, 1, 2, 3].map((h) => sample(t0 + h * HOUR, { upMs: t0 + h * HOUR, dom: h * 100 }));
+    const d = vitalsDrift(ring)!;
+    expect(d.samples).toBe(4);
+    expect(d.spanMs).toBe(3 * HOUR);
+    expect(d.rows.find((r) => r.id === "dom")!.delta).toBe(300);
+  });
+  // A percentage off a zero start is either infinity or a fiction, and the readout draws
+  // whatever it is handed.
+  it("gives no percentage when a counter started at zero", () => {
+    const d = vitalsDrift(series(1, { dom: 50, heapMB: 0 }))!;
+    expect(d.rows.find((r) => r.id === "dom")!.pct).toBeNull();
+  });
+  it("gives a percentage when it started somewhere", () => {
+    const t0 = 1_700_000_000_000;
+    const d = vitalsDrift([
+      sample(t0, { dom: 100 }),
+      sample(t0 + HOUR, { upMs: t0 + HOUR, dom: 150 }),
+    ])!;
+    expect(d.rows.find((r) => r.id === "dom")!.pct).toBeCloseTo(50);
+  });
+  // The one signal that says the series spans two lives of the page. Without it a reload
+  // — the workaround for this very bug — reads as every counter dropping to zero, i.e.
+  // as a fix.
+  it("flags a window the webview reloaded inside", () => {
+    const t0 = 1_700_000_000_000;
+    const ring = [
+      sample(t0, { upMs: 10 * HOUR, dom: 5000 }),
+      sample(t0 + HOUR, { upMs: 60_000, dom: 700 }),
+    ];
+    expect(vitalsDrift(ring)!.reloaded).toBe(true);
+    expect(vitalsDrift(series(1, { dom: 1 }))!.reloaded).toBe(false);
+  });
+});
+
+describe("leakSuspects — what is allowed to accuse", () => {
+  it("names a growth counter climbing past its threshold", () => {
+    // 800 DOM nodes over 2h is 400/h, twice the 200/h threshold.
+    const bad = leakSuspects(vitalsDrift(series(2, { dom: 800 })));
+    expect(bad.map((r) => r.id)).toEqual(["dom"]);
+  });
+  it("stays quiet below the threshold", () => {
+    expect(leakSuspects(vitalsDrift(series(2, { dom: 100 })))).toEqual([]);
+  });
+  // The health.ts rule, one level down: a chip that fires on ordinary behaviour teaches
+  // you to ignore the row that matters. Scrollback filling to its ceiling and the paint
+  // counter counting are both *correct*, and both would otherwise dominate every reading.
+  it("never accuses a level or a rate, however fast it climbs", () => {
+    const d = vitalsDrift(series(2, { termLines: 90_000, acts: 40_000, paints: 300_000, events: 500_000 }));
+    expect(leakSuspects(d)).toEqual([]);
+  });
+  it("says nothing about a window shorter than half an hour", () => {
+    const short = vitalsDrift(series(MIN_SPAN_MS / HOUR / 2, { dom: 100_000 }));
+    expect(short!.rows.find((r) => r.id === "dom")!.perHour).toBeGreaterThan(0);
+    expect(leakSuspects(short)).toEqual([]);
+  });
+  it("says nothing about a window the page reloaded inside", () => {
+    const t0 = 1_700_000_000_000;
+    const ring = [
+      sample(t0, { upMs: 10 * HOUR, dom: 100 }),
+      sample(t0 + 2 * HOUR, { upMs: 60_000, dom: 9000 }),
+    ];
+    expect(leakSuspects(vitalsDrift(ring))).toEqual([]);
+  });
+  it("ignores a counter that fell", () => {
+    const t0 = 1_700_000_000_000;
+    const ring = [
+      sample(t0, { dom: 9000 }),
+      sample(t0 + 2 * HOUR, { upMs: t0 + 2 * HOUR, dom: 100 }),
+    ];
+    expect(leakSuspects(vitalsDrift(ring))).toEqual([]);
+  });
+  // Counters measured in nodes and in megabytes cannot be ranked by raw rate, so the
+  // order is by multiple of each one's own threshold. Here: dom at 3x, heap at 10x.
+  it("ranks by how far past its own threshold each one is, not by raw rate", () => {
+    const bad = leakSuspects(vitalsDrift(series(1, { dom: 600, heapMB: 40 })));
+    expect(bad.map((r) => r.id)).toEqual(["heapMB", "dom"]);
+  });
+});
+
+describe("driftVerdict — the sentence the tab leads with", () => {
+  const on = { enabled: true, everyMs: 300_000 };
+  it("says it is not recording when it is not, and says what that costs", () => {
+    const v = driftVerdict({ enabled: false, everyMs: 300_000 }, vitalsDrift(series(9, { dom: 9000 })));
+    expect(v).toMatch(/not recording/i);
+  });
+  it("distinguishes too-early from clean", () => {
+    expect(driftVerdict(on, null)).toMatch(/two samples/i);
+    expect(driftVerdict(on, vitalsDrift(series(0.2, {})))).toMatch(/half an hour/i);
+    expect(driftVerdict(on, vitalsDrift(series(9, {})))).toMatch(/nothing growing/i);
+  });
+  it("names what grew, with its rate", () => {
+    const v = driftVerdict(on, vitalsDrift(series(2, { dom: 800 })));
+    expect(v).toMatch(/DOM nodes/);  // as written in the table, not lowercased into "dom nodes"
+    expect(v).toContain("+400/h");
+  });
+  it("explains a reload rather than reporting the nonsense it produces", () => {
+    const t0 = 1_700_000_000_000;
+    const v = driftVerdict(on, vitalsDrift([
+      sample(t0, { upMs: 10 * HOUR, dom: 5000 }),
+      sample(t0 + 2 * HOUR, { upMs: 60_000, dom: 100 }),
+    ]));
+    expect(v).toMatch(/reloaded/i);
+  });
+});
+
+describe("the two formatters", () => {
+  it("writes a span in hours and minutes", () => {
+    expect(fmtSpanShort(20 * 60_000)).toBe("20m");
+    expect(fmtSpanShort(95 * 60_000)).toBe("1h 35m");
+    // A whole number of hours drops the minutes — "16h 0m" reads as a bug in the sentence
+    // the verdict builds around it.
+    expect(fmtSpanShort(16 * 3_600_000)).toBe("16h");
+  });
+  // The heap threshold is 4MB/h, so a rate rounded to a whole number would print a clean
+  // 3.6 as "4" — the flagged value — on the counter the whole feature turns on.
+  it("keeps a decimal on small rates, where the thresholds live", () => {
+    expect(fmtPerHour(3.6)).toBe("3.6");
+    expect(fmtPerHour(0.4)).toBe("0.4");
+    expect(fmtPerHour(34.2)).toBe("34");
+    expect(fmtPerHour(4210)).toBe((4210).toLocaleString());
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,15 @@ export default defineConfig(async () => ({
   //
   // 1. prevent Vite from obscuring rust errors
   clearScreen: false,
+  // Off by default, on for a build you intend to profile: `EPISKO_SOURCEMAP=1 pnpm tauri
+  // build`. The inspector now ships in release builds (the `devtools` Cargo feature), but
+  // the bundle it opens on is 842KB of minified JavaScript, so every frame in a CPU
+  // profile comes back as `Iu` or `Vf` — readable enough to tell library from app code
+  // and useless for anything past that. This is the switch that makes a profile name our
+  // own functions. It stays off by default because a normal release has no reason to ship
+  // the source of every module beside it.
+  // @ts-expect-error process is a nodejs global
+  build: { sourcemap: !!process.env.EPISKO_SOURCEMAP },
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
     port: 1420,


### PR DESCRIPTION
Left running for a day with a fleet of panes, the webview's renderer slowly saturates a core until every hover and click lags — and a reload fixes it, freeing ~130MB and costing no sessions. Every existing surface is blind to it: `dbgSnapshot` is state-of-now by construction, so nothing in it can show a counter that has been climbing since breakfast, and by the time the app is slow enough to investigate, the only honest move is the reload that destroys the evidence.

So this adds the half that was missing — a time series that is already running before anybody notices — plus the three things you reach for once it names something.

## Settings › Diagnostics

| Row | What |
| --- | --- |
| **Record performance vitals** *(ships off)* | Samples DOM nodes, JS heap, canvases, scrollback lines, context files, background shells, panes, WebGL contexts, paints and events every 1/5/15 min |
| **Terminal scrollback** | 1,000 / 4,000 / 8,000 lines, applied to panes already open |
| **Reload the interface** | The Ctrl+R workaround, as a button that says no session is lost |
| **Web inspector** | Real devtools in the shipped build |

Each reading is teed into the rolling `episko.log` via `log_frontend` — **never `dlog`**, which would push real events out of the 400-entry ring the debug panel exists to show. One greppable line per sample, in a form that survives both a crash and the reload:

```
vitals up=961m dom=4884 heap=148 canvas=8 files=600 srv=3 term=48000 panes=6 gl=6 paints=49600 ev=57600
```

## Three rules keep the readout honest

- **A counter's `kind` decides what it may accuse.** Only an unbounded `growth` one can; never a `level` (scrollback lines saturate at their ceiling by design) or a `rate` (a total that counts is not a leak). Same reasoning as `health.ts`'s — a rule that fires on ordinary behaviour teaches you to ignore the row that matters, and here it would fire on the very structures already ruled out by measurement.
- **No verdict under half an hour.** One busy turn makes any counter look alarming, and a diagnostic that cries leak on its first reading is one you learn to close.
- **No verdict across a reload.** `upMs` going backwards means the page restarted; the fix for this bug zeroes every growth counter, which would otherwise read as a cure.

Fed a simulated sixteen-hour night it says *"Over 16h: JS heap +8.4/h, DOM nodes +260/h"* — and stays quiet about scrollback climbing 3000/h, which is the row that would otherwise dominate every reading.

It ships **off**, on the sound-alerts rule, and the tab says plainly that it has to be armed *before* the day it is needed.

## The other three rows

- **The inspector** comes from the `devtools` Cargo feature, so a heap snapshot no longer needs relaunching the shipped binary under a WebView2 debugging port and reading minified frames. `EPISKO_SOURCEMAP=1 pnpm tauri build` makes one whose profiles name our own functions; off by default, since a normal release has no reason to ship the source beside the bundle. (Tauri's note about private APIs on macOS matters for the App Store, not for Developer ID distribution.)
- **Scrollback** is the direct test of the standing hypothesis that 8,000 lines across a long-lived fleet is what goes wrong — `trimScrollback` only ever reclaims it from panes that have *ended*. `applyScrollback` leaves a pane already trimmed to 0 alone: that zero is the deliberate reclaim, and handing it a limit back would refill a buffer the app just freed.
- **Reload** was always the fix and always looked like it would kill your fleet. It does not — the backend holds the PTYs and `adoptOrphans` re-adopts every pane with its scrollback — and nothing in the app said so.

## Shape

`perf.ts` is a new tested logic module (no DOM, no Tauri, no render imports) holding the counter table, the two preferences, the drift between two readings and the log line. `debug.ts` samples it, because it is the module that already owns both the snapshot and the log tee — and because sampling touches `document` and `performance.memory`, which the node test environment does not have. The Diagnostics readout reaches it through the settings host rather than an import, like `effectiveTheme`.

`SetControl` grows one kind, `action` — a row whose control is a verb rather than a stored choice. It rides the existing `data-set`/`data-val` join, so it needs no wiring of its own.

## Gates

- `tsc` clean on **both** projects (`src/` and `test/`)
- 1498 vitest pass across 38 files — 33 new in `test/perf.test.ts`
- `pnpm build` clean
- `cargo clippy --all-targets -- -D warnings` clean; 253 cargo tests pass (3 ignored)
- No import cycles across the 77 modules

**Not verified: the tab has not been walked in a running app.** The logic is tested and the markup builds, but per CLAUDE.md the render half is only real once it is clicked — worth a pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8EC4svqSeqFB41ryENtD3
