### PR TITLE
usage: name every model, rather than filing most of them under Other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Markers: `+` new · `~` changed · `!` fixed
 
 ## Unreleased
 
+~ **Usage & spend names every model.** Fable, and anything a non-Claude provider runs, was
+  counted as *Other*; the bar chart, mix and legend now list each model by name and version,
+  a family keeping one colour across its releases.
+
 ## 0.26.0 — 2026-09-08
 What the status bar and the dashboard only summarise now opens in one click — and the
 outline finds the question you clicked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ What `main.ts` still holds, deliberately: the imports and the whole of the `setX
 | `format.ts` | durations, paths, escaping, sparklines, recency bands, money and token counts; data in, string out. `dialogBody` is here too: a confirmation's plain-text prose → the markup ./confirm paints. So is `cleanTitle` — the OSC title minus Claude's spinner — because that table tracks somebody else's release and belongs where it can be tested. `TitlePrefs` (Settings › Appearance, `cc-title`) only ever **adds** to that table, so a new spinner family needs no release; added codepoints are emitted as `\u{…}` escapes, since the field invites people to type the character class's own syntax |
 | `diff.ts` | the unified-diff parser behind the working-set viewer (the extraction precedent), plus what a *reader* needs from a hunk: which deletion became which addition (by similarity, not by position), and which words inside that pair moved — including when marking them would be noise |
 | `rl.ts` | account-wide rate limits: merging readings, burn rate, the window forecast |
-| `usage.ts` | the `cc-usage` daily rollup, `uBuckets`/`uSum`, the day/token join, `daySpend`'s split of a day, the `cc-io` disk rollup and what keeps a claude self-update's ~290 MiB out of it |
+| `usage.ts` | the `cc-usage` daily rollup, `uBuckets`/`uSum`, the day/token join, `daySpend`'s split of a day, how a model is named (`modelName`) and the one order and colour slot every model surface shares (`modelSeries`), the `cc-io` disk rollup and what keeps a claude self-update's ~290 MiB out of it |
 | `phase.ts` | `applyHook` / `applyStatusline`: telemetry → session state. The heart of the display |
 | `files.ts` | the inspector's Context card: which files a session read, edited and created, the ladder a file's kind climbs, and the one-line tally of everything that moved no file |
 | `health.ts` | which of `health.rs`'s measurements are worth saying: the thresholds and where each comes from, the two rules the patch answers alone (silenced errors, no test changed), and what a chip says |
@@ -367,6 +367,13 @@ And the things that hold however the files are arranged:
   `docs/architecture.md`.
 - **A turn that ended while its agents run on stays `background`.** The `Workflow` tool returns a run id in ~2s and `Stop` fires while its fleet runs for another twenty minutes, so `done` alone stopped meaning "your turn". `Sess.fanout` holds the run (named from the `PreToolUse{Workflow}` payload, with no disk and no backend) and **`Sess.agents` holds the agents still up, keyed by the `agent_id` both `Subagent*` hooks carry** — identity rather than a counter, for the same reason a tool call's Pre and Post pair by `tool_use_id`. Read it through `liveAgents`/`liveCount`, never by `.size`: an agent a *newer* fan-out inherited is stamped `orphanedAt` by `startFanout` and ages out on its own short window, because the hour that guards a live fleet only guards a ghost once the run that would report its Stop has been replaced (that is the "34 / 36" bug — see `docs/architecture.md`). `statusKey` answers `"background"` for a live fleet, and `needsYou` says no. **Never add a status to `GLYPH`/`GCLASS` without also adding it to `tray.ts`'s `SHAPE`**; see `docs/architecture.md`.
 - **A `localStorage` write on the telemetry path is a disk write**: statusLines land every ~10s per session. Three cadences, chosen deliberately: eager (`cc-usage`, small and unreconstructable), only-when-changed (`cc-cost-base`), floored and flushed on quit/midnight (`cc-usage-detail` 30s, `cc-io` 60s). Cap anything keyed by day. Sizes and reasoning: `docs/architecture.md`.
+- **A model is named on read, and both spellings must land on one name.** The transcript
+  scan stores `message.model` verbatim and the live provider rows store `Sess.model`, so
+  `usage.rs` never spells a family: ./usage's `modelName` turns `claude-fable-5-1` and the
+  statusLine's "Claude Fable 5.1" into one key, or a day's tokens draw the same model twice.
+  It is idempotent (a store may already hold a named key) and it names *everything* — the
+  fixed opus/sonnet/haiku/other columns it replaced filed a whole provider under `Other`.
+  ./usageview owns the colours; `modelSeries` owns the order and which version wears the hue.
 - **An infinite animation and a `backdrop-filter` are a per-frame GPU cost, not a
   one-off.** Each pins the WebView2 compositor to the monitor's refresh rate for as long
   as it exists — 144Hz on a Windows desktop against the 60 this was designed at, which is

--- a/src-tauri/src/usage.rs
+++ b/src-tauri/src/usage.rs
@@ -405,25 +405,13 @@ fn scan_history_in(base: &Path, limit: usize) -> Vec<HistorySession> {
     out
 }
 
-/// The three model tiers collapsed to a family (matches the frontend's `modelFamily`).
-fn model_family(model: &str) -> &'static str {
-    let s = model.to_ascii_lowercase();
-    if s.contains("opus") {
-        "opus"
-    } else if s.contains("sonnet") {
-        "sonnet"
-    } else if s.contains("haiku") {
-        "haiku"
-    } else {
-        "other"
-    }
-}
-
 struct LineUsage {
-    day: String,           // YYYY-MM-DD from the line's own ISO timestamp (UTC)
-    tokens: [u64; 4],      // [input, output, cache_read, cache_write]
-    family: &'static str,  // opus | sonnet | haiku | other
-    cwd: String,           // the line's cwd verbatim; `project_label` groups it
+    day: String,      // YYYY-MM-DD from the line's own ISO timestamp (UTC)
+    tokens: [u64; 4], // [input, output, cache_read, cache_write]
+    /// `message.model` verbatim. Naming it is the frontend's (`modelName`), so one rule
+    /// covers both spellings and improving it needs no re-scan of every transcript.
+    model: String,
+    cwd: String, // the line's cwd verbatim; `project_label` groups it
     /// `message.id`. Claude Code writes one line per content block, each repeating the
     /// same `usage`, so the scan dedupes on this; a record with no id is counted as it is.
     id: Option<String>,
@@ -465,7 +453,7 @@ fn parse_usage_line(line: &str) -> Option<LineUsage> {
             g("cache_read_input_tokens"),
             g("cache_creation_input_tokens"),
         ],
-        family: model_family(model),
+        model: model.to_string(),
         cwd,
         id,
     })
@@ -499,10 +487,7 @@ pub(crate) struct DayUsage {
     output: u64,
     cache_read: u64,
     cache_write: u64,
-    opus: u64,
-    sonnet: u64,
-    haiku: u64,
-    other: u64,
+    models: std::collections::BTreeMap<String, u64>,
     sessions: u64,
     projects: std::collections::BTreeMap<String, u64>,
 }
@@ -566,7 +551,7 @@ fn scan_usage_in(base: &Path, days: u64) -> Result<Vec<DayUsage>, String> {
             let mut file_days: HashSet<String> = HashSet::new();
             for line in BufReader::new(file).lines().map_while(Result::ok) {
                 let Some(lu) = parse_usage_line(&line) else { continue };
-                let LineUsage { day, tokens, family, cwd, id } = lu;
+                let LineUsage { day, tokens, model, cwd, id } = lu;
                 // Claimed before the dedupe gate: the session was active that day even if
                 // every line of it is a repeat.
                 file_days.insert(day.clone());
@@ -585,12 +570,7 @@ fn scan_usage_in(base: &Path, days: u64) -> Result<Vec<DayUsage>, String> {
                 e.output += tokens[1];
                 e.cache_read += tokens[2];
                 e.cache_write += tokens[3];
-                match family {
-                    "opus" => e.opus += tot,
-                    "sonnet" => e.sonnet += tot,
-                    "haiku" => e.haiku += tot,
-                    _ => e.other += tot,
-                }
+                *e.models.entry(model).or_insert(0) += tot;
                 *e.projects.entry(project).or_insert(0) += tot;
             }
             for d in file_days {
@@ -1167,19 +1147,19 @@ mod tests {
 
 
     #[test]
-    fn parse_usage_line_extracts_day_tokens_family_and_project() {
+    fn parse_usage_line_extracts_day_tokens_model_and_project() {
         let line = r#"{"type":"assistant","timestamp":"2026-07-21T10:00:00.000Z","cwd":"/Users/tim/dev/episko","message":{"model":"claude-opus-4-8","usage":{"input_tokens":10,"output_tokens":20,"cache_read_input_tokens":300,"cache_creation_input_tokens":4}}}"#;
         let lu = parse_usage_line(line).expect("assistant usage line should parse");
         assert_eq!(lu.day, "2026-07-21");
         assert_eq!(lu.tokens, [10, 20, 300, 4]);
-        assert_eq!(lu.family, "opus");
+        assert_eq!(lu.model, "claude-opus-4-8", "verbatim; the frontend names it");
         assert_eq!(lu.cwd, "/Users/tim/dev/episko"); // verbatim; grouped by project_label
-        // Missing token fields default to 0, an unknown model is "other", no cwd is ""
+        // Missing token fields default to 0, a line with no model reports "", no cwd is ""
         // (`project_label` says "unknown"), and no message.id is None, so the line is counted.
         let partial = r#"{"timestamp":"2026-07-21T10:00:00Z","message":{"usage":{"output_tokens":7}}}"#;
         let lu = parse_usage_line(partial).expect("should parse");
         assert_eq!(lu.tokens, [0, 7, 0, 0]);
-        assert_eq!(lu.family, "other");
+        assert_eq!(lu.model, "");
         assert_eq!(lu.cwd, "");
         assert_eq!(lu.id, None);
         assert_eq!(project_label("", &mut std::collections::HashMap::new()), "unknown");
@@ -1220,7 +1200,7 @@ mod tests {
         assert_eq!(days.len(), 1);
         let d20 = &days[0];
         assert_eq!((d20.input, d20.output), (30, 3), "3 counted responses, not 5 lines");
-        assert_eq!(d20.opus, 33);
+        assert_eq!(d20.models.get("claude-opus-4-8"), Some(&33));
         assert_eq!(d20.projects.get("alpha"), Some(&33));
         assert_eq!(d20.sessions, 1);
 
@@ -1239,14 +1219,6 @@ mod tests {
         assert!(parse_usage_line("not json at all").is_none());
         // A usage record with no timestamp can't be bucketed, so it's dropped.
         assert!(parse_usage_line(r#"{"message":{"usage":{"input_tokens":5}}}"#).is_none());
-    }
-
-    #[test]
-    fn model_family_buckets_by_tier() {
-        assert_eq!(model_family("claude-opus-4-8"), "opus");
-        assert_eq!(model_family("claude-sonnet-4-5"), "sonnet");
-        assert_eq!(model_family("claude-haiku-4-5-20251001"), "haiku");
-        assert_eq!(model_family("some-future-model"), "other");
     }
 
     #[test]
@@ -1638,7 +1610,7 @@ mod tests {
     }
 
     #[test]
-    fn scan_usage_folds_days_families_and_counts_sessions_once() {
+    fn scan_usage_folds_days_models_and_counts_sessions_once() {
         let base = scratch_dir();
         let write = |proj: &str, file: &str, body: &str| {
             let d = base.join("projects").join(proj);
@@ -1682,16 +1654,17 @@ mod tests {
 
         let d20 = &days[0];
         assert_eq!((d20.input, d20.output, d20.cache_read, d20.cache_write), (31, 4, 1, 1));
-        assert_eq!(d20.opus, 11);
-        assert_eq!(d20.sonnet, 22);
-        assert_eq!(d20.other, 4, "an unrecognised model falls into `other`");
-        assert_eq!(d20.haiku, 0);
+        assert_eq!(d20.models.get("claude-opus-4-8"), Some(&11));
+        assert_eq!(d20.models.get("claude-sonnet-4-5"), Some(&22));
+        // Every id gets its own key, this one included: nothing is collapsed into an "other".
+        assert_eq!(d20.models.get("some-future-model"), Some(&4));
+        assert_eq!(d20.models.get("claude-haiku-4-5"), None);
         assert_eq!(d20.sessions, 2, "two files touched this day");
         assert_eq!(d20.projects.get("alpha"), Some(&33), "keyed by cwd basename");
         assert_eq!(d20.projects.get("beta"), Some(&4));
 
         let d21 = &days[1];
-        assert_eq!(d21.haiku, 15);
+        assert_eq!(d21.models.get("claude-haiku-4-5"), Some(&15));
         assert_eq!(d21.sessions, 1, "the SAME file again — counted once per day, not per line");
         assert_eq!(d21.projects.get("beta"), None, "beta wasn't active on the 21st");
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -30,6 +30,9 @@
   --tool-read:#7cc7ff; --tool-edit:#c3b0ff; --tool-bash:#e0a44a; --tool-task:#6ad0b0; --tool-web:#f0a6d0; --tool-mcp:#9aa0b4;
   /* usage analytics: model families (colourblind-validated), the spend-heatmap ramp, the token-mix ramp */
   --m-opus:#8f74ee; --m-sonnet:#c07d1e; --m-haiku:#149a73; --m-other:#8a8394; --m-unattr:#6b6478;
+  --m-fable:#3f8ee0; --m-gpt:#d3618f; --m-codex:#2ca6b8;
+  /* spares for a provider we ship no hue for, and the ground an older version is faded into */
+  --m-s1:#93b03c; --m-s2:#b968d8; --m-s3:#7f93b8; --m-s4:#cc6a55; --m-fade:#ffffff;
   --u-g0:#191622; --u-g1:#372e57; --u-g2:#544499; --u-g3:#7d63d8; --u-g4:#a78bfa;
   --u-t1:#2c2740; --u-t2:#4a3d7a; --u-t3:#7159c4; --u-t4:#a78bfa;
   /* commit-graph lanes: eight hues that must stay apart from each other and off the accent */
@@ -49,6 +52,8 @@
   --tool-read:#2a7fd0; --tool-edit:#6a45e0; --tool-bash:#b9791a; --tool-task:#128a63; --tool-web:#c04f97; --tool-mcp:#6a6480;
   /* usage analytics — re-stepped for the light ground (own steps, not an inversion) */
   --m-opus:#7c5cf0; --m-sonnet:#b8760f; --m-haiku:#0c8f68; --m-other:#8a8598; --m-unattr:#b8b2c6;
+  --m-fable:#2b6fd0; --m-gpt:#c04270; --m-codex:#0f8fa3;
+  --m-s1:#6e8c1e; --m-s2:#9a45c0; --m-s3:#5a7095; --m-s4:#b34a35; --m-fade:#241d33;
   --u-g0:#eceaf2; --u-g1:#d8cff2; --u-g2:#b7a4ee; --u-g3:#9575e8; --u-g4:#7c5cf0;
   --u-t1:#e4def3; --u-t2:#c3b0ee; --u-t3:#9878e6; --u-t4:#7c5cf0;
   /* lane hues re-stepped: the dark set's pastels vanish on white at 1.6px of stroke */

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -8,13 +8,46 @@ import { basename } from "./format";
 
 // ---------- the daily rollup (telemetry-fed) ----------
 
-// Family, not display name: "Opus 4.8" changes across releases, the tier does not.
-export function modelFamily(m: string): string {
-  const s = (m || "").toLowerCase();
-  if (s.includes("opus")) return "Opus";
-  if (s.includes("sonnet")) return "Sonnet";
-  if (s.includes("haiku")) return "Haiku";
-  return m ? "Other" : "Unknown";
+// One display name per model, reached from both spellings we are given: the transcript scan
+// reports a raw id (`claude-fable-5-1`), the statusLine a display name ("Claude Fable 5.1"),
+// and a day whose tokens split across two keys draws the same model twice. Naming happens on
+// read (`mergeTokenDays`), never in the stores, so a better rule needs no re-scan.
+const TIERS = ["opus", "sonnet", "haiku", "fable"];
+const ACRONYMS = new Set(["gpt", "ai", "llm", "api", "xai"]);
+const isNum = (s: string) => /^\d[\d.]*$/.test(s);
+export function modelName(m: string): string {
+  const bare = (m || "").toLowerCase().trim()
+    .replace(/^(?:us|eu|apac)\./, "")                      // Bedrock region prefix
+    .replace(/^(?:anthropic|openai|google|meta|x-ai)[./]/, "")
+    .replace(/\[[^\]]*]$/, "")                             // the context-window suffix
+    .replace(/-latest$/, "").replace(/-v\d+:\d+$/, "")
+    .replace(/[-@]\d{8}$/, "")                             // release date stamp
+    .replace(/^claude[-\s]/, "");
+  const parts = bare.split(/[-_\s/]+/).filter(Boolean);
+  // `<synthetic>` is Claude Code's own placeholder line (an API error, a hook message), not
+  // a model. Its usage record is all zeroes today, so this only guards the day it isn't.
+  if (!parts.length || bare === "<synthetic>") return "Unknown";
+  const tier = parts.findIndex((p) => TIERS.includes(p));
+  if (tier >= 0) {
+    // The version sits on either side of the tier: `opus-4-8` after it, `3-5-sonnet` before.
+    const run = (from: number, step: number) => {
+      const out: string[] = [];
+      for (let j = from; j >= 0 && j < parts.length && isNum(parts[j]); j += step) out.push(parts[j]);
+      return step < 0 ? out.reverse() : out;
+    };
+    const ver = (run(tier + 1, 1).length ? run(tier + 1, 1) : run(tier - 1, -1)).join(".");
+    const name = parts[tier][0].toUpperCase() + parts[tier].slice(1);
+    return ver ? `${name} ${ver}` : name;
+  }
+  const out: string[] = [];
+  for (const p of parts) {
+    const w = ACRONYMS.has(p) ? p.toUpperCase() : p[0].toUpperCase() + p.slice(1);
+    const prev = out[out.length - 1];
+    // A version joins an acronym with a hyphen, the way its vendor writes it: GPT-5.1.
+    if (isNum(p) && prev && prev === prev.toUpperCase()) out[out.length - 1] = `${prev}-${w}`;
+    else out.push(w);
+  }
+  return out.join(" ").slice(0, 32);
 }
 
 // `cc-usage` is the authoritative per-day total; `cc-usage-detail` layers the per-model /
@@ -63,7 +96,7 @@ export function addUsage(delta: number, s?: Sess) {
   localStorage.setItem("cc-usage", JSON.stringify(usage));
   if (!s || !hasAgentCapability(s, "usage")) return;
   const d = usageDetail[k] || (usageDetail[k] = { models: {}, projects: {} });
-  const fam = modelFamily(s.model);
+  const fam = modelName(s.model);
   d.models[fam] = (d.models[fam] || 0) + delta;
   const proj = s.project || basename(s.workdir) || "unknown";
   d.projects[proj] = (d.projects[proj] || 0) + delta;
@@ -379,22 +412,31 @@ export function resetCostBaselines() { costBaseline.clear(); localStorage.remove
 // (full history); provider deltas record from the first integrated session onward.
 export interface DayUsage {
   day: string; input: number; output: number; cache_read: number; cache_write: number;
-  opus: number; sonnet: number; haiku: number; other: number;
+  models: Record<string, number>; // raw model id in the stores, display name once merged
   sessions: number; projects: Record<string, number>;
 }
+// What an older cache holds: four fixed family columns, and no version to recover.
+interface StoredDay extends DayUsage { opus?: number; sonnet?: number; haiku?: number; other?: number }
+const LEGACY: [keyof StoredDay & string, string][] = [["opus", "Opus"], ["sonnet", "Sonnet"], ["haiku", "Haiku"], ["other", "Other"]];
 export type UDay = { key: string; cost: number; tok: number; u?: DayUsage };
 interface LiveTokenDay extends DayUsage { session_ids: string[] }
 const scannedTokenDays: { value: DayUsage[] } = { value: readList<DayUsage>("cc-usage-tokens") };
 const liveTokenDays: LiveTokenDay[] = readList<LiveTokenDay>("cc-agent-usage-tokens");
 function mergeTokenDays(scanned: DayUsage[], live: LiveTokenDay[]): DayUsage[] {
   const by = new Map<string, DayUsage>();
-  const add = (d: DayUsage) => {
+  const add = (d: StoredDay) => {
     let x = by.get(d.day);
     if (!x) {
-      x = { day: d.day, input: 0, output: 0, cache_read: 0, cache_write: 0, opus: 0, sonnet: 0, haiku: 0, other: 0, sessions: 0, projects: {} };
+      x = { day: d.day, input: 0, output: 0, cache_read: 0, cache_write: 0, models: {}, sessions: 0, projects: {} };
       by.set(d.day, x);
     }
-    for (const k of ["input", "output", "cache_read", "cache_write", "opus", "sonnet", "haiku", "other", "sessions"] as const) x[k] += d[k] || 0;
+    for (const k of ["input", "output", "cache_read", "cache_write", "sessions"] as const) x[k] += d[k] || 0;
+    // `modelName` is idempotent, so a key already named (an older row, the other store) is safe.
+    for (const [model, tokens] of Object.entries(d.models || {})) {
+      const nm = modelName(model);
+      x.models[nm] = (x.models[nm] || 0) + tokens;
+    }
+    for (const [k, nm] of LEGACY) { const v = d[k] as number | undefined; if (v) x.models[nm] = (x.models[nm] || 0) + v; }
     for (const [project, tokens] of Object.entries(d.projects || {})) x.projects[project] = (x.projects[project] || 0) + tokens;
   };
   scanned.forEach(add); live.forEach(add);
@@ -438,14 +480,16 @@ export function addAgentTokenUsage(s: Sess, reading: AgentTokenUsage): void {
   const day = todayKey();
   let row = liveTokenDays.find((x) => x.day === day);
   if (!row) {
-    row = { day, input: 0, output: 0, cache_read: 0, cache_write: 0, opus: 0, sonnet: 0, haiku: 0, other: 0, sessions: 0, projects: {}, session_ids: [] };
+    row = { day, input: 0, output: 0, cache_read: 0, cache_write: 0, models: {}, sessions: 0, projects: {}, session_ids: [] };
     liveTokenDays.push(row);
   }
   // OpenAI's input total includes its cached subset; keep `input + cache_read` equal to it.
   const input = Math.max(0, d.inputTokens - d.cachedInputTokens);
   const processed = input + d.cachedInputTokens + d.cacheWriteInputTokens + d.outputTokens;
   row.input += input; row.cache_read += d.cachedInputTokens; row.cache_write += d.cacheWriteInputTokens; row.output += d.outputTokens;
-  row.other += processed;
+  // Attributed to the model the pane is on now, as the $ split is: a reading is a delta, and
+  // the provider's own cumulative total carries no per-model split to diff against.
+  row.models[s.model] = (row.models[s.model] || 0) + processed;
   const project = s.project || basename(s.workdir) || "unknown";
   row.projects[project] = (row.projects[project] || 0) + processed;
   if (!row.session_ids.includes(id)) { row.session_ids.push(id); row.sessions++; }
@@ -458,12 +502,38 @@ export let usageRange = 30; // days the analytics panel looks back
 export function setUsageRange(n: number) { usageRange = n; }
 
 export const U_MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-// Sum a day's per-model tokens into a fixed-key record (backfill fields are lowercase).
+// Sum a day's per-model tokens by display name. Only the models actually used appear, so a
+// caller must not index a fixed key set; `modelSeries` gives the order and the colour slot.
 export const uModels = (a: UDay[]): Record<string, number> => {
-  const m: Record<string, number> = { Opus: 0, Sonnet: 0, Haiku: 0, Other: 0 };
-  for (const d of a) if (d.u) { m.Opus += d.u.opus; m.Sonnet += d.u.sonnet; m.Haiku += d.u.haiku; m.Other += d.u.other; }
+  const m: Record<string, number> = {};
+  for (const d of a) if (d.u) for (const [k, v] of Object.entries(d.u.models || {})) m[k] = (m[k] || 0) + v;
   return m;
 };
+
+// A model's colour family: its name without the version, so every Opus shares one hue.
+export const modelKin = (name: string) => name.toLowerCase().split(/[-\s]/)[0] || "unknown";
+const RESIDUE = ["other", "unknown"]; // the two names that mean "we could not tell"
+const verOf = (name: string) => (name.match(/\d+/g) || []).map(Number);
+// Newest first, numerically: "Opus 5" is above "Opus 4.8", which string order gets backwards.
+function newerFirst(a: string, b: string): number {
+  const x = verOf(b), y = verOf(a);
+  for (let i = 0; i < Math.max(x.length, y.length); i++) { const d = (x[i] ?? -1) - (y[i] ?? -1); if (d) return d; }
+  return a.localeCompare(b);
+}
+export interface ModelSeries { name: string; total: number; kin: string; shade: number }
+// The chart's series in one order for every bucket, legend and row. Biggest first, with the
+// residue last; within a family the newest release wears the undimmed hue, so shipping a
+// version dims the old one rather than reshuffling the colours.
+export function modelSeries(models: Record<string, number>): ModelSeries[] {
+  const rows: ModelSeries[] = Object.entries(models).filter(([, v]) => v > 0)
+    .map(([name, total]) => ({ name, total, kin: modelKin(name), shade: 0 }));
+  const res = (r: ModelSeries) => RESIDUE.includes(r.kin) ? 1 : 0;
+  rows.sort((a, b) => res(a) - res(b) || b.total - a.total || a.name.localeCompare(b.name));
+  const kin = new Map<string, ModelSeries[]>();
+  for (const r of rows) { const a = kin.get(r.kin) || []; a.push(r); kin.set(r.kin, a); }
+  for (const a of kin.values()) [...a].sort((x, y) => newerFirst(x.name, y.name)).forEach((r, i) => { r.shade = Math.min(i, 3); });
+  return rows;
+}
 
 // The last n calendar days ending today, oldest first, each joined to its cost and tokens.
 export function usageWindow(n: number): UDay[] {
@@ -485,7 +555,7 @@ export function uBuckets(): UBucket[] {
   const cur = usageWindow(usageRange);
   const mk = (label: string, tip: string, days: UDay[]): UBucket => {
     const models = uModels(days);
-    return { label, tip, total: models.Opus + models.Sonnet + models.Haiku + models.Other, models };
+    return { label, tip, total: Object.values(models).reduce((n, v) => n + v, 0), models };
   };
   if (usageRange <= 31) return cur.map((d) => { const dt = new Date(d.key + "T00:00:00"); return mk(String(dt.getDate()), `${U_MONTHS[dt.getMonth()]} ${dt.getDate()}`, [d]); });
   if (usageRange === 90) {

--- a/src/usageview.ts
+++ b/src/usageview.ts
@@ -9,8 +9,9 @@ import { D7_LEN, forecast5h, forecast7d, H5_LEN, type Forecast } from "./rl";
 import { accentFor, ioAll, sessions } from "./state";
 import { hasAgentCapability } from "./types";
 import {
-  dayIo, ioDayCount, ioSameNote, ioTotal, todayKey, tokenDays, U_MONTHS, uBuckets, uDkey,
-  uModels, usage, usageRange, usageWindow, uSum, type DaySpend, type UDay,
+  dayIo, ioDayCount, ioSameNote, ioTotal, modelSeries, todayKey, tokenDays, U_MONTHS, uBuckets,
+  uDkey, uModels, usage, usageRange, usageWindow, uSum,
+  type DaySpend, type ModelSeries, type UDay,
 } from "./usage";
 
 // Plain-language forecast line for a window ("→ ~86% by reset" / "runs out …").
@@ -84,8 +85,24 @@ export function costPopHtml(d: DaySpend, live: Set<string>): string {
 export let tokenScanning = false;
 export function setTokenScanning(v: boolean) { tokenScanning = v; }
 const USAGE_RANGES: [number, string][] = [[7, "7D"], [30, "30D"], [90, "90D"], [365, "12M"]];
-const MODEL_ORDER = ["Opus", "Sonnet", "Haiku", "Other"];
-const MODEL_VAR: Record<string, string> = { Opus: "--m-opus", Sonnet: "--m-sonnet", Haiku: "--m-haiku", Other: "--m-other" };
+const KIN_VAR: Record<string, string> = {
+  opus: "--m-opus", sonnet: "--m-sonnet", haiku: "--m-haiku", fable: "--m-fable",
+  gpt: "--m-gpt", codex: "--m-codex", other: "--m-other", unknown: "--m-other",
+};
+const SPARE_VAR = ["--m-s1", "--m-s2", "--m-s3", "--m-s4"];
+const SHADE = [100, 74, 54, 40];
+// One colour per model for every surface in the panel: its family's hue, faded a step per
+// older version, and a spare hue for a provider we ship no colour for.
+function modelColors(rows: ModelSeries[]): Map<string, string> {
+  const spare = new Map<string, string>(), out = new Map<string, string>();
+  for (const r of rows) {
+    let v = KIN_VAR[r.kin];
+    if (!v) { if (!spare.has(r.kin)) spare.set(r.kin, SPARE_VAR[spare.size % SPARE_VAR.length]); v = spare.get(r.kin)!; }
+    const pct = SHADE[r.shade] ?? SHADE[SHADE.length - 1];
+    out.set(r.name, pct === 100 ? `var(${v})` : `color-mix(in srgb, var(${v}) ${pct}%, var(--m-fade))`);
+  }
+  return out;
+}
 
 const U_WD = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
@@ -173,23 +190,22 @@ function uHeatmap(): string {
 function uBars(): string {
   const data = uBuckets();
   const max = Math.max(...data.map((d) => d.total), 1), H = 168;
-  const parts: [string, string][] = [["Haiku", "--m-haiku"], ["Sonnet", "--m-sonnet"], ["Opus", "--m-opus"], ["Other", "--m-other"]];
+  // One order for every column and the legend, from the range's totals: a bucket that happens
+  // to be all Haiku must still stack its segment where every other bucket puts Haiku.
+  const series = modelSeries(uModels(usageWindow(usageRange)));
+  const color = modelColors(series);
   const gap = data.length > 40 ? "2px" : data.length > 16 ? "4px" : "7px";
   const cols = data.map((d) => {
     let segs = "";
-    for (const [m, cssvar] of parts) { const v = d.models[m] || 0; if (v > 0) segs += `<i class="u-seg" style="height:${(v / max * H).toFixed(1)}px;background:var(${cssvar})"></i>`; }
-    const lines = parts.filter(([m]) => (d.models[m] || 0) > 0).map(([m]) => `${m} ${uTok(d.models[m])}`);
+    for (const r of series) { const v = d.models[r.name] || 0; if (v > 0) segs += `<i class="u-seg" style="height:${(v / max * H).toFixed(1)}px;background:${color.get(r.name)}"></i>`; }
+    const lines = series.filter((r) => (d.models[r.name] || 0) > 0).map((r) => `${r.name} ${uTok(d.models[r.name])}`);
     const tip = [d.tip, ...lines, `Total ${uTok(d.total)}`].join("||");
     return `<div class="u-col" data-tip="${esc(tip)}"><div class="u-stack">${segs}</div></div>`;
   }).join("");
   const step = Math.ceil(data.length / 12);
   const labels = data.map((d, i) => `<span>${(i % step === 0 || i === data.length - 1) ? esc(d.label) : ""}</span>`).join("");
   const title = usageRange <= 31 ? `Last ${usageRange} days` : usageRange === 90 ? "Last 90 days · weekly" : "Last 12 months · monthly";
-  const anyOther = data.some((d) => (d.models.Other || 0) > 0);
-  const legModels: [string, string][] = anyOther
-    ? [["Opus", "--m-opus"], ["Sonnet", "--m-sonnet"], ["Haiku", "--m-haiku"], ["Other", "--m-other"]]
-    : [["Opus", "--m-opus"], ["Sonnet", "--m-sonnet"], ["Haiku", "--m-haiku"]];
-  const legend = legModels.map(([m, c]) => `<span class="u-lg"><i style="background:var(${c})"></i>${m}</span>`).join("");
+  const legend = series.map((r) => `<span class="u-lg"><i style="background:${color.get(r.name)}"></i>${esc(r.name)}</span>`).join("");
   const empty = !data.some((d) => d.total > 0);
   const plot = empty && tokenScanning
     ? `<div class="u-skelbar" style="height:${H}px"></div>`
@@ -202,11 +218,12 @@ function uBars(): string {
 }
 
 function uModelMix(): string {
-  const models = uModels(usageWindow(usageRange));
-  const total = models.Opus + models.Sonnet + models.Haiku + models.Other;
-  const rows = MODEL_ORDER.filter((m) => models[m] > 0).map((m) => {
-    const v = models[m], pct = total ? v / total * 100 : 0;
-    return `<div class="u-srow"><div class="u-stop"><span class="u-sw" style="background:var(${MODEL_VAR[m]})"></span><span class="u-snm">${m}</span><span class="u-susd mono">${uTok(v)}</span></div><div class="u-strack"><i style="width:${pct.toFixed(1)}%;background:var(${MODEL_VAR[m]})"></i></div></div>`;
+  const series = modelSeries(uModels(usageWindow(usageRange)));
+  const color = modelColors(series);
+  const total = series.reduce((n, r) => n + r.total, 0);
+  const rows = series.map((r) => {
+    const pct = total ? r.total / total * 100 : 0;
+    return `<div class="u-srow"><div class="u-stop"><span class="u-sw" style="background:${color.get(r.name)}"></span><span class="u-snm">${esc(r.name)}</span><span class="u-susd mono">${uTok(r.total)}</span></div><div class="u-strack"><i style="width:${pct.toFixed(1)}%;background:${color.get(r.name)}"></i></div></div>`;
   }).join("");
   const body = total > 0
     ? `<div class="u-share">${rows}</div>`

--- a/test/phase.test.ts
+++ b/test/phase.test.ts
@@ -934,7 +934,7 @@ describe("applyStatusline — the meters, and the proof a session is alive", () 
       applyStatusline(s, { cost: { total_cost_usd: 3.0 } });
       expect(s.cost).toBe(3.0);
       expect(Object.values(usage)[0]).toBeCloseTo(3.0, 10); // 1.25 + 1.75, not 4.25
-      expect(Object.values(usageDetail)[0].models).toEqual({ Opus: 3.0 });
+      expect(Object.values(usageDetail)[0].models).toEqual({ "Opus 4.8": 3.0 });
     });
     it("adds nothing when a repeated statusLine reports the same total", () => {
       const s = sess();

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -4,7 +4,7 @@ import { store } from "./localstorage"; // must precede the subject import
 import {
   addIo, addUsage, costDelta, dayIo, daySpend, flushIo, flushUsageDetail, installGrown,
   ioCreditBps, ioDayCount, ioDelta, ioExcludedMb, ioSameNote, ioTotal,
-  modelFamily,
+  modelName, modelSeries,
   resetCostBaselines, resetIoRollup, resetUsageWrites, setTokenDays, setUsageRange, splitIo,
   todayKey, tokenDays, tokenScanAt, uBuckets, uDkey, uModels, usage, usageDetail,
   usageWindow, uSum, type DayUsage, type UDay,
@@ -35,7 +35,7 @@ const sess = (o: Partial<Sess>): Sess =>
 // One transcript-scanned day, with only the fields under test spelled out.
 const day = (d: string, o: Partial<DayUsage> = {}): DayUsage => ({
   day: d, input: 0, output: 0, cache_read: 0, cache_write: 0,
-  opus: 0, sonnet: 0, haiku: 0, other: 0, sessions: 0, projects: {}, ...o,
+  models: {}, sessions: 0, projects: {}, ...o,
 });
 
 describe("todayKey / uDkey — the calendar-day key both stores are keyed by", () => {
@@ -142,15 +142,31 @@ describe("costDelta — what a running total owes the day", () => {
   });
 });
 
-describe("modelFamily — collapsing display names to a tier", () => {
-  it("matches the family anywhere in the name, case-insensitively", () => {
-    expect(modelFamily("Claude Opus 4.8")).toBe("Opus");
-    expect(modelFamily("sonnet-4-5")).toBe("Sonnet");
-    expect(modelFamily("Haiku 4.5")).toBe("Haiku");
+describe("modelName — one display name per model, from either spelling", () => {
+  it("names an Anthropic tier with its version, id or display name alike", () => {
+    // The scan sees the id and the statusLine the display name; both must land on one key.
+    expect(modelName("claude-opus-4-8")).toBe("Opus 4.8");
+    expect(modelName("Claude Opus 4.8")).toBe("Opus 4.8");
+    expect(modelName("claude-fable-5-1")).toBe("Fable 5.1");
+    expect(modelName("claude-opus-5")).toBe("Opus 5");
   });
-  it("distinguishes an unrecognised model from no model at all", () => {
-    expect(modelFamily("gpt-9")).toBe("Other");
-    expect(modelFamily("")).toBe("Unknown");
+  it("strips what carries no meaning: date stamps, context suffixes, vendor prefixes", () => {
+    expect(modelName("claude-haiku-4-5-20251001")).toBe("Haiku 4.5");
+    expect(modelName("claude-opus-5[1m]")).toBe("Opus 5");
+    expect(modelName("us.anthropic.claude-3-5-sonnet-20241022-v2:0")).toBe("Sonnet 3.5");
+  });
+  it("names another provider's model too, rather than calling it Other", () => {
+    expect(modelName("gpt-5.1-codex-max")).toBe("GPT-5.1 Codex Max");
+    expect(modelName("codex-mini-latest")).toBe("Codex Mini");
+    expect(modelName("gemini-2.5-pro")).toBe("Gemini 2.5 Pro");
+  });
+  it("is idempotent, since a store may already hold a named key", () => {
+    for (const n of ["Opus 4.8", "GPT-5.1 Codex Max", "Codex Mini", "Unknown"]) expect(modelName(n)).toBe(n);
+  });
+  it("still has one word for no model at all", () => {
+    expect(modelName("")).toBe("Unknown");
+    expect(modelName("   ")).toBe("Unknown");
+    expect(modelName("<synthetic>")).toBe("Unknown"); // Claude Code's placeholder line
   });
 });
 
@@ -181,7 +197,7 @@ describe("addUsage — the daily $ rollup", () => {
     expect(usageDetail).toEqual({});
   });
   it("counts the total but records no split for a non-agent pane", () => {
-    // Shell and task panes have no model; attributing to a family would be an invention.
+    // Shell and task panes have no model; naming one would be an invention.
     addUsage(2, sess({ kind: "shell" }));
     addUsage(3, sess({ kind: "task" }));
     expect(usage["2027-03-14"]).toBe(5);
@@ -193,7 +209,7 @@ describe("addUsage — the daily $ rollup", () => {
       addUsage(1, sess({ model: "Claude Opus 4.8" }));
       addUsage(2, sess({ model: "Sonnet 4.5" }));
       addUsage(4, sess({ model: "Claude Opus 4.8" }));
-      expect(usageDetail["2027-03-14"].models).toEqual({ Opus: 5, Sonnet: 2 });
+      expect(usageDetail["2027-03-14"].models).toEqual({ "Opus 4.8": 5, "Sonnet 4.5": 2 });
     });
     it("attributes it to the session's project", () => {
       addUsage(1, sess({ project: "epi" }));
@@ -227,7 +243,7 @@ describe("addUsage — the daily $ rollup", () => {
       addUsage(1, sess({ id: "a", model: "Haiku 4.5", project: "epi", title: "t" }));
       expect(JSON.parse(store.get("cc-usage-detail")!)).toEqual({
         "2027-03-14": {
-          models: { Haiku: 1 }, projects: { epi: 1 },
+          models: { "Haiku 4.5": 1 }, projects: { epi: 1 },
           sess: { a: { usd: 1, title: "t", project: "epi" } },
         },
       });
@@ -764,15 +780,50 @@ describe("uSum / uModels — the two summaries the panel builds on", () => {
     expect(uSum(w, (d) => d.tok)).toBe(30);
     expect(uSum([], (d) => d.cost)).toBe(0);
   });
-  it("uModels sums per family across days and keeps all four keys present", () => {
-    // The bar chart indexes by a fixed key set; a family with no tokens must read 0, not be missing.
+  it("uModels sums per model across days, listing only what was used", () => {
     const w: UDay[] = [
-      { key: "a", cost: 0, tok: 0, u: day("a", { opus: 1, sonnet: 2 }) },
-      { key: "b", cost: 0, tok: 0, u: day("b", { opus: 4, other: 8 }) },
+      { key: "a", cost: 0, tok: 0, u: day("a", { models: { "Opus 5": 1, "Sonnet 4.5": 2 } }) },
+      { key: "b", cost: 0, tok: 0, u: day("b", { models: { "Opus 5": 4, "Fable 5.1": 8 } }) },
       { key: "c", cost: 0, tok: 0 }, // never scanned — contributes nothing
     ];
-    expect(uModels(w)).toEqual({ Opus: 5, Sonnet: 2, Haiku: 0, Other: 8 });
-    expect(uModels([])).toEqual({ Opus: 0, Sonnet: 0, Haiku: 0, Other: 0 });
+    expect(uModels(w)).toEqual({ "Opus 5": 5, "Sonnet 4.5": 2, "Fable 5.1": 8 });
+    expect(uModels([])).toEqual({});
+  });
+});
+
+describe("modelSeries — the order and colour slot every model surface shares", () => {
+  it("ranks by tokens and keeps the residue last, however big it is", () => {
+    const r = modelSeries({ "Opus 5": 10, Unknown: 999, "Fable 5.1": 40 });
+    expect(r.map((x) => x.name)).toEqual(["Fable 5.1", "Opus 5", "Unknown"]);
+  });
+  it("drops a model with no tokens rather than drawing an empty series", () => {
+    expect(modelSeries({ "Opus 5": 0, "Haiku 4.5": 3 }).map((x) => x.name)).toEqual(["Haiku 4.5"]);
+  });
+  it("gives one family one hue, undimmed on its newest version", () => {
+    // Versions compare numerically: 5 is newer than 4.8, which string order gets backwards.
+    const r = modelSeries({ "Opus 4.8": 90, "Opus 5": 10, "GPT-5.1 Codex": 5 });
+    const by = Object.fromEntries(r.map((x) => [x.name, x]));
+    expect(by["Opus 5"].kin).toBe("opus");
+    expect(by["Opus 4.8"].kin).toBe("opus");
+    expect(by["GPT-5.1 Codex"].kin).toBe("gpt");
+    expect(by["Opus 5"].shade).toBe(0);
+    expect(by["Opus 4.8"].shade).toBe(1);
+    expect(by["GPT-5.1 Codex"].shade).toBe(0);
+  });
+});
+
+describe("the token stores' model keys — named on read, never on write", () => {
+  it("names a raw id and sums the two spellings of one model into one key", () => {
+    setTokenDays([day("2027-03-14", { models: { "claude-opus-4-8": 3, "Opus 4.8": 4 } })]);
+    expect(tokenDays[0].models).toEqual({ "Opus 4.8": 7 });
+    // Stored verbatim: a better naming rule must not need a re-scan of every transcript.
+    expect(JSON.parse(store.get("cc-usage-tokens")!)[0].models["claude-opus-4-8"]).toBe(3);
+  });
+  it("folds a cache written before models were named", () => {
+    const legacy = { day: "2027-03-14", input: 0, output: 0, cache_read: 0, cache_write: 0, opus: 5, other: 2, sessions: 0, projects: {} };
+    setTokenDays([legacy as unknown as DayUsage]);
+    // The version is gone for good, so the old column keeps its unversioned name.
+    expect(tokenDays[0].models).toEqual({ Opus: 5, Other: 2 });
   });
 });
 
@@ -793,9 +844,9 @@ describe("uBuckets — the bar chart's x-axis, one shape per range", () => {
   });
   it("totals a bucket from its days' per-model tokens", () => {
     setUsageRange(7);
-    setTokenDays([day("2027-03-14", { opus: 3, haiku: 4 })]);
+    setTokenDays([day("2027-03-14", { models: { "claude-opus-5": 3, "claude-haiku-4-5": 4 } })]);
     const last = uBuckets()[6];
-    expect(last.models).toEqual({ Opus: 3, Sonnet: 0, Haiku: 4, Other: 0 });
+    expect(last.models).toEqual({ "Opus 5": 3, "Haiku 4.5": 4 });
     expect(last.total).toBe(7);
   });
   it("buckets 90D into weeks of seven, labelled by the week's first day", () => {


### PR DESCRIPTION
The Usage & spend panel had four fixed columns — opus / sonnet / haiku / **other** — so any
model outside the three tiers was a grey slice. Three weeks of real transcripts on this
machine are 33% Fable, all of it counted as *Other*, and every non-Claude provider landed
there too: `addAgentTokenUsage` wrote its whole delta to `row.other`.

## What changed

- **`usage.rs` names nothing.** `DayUsage`'s four columns become `models: BTreeMap<String, u64>`
  keyed by `message.model` verbatim. One naming rule, in the frontend, so a better one needs
  no re-scan of every transcript.
- **`modelName` (`src/usage.ts`)** joins the two spellings we receive onto one key — the scan's
  `claude-fable-5-1` and the statusLine's `Claude Fable 5.1` both give `Fable 5.1`, or a day's
  tokens draw the same model twice. It strips date stamps, `[1m]`, `-latest` and Bedrock
  region/vendor prefixes, handles the old `claude-3-5-sonnet` version order, and is idempotent
  because a store may already hold a named key. Other providers are named the same way
  (`gpt-5.1-codex-max` → `GPT-5.1 Codex Max`). Only an empty model — and Claude Code's
  `<synthetic>` placeholder — is `Unknown`; nothing is `Other` any more.
- **The live provider path** attributes its delta to `Sess.model`, as the `$` split already did.
- **`modelSeries`** gives the bars, legend and mix rows one order (biggest first, residue last)
  and a family one hue across its releases: `Fable 5.1` wears it, `Fable 5` a step faded via
  `color-mix`. Shipping a version dims the old one rather than reshuffling the chart. New
  palette vars for fable / gpt / codex plus four spares, in both themes.
- **Older caches still read**: the four legacy columns fold in at merge (unversioned — the
  version is gone for good), and the next scan replaces them with named rows.

## Verified

The panel's own join, run over the real `~/.claude` for the last 30 days:

```
Model mix · last 30 days · 4468.7M tokens
  Opus 5        2996.66M  67.1%
  Fable 5.1     1028.10M  23.0%
  Fable 5        439.51M   9.8%
  Haiku 4.5        4.39M   0.1%
```

Gates: `tsc` (both projects), `pnpm build`, 1844 vitest, `cargo test`,
`cargo clippy --all-targets -- -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcwVWe7yTxDo2LwruV94jv